### PR TITLE
Surround schema information table with back quotes

### DIFF
--- a/lineage/bigquery_query_history.py
+++ b/lineage/bigquery_query_history.py
@@ -22,7 +22,7 @@ class BigQueryQueryHistory(QueryHistory):
     user_email, destination_table, referenced_tables, TIMESTAMP_DIFF(end_time, start_time, MILLISECOND),
     job_id
            
-    FROM {database_name}.region-{location}.INFORMATION_SCHEMA.JOBS_BY_PROJECT
+    FROM `{database_name}.region-{location}.INFORMATION_SCHEMA.JOBS_BY_PROJECT`
     WHERE
          project_id = '{database_name}'
          AND creation_time BETWEEN @start_time AND {creation_time_range_end_expr}


### PR DESCRIPTION
## Overview
We have to surround the schema information table with back quotes.

## Error logs
```bash
05:20:19  target not specified in profile 'elementary', using 'default'
Pulling query history from BigQuery (!)  in 0.9s (4.32/s)
Traceback (most recent call last):
  File "/Users/yu/anaconda2/envs/python3.8/bin/edr", line 8, in <module>
    sys.exit(cli())
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/cli/../lineage/cli.py", line 253, in generate
    queries = query_history_extractor.extract_queries(start_date, end_date)
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/lineage/query_history.py", line 85, in extract_queries
    self._query_history_table(start_date, end_date)
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/lineage/bigquery_query_history.py", line 98, in _query_history_table
    rows = list(job.result())
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/google/cloud/bigquery/job/query.py", line 1447, in result
    do_get_result()
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/google/api_core/retry.py", line 286, in retry_wrapped_func
    return retry_target(
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/google/api_core/retry.py", line 189, in retry_target
    return target()
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/google/cloud/bigquery/job/query.py", line 1437, in do_get_result
    super(QueryJob, self).result(retry=retry, timeout=timeout)
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/google/cloud/bigquery/job/base.py", line 727, in result
    return super(_AsyncJob, self).result(timeout=timeout, **kwargs)
  File "/Users/yu/anaconda2/envs/python3.8/lib/python3.8/site-packages/google/api_core/future/polling.py", line 135, in result
    raise self._exception
google.api_core.exceptions.BadRequest: 400 Syntax error: Expected ")" but got "-" at [7:33]
```