### PR TITLE
fixed vars params for cli monitor

### DIFF
--- a/monitor/cli.py
+++ b/monitor/cli.py
@@ -122,7 +122,7 @@ def monitor(
                f"https://bit.ly/slack-elementary\n")
     if ctx.invoked_subcommand is not None:
         return
-    vars = ordered_yaml.loads(dbt_vars) if dbt_vars else None
+    vars = yaml.loads(dbt_vars) if dbt_vars else None
     config = Config(config_dir, profiles_dir, profile_target)
     anonymous_tracking = AnonymousTracking(config)
     track_cli_start(anonymous_tracking, 'monitor', get_cli_properties(), ctx.command.name)

--- a/monitor/cli.py
+++ b/monitor/cli.py
@@ -138,7 +138,7 @@ def monitor(
             slack_token=slack_token,
             slack_channel_name=slack_channel_name
         )
-        success = data_monitoring.run(days_back, full_refresh_dbt_package, vars=vars)
+        success = data_monitoring.run(days_back, full_refresh_dbt_package, dbt_vars=vars)
         track_cli_end(anonymous_tracking, 'monitor', data_monitoring.properties(), ctx.command.name)
         if not success:
             return 1

--- a/monitor/data_monitoring.py
+++ b/monitor/data_monitoring.py
@@ -169,10 +169,9 @@ class DataMonitoring(object):
         if alerts:
             self._send_alerts_to_slack(alerts)
 
-    def run(self, days_back: int, dbt_full_refresh: bool = False, vars: Optional[dict] = None) -> bool:
-
+    def run(self, days_back: int, dbt_full_refresh: bool = False, dbt_vars: Optional[dict] = None) -> bool:
         logger.info("Running internal dbt run to aggregate alerts")
-        success = self.dbt_runner.run(models='alerts', full_refresh=dbt_full_refresh, vars=vars)
+        success = self.dbt_runner.run(models='alerts', full_refresh=dbt_full_refresh, vars=dbt_vars)
         self.execution_properties['alerts_run_success'] = success
         if not success:
             logger.info('Could not aggregate alerts successfully')

--- a/monitor/data_monitoring.py
+++ b/monitor/data_monitoring.py
@@ -169,7 +169,7 @@ class DataMonitoring(object):
         if alerts:
             self._send_alerts_to_slack(alerts)
 
-    def run(self, days_back: int, dbt_full_refresh: bool = False) -> bool:
+    def run(self, days_back: int, dbt_full_refresh: bool = False, vars: Optional[dict] = None) -> bool:
 
         logger.info("Running internal dbt run to aggregate alerts")
         success = self.dbt_runner.run(models='alerts', full_refresh=dbt_full_refresh, vars=vars)


### PR DESCRIPTION
Fixed a bug in dbt-vars param at cli monitor:
- wrong use of yaml: `ordered_yaml -> yaml`
- add vars support to data_monitoring run method