### PR TITLE
add config to send alerts to slack workflow endpoints

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -12,7 +12,9 @@ ordered_yaml = OrderedYaml()
 
 
 class Config(object):
-    SLACK_NOTIFICATION_WEBHOOK = 'slack_notification_webhook'
+    SLACK = 'slack'
+    NOTIFICATION_WEBHOOK = 'notification_webhook'
+    WORKFLOWS = 'workflows'
     CONFIG_FILE_NAME = 'config.yml'
 
     def __init__(self, config_dir: str, profiles_dir: str, profile_name: str) -> None:
@@ -47,7 +49,11 @@ class Config(object):
 
     @property
     def slack_notification_webhook(self) -> Union[str, None]:
-        return self.config_dict.get(self.SLACK_NOTIFICATION_WEBHOOK)
+        return self.config_dict.get(self.SLACK).get(self.NOTIFICATION_WEBHOOK)
+
+    @property
+    def is_slack_workflow(self) -> bool:
+        return True if self.config_dict.get(self.SLACK).get(self.WORKFLOWS) else False 
 
     @property
     def target_dir(self) -> str:

--- a/monitor/alerts.py
+++ b/monitor/alerts.py
@@ -30,8 +30,15 @@ class Alert(object):
     def to_slack_message(self) -> dict:
         pass
 
-    def send_to_slack(self, webhook: str):
-        data = self.to_slack_message()
+    def to_slack_workflows_message(self) -> dict:
+        pass
+
+    def send_to_slack(self, webhook: str, is_slack_workflow = False):
+        data = {}
+        if is_slack_workflow:
+            data = self.to_slack_workflows_message()
+        else:
+            data = self.to_slack_message()
         self.send(webhook, data)
 
     @property
@@ -91,6 +98,15 @@ class SchemaChangeAlert(Alert):
             ]
         }
 
+    def to_slack_workflows_message(self) -> dict:
+        return {
+            "alert_description": self.ALERT_DESCRIPTION,
+            "table_name": self.table_name,
+            "detected_at": self.detected_at,
+            "type": self.change_type,
+            "description": self.description
+        }
+
 
 class AnomalyDetectionAlert(Alert):
     ALERT_DESCRIPTION = "Data anomaly detected"
@@ -142,4 +158,13 @@ class AnomalyDetectionAlert(Alert):
                     ]
                 }
             ]
+        }
+
+    def to_slack_workflows_message(self) -> dict:
+        return {
+            "alert_description": self.ALERT_DESCRIPTION,
+            "table_name": self.table_name,
+            "detected_at": self.detected_at,
+            "type": self.anomaly_type,
+            "description": self.description
         }

--- a/monitor/data_monitoring.py
+++ b/monitor/data_monitoring.py
@@ -70,7 +70,7 @@ class DataMonitoring(object):
         if slack_webhook is not None:
             sent_alerts = []
             for alert in alerts:
-                alert.send_to_slack(slack_webhook)
+                alert.send_to_slack(slack_webhook, self.config.is_slack_workflow)
                 sent_alerts.append(alert.id)
 
             sent_alert_count = len(sent_alerts)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -6,7 +6,9 @@ from config.config import Config
 
 FILE_DIR = os.path.dirname(__file__)
 
