### PR TITLE
fix broken report on error tests

### DIFF
--- a/monitor/api/tests/schema.py
+++ b/monitor/api/tests/schema.py
@@ -20,7 +20,7 @@ class TestMetadataSchema(BaseModel):
     test_results_description: Optional[str]
     owners: Optional[str]
     tags: Optional[str]
-    test_results_query: str
+    test_results_query: Optional[str] = None
     other: Optional[str]
     test_name: str
     test_params: Optional[str]


### PR DESCRIPTION
Support tests without test_result_query (can happen on error test)