-CONFIG = {'slack_notification_webhook': 'test_slack_webhook', 'dbt_projects': [FILE_DIR]}
+CONFIG = {'slack': { 'notification_webhook': 'test_slack_webhook', 'workflows': False }, 'dbt_projects': [FILE_DIR]}
+
+WORKFLOWS_CONFIG = {'slack': { 'notification_webhook': 'test_slack_webhook', 'workflows': True }, 'dbt_projects': [FILE_DIR]}
 
 SOURCES = {'sources':
                 [{'name': 'unit_tests',
@@ -63,6 +65,16 @@ def create_config_files():
     yml.dump(DBT_PROJECT, os.path.join(FILE_DIR, 'dbt_project.yml'))
     yml.dump(PROFILES, os.path.join(FILE_DIR, 'profiles.yml'))
 
+def create_slack_workflows_config_files():
+    yml = OrderedYaml()
+    yml.dump(WORKFLOWS_CONFIG, os.path.join(FILE_DIR, 'config.yml'))
+    schema_path = os.path.join(FILE_DIR, 'models')
+    if not os.path.exists(schema_path):
+        os.makedirs(schema_path)
+    yml.dump(SOURCES, os.path.join(schema_path, 'schema.yml'))
+    yml.dump(DBT_PROJECT, os.path.join(FILE_DIR, 'dbt_project.yml'))
+    yml.dump(PROFILES, os.path.join(FILE_DIR, 'profiles.yml'))    
+
 
 def read_csv(csv_path):
     csv_lines = []
@@ -78,9 +90,17 @@ def config():
     create_config_files()
     return Config(config_dir=FILE_DIR, profiles_dir=FILE_DIR, profile_name='elementary')
 
+@pytest.fixture
+def slack_workflows_config():
+    create_slack_workflows_config_files()
+    return Config(config_dir=FILE_DIR, profiles_dir=FILE_DIR, profile_name='elementary')
+
 
 def test_config_get_slack_notification_webhook(config):
-    assert config.slack_notification_webhook == CONFIG['slack_notification_webhook']
+    assert config.slack_notification_webhook == CONFIG['slack']['notification_webhook']
+
+def test_slack_workflows_config_get_workflows(slack_workflows_config):
+    assert slack_workflows_config.is_slack_workflow == WORKFLOWS_CONFIG['slack']['workflows']
 
 
 def test_config__get_sources_from_all_dbt_projects(config):

--- a/tests/monitor/test_alerts.py
+++ b/tests/monitor/test_alerts.py
@@ -23,3 +23,14 @@ def test_schema_change_alert_to_slack_message():
     assert alert.description.lower() in schema_change_slack_msg_str
     local_time = convert_utc_time_to_local_time(alert_time)
     assert local_time.strftime('%Y-%m-%d %H:%M:%S') in schema_change_slack_msg_str
+
+
+def test_schema_change_alert_to_slack_workflow_message():
+    alert_time = datetime.now()
+    alert = SchemaChangeAlert('123', 'db', 'sc', 't1', alert_time, 'column_added', 'Column was added')
+    schema_change_slack_msg_str = json.dumps(alert.to_slack_workflows_message()).lower()
+    assert alert.table_name.lower() in schema_change_slack_msg_str
+    assert alert.change_type.lower() in schema_change_slack_msg_str
+    assert alert.description.lower() in schema_change_slack_msg_str
+    local_time = convert_utc_time_to_local_time(alert_time)
+    assert local_time.strftime('%Y-%m-%d %H:%M:%S') in schema_change_slack_msg_str

--- a/tests/monitor/test_data_monitoring.py
+++ b/tests/monitor/test_data_monitoring.py
@@ -29,9 +29,18 @@ def config_mock():
     config_mock = mock.create_autospec(Config)
     config_mock.profiles_dir = 'profiles_dir_path'
     config_mock.slack_notification_webhook = WEBHOOK_URL
+    config_mock.is_slack_workflow = False
     config_mock.monitoring_configuration_in_dbt_sources_to_csv.return_value = None
     return config_mock
 
+@pytest.fixture
+def slack_workflows_config_mock():
+    config_mock = mock.create_autospec(Config)
+    config_mock.profiles_dir = 'profiles_dir_path'
+    config_mock.slack_notification_webhook = WEBHOOK_URL
+    config_mock.is_slack_workflow = True
+    config_mock.monitoring_configuration_in_dbt_sources_to_csv.return_value = None
+    return config_mock
 
 @pytest.fixture
 def dbt_runner_mock():
@@ -64,6 +73,24 @@ def snowflake_data_monitoring(config_mock, snowflake_con_mock, dbt_runner_mock):
     snowflake_cursor_context_manager_return_value.execute.side_effect = execute_query_side_effect
 
     snowflake_data_mon = SnowflakeDataMonitoring(config_mock, snowflake_con_mock)
+    snowflake_data_mon.dbt_runner = dbt_runner_mock
+    return snowflake_data_mon
+
+
+@pytest.fixture
+def snowflake_data_monitoring_slack_workflow(slack_workflows_config_mock, snowflake_con_mock, dbt_runner_mock):
+    # This cursor mock will use the side effect to return non empty configuration
+    snowflake_cursor_context_manager_return_value = snowflake_con_mock.cursor.return_value.__enter__.return_value
+
+    def execute_query_side_effect(*args, **kwargs):
+        if 'count(*)' in args[0].lower():
+            snowflake_cursor_context_manager_return_value.fetchall.return_value = [[1]]
+        else:
+            snowflake_cursor_context_manager_return_value.fetchall.return_value = []
+
+    snowflake_cursor_context_manager_return_value.execute.side_effect = execute_query_side_effect
+
+    snowflake_data_mon = SnowflakeDataMonitoring(slack_workflows_config_mock, snowflake_con_mock)
     snowflake_data_mon.dbt_runner = dbt_runner_mock
     return snowflake_data_mon
 
@@ -203,6 +230,12 @@ def test_data_monitoring_send_alert_to_slack(requests_post_mock, snowflake_data_
     requests_post_mock.assert_called_once_with(url=WEBHOOK_URL, headers={'Content-type': 'application/json'},
                                                data=json.dumps(alert.to_slack_message()))
 
+@mock.patch('requests.post')
+def test_data_monitoring_send_alert_to_slack_workflows(requests_post_mock, snowflake_data_monitoring_slack_workflow):
+    alert = Alert.create_alert_from_row(ALERT_ROW)
+    snowflake_data_monitoring_slack_workflow._send_to_slack([alert])
+    requests_post_mock.assert_called_once_with(url=WEBHOOK_URL, headers={'Content-type': 'application/json'},
+                                               data=json.dumps(alert.to_slack_workflows_message()))
 
 def test_data_monitoring_send_alerts(snowflake_data_monitoring_with_alerts_in_db):
     snowflake_data_monitoring = snowflake_data_monitoring_with_alerts_in_db
@@ -211,3 +244,5 @@ def test_data_monitoring_send_alerts(snowflake_data_monitoring_with_alerts_in_db
     assert len(alerts) == len(expected_alerts)
     assert alerts[0].id == expected_alerts[0].id
     assert type(alerts[0]) == type(expected_alerts[0])
+
+


### PR DESCRIPTION
## Overview
Adding a configuration to the slack config that allows the user to receive alerts in a format conducive with Slack Workflows

### Slack workflows
Slack allows users to create no code workflows that can pass messages to slack channels from a slack generated url. The builder of the workflow can configure the message to read the received body, but only if the body consists of key-value pairs where the values are strings. This update would allow users to build a slack workflow to receive an alert in the following format `{
            "alert_description": str,
            "table_name": str,
            "detected_at": str,
            "type": str,
            "description": str
        }`

### Config
Updated config to expect a slack yaml with the following format
`slack:
    notification_webhook: <webhook_url>
    workflows: true / false`

### Data monitoring
Data monitoring class passes the workflows bool value to alert's send to slack method so alert can send the correct format

### Alert
The alert uses the workflows bool to specify which alert format should be sent to slack