### PR TITLE
Flag sample data for passed elementary tests

### DIFF
--- a/monitor/alerts/test.py
+++ b/monitor/alerts/test.py
@@ -286,7 +286,8 @@ class ElementaryTestAlert(DbtTestAlert):
             sensitivity = test_params.get('sensitivity')
             test_params = {'timestamp_column': timestamp_column,
                            'anomaly_threshold': sensitivity}
-            self.test_rows_sample.sort(key=lambda metric: metric.get('end_time'))
+            if self.test_rows_sample:               
+                self.test_rows_sample.sort(key=lambda metric: metric.get('end_time'))
             test_alerts = {'display_name': self.test_sub_type_display_name,
                            'metrics': self.test_rows_sample,
                            'result_description': self.test_results_description}

--- a/monitor/api/tests/tests.py
+++ b/monitor/api/tests/tests.py
@@ -27,14 +27,14 @@ class TestsAPI(APIClient):
             self,
             days_back: Optional[int] = 7,
             metrics_sample_limit: int = 5,
-            disable_elementary_passed_tests_samples: bool = False
+            disable_passed_test_metrics: bool = False
     ) -> Dict[TestUniqueIdType, Dict[str, Any]]:
         run_operation_response = self.dbt_runner.run_operation(
             macro_name='get_tests_sample_data',
             macro_args=dict(
                 days_back=days_back,
                 metrics_sample_limit=metrics_sample_limit,
-                disable_elementary_passed_tests_samples=disable_elementary_passed_tests_samples
+                disable_passed_test_metrics=disable_passed_test_metrics
             )
         )
         tests_metrics = json.loads(run_operation_response[0]) if run_operation_response else {}

--- a/monitor/api/tests/tests.py
+++ b/monitor/api/tests/tests.py
@@ -26,13 +26,15 @@ class TestsAPI(APIClient):
     def get_tests_sample_data(
             self,
             days_back: Optional[int] = 7,
-            metrics_sample_limit: int = 5
+            metrics_sample_limit: int = 5,
+            disable_elementary_passed_tests_sample: bool = False
     ) -> Dict[TestUniqueIdType, Dict[str, Any]]:
         run_operation_response = self.dbt_runner.run_operation(
             macro_name='get_tests_sample_data',
             macro_args=dict(
                 days_back=days_back,
-                metrics_sample_limit=metrics_sample_limit
+                metrics_sample_limit=metrics_sample_limit,
+                disable_elementary_passed_tests_sample=disable_elementary_passed_tests_sample
             )
         )
         tests_metrics = json.loads(run_operation_response[0]) if run_operation_response else {}

--- a/monitor/api/tests/tests.py
+++ b/monitor/api/tests/tests.py
@@ -27,14 +27,14 @@ class TestsAPI(APIClient):
             self,
             days_back: Optional[int] = 7,
             metrics_sample_limit: int = 5,
-            disable_elementary_passed_tests_sample: bool = False
+            disable_elementary_passed_tests_samples: bool = False
     ) -> Dict[TestUniqueIdType, Dict[str, Any]]:
         run_operation_response = self.dbt_runner.run_operation(
             macro_name='get_tests_sample_data',
             macro_args=dict(
                 days_back=days_back,
                 metrics_sample_limit=metrics_sample_limit,
-                disable_elementary_passed_tests_sample=disable_elementary_passed_tests_sample
+                disable_elementary_passed_tests_samples=disable_elementary_passed_tests_samples
             )
         )
         tests_metrics = json.loads(run_operation_response[0]) if run_operation_response else {}

--- a/monitor/cli.py
+++ b/monitor/cli.py
@@ -195,20 +195,20 @@ def monitor(
     help="The file path where Elementary's report will be saved."
 )
 @click.option(
-    '--disable-elemetary-passed-tests-samples',
+    '--disable-elementary-passed-tests-samples',
     type=bool,
     default=False,
     help="If true, elementary won't query sample data for elementary passed tests (can improve report run time)."
 )
 @click.pass_context
-def report(ctx, days_back, config_dir, profiles_dir, update_dbt_package, profile_target, executions_limit, file_path, disable_elementary_passed_tests_sample):
+def report(ctx, days_back, config_dir, profiles_dir, update_dbt_package, profile_target, executions_limit, file_path, disable_elementary_passed_tests_samples):
     config = Config(config_dir, profiles_dir, profile_target)
     anonymous_tracking = AnonymousTracking(config)
     track_cli_start(anonymous_tracking, 'monitor-report', get_cli_properties(), ctx.command.name)
     try:
         data_monitoring = DataMonitoring(config, update_dbt_package)
         success = data_monitoring.generate_report(days_back=days_back, test_runs_amount=executions_limit,
-                                                  file_path=file_path, disable_elementary_passed_tests_sample=disable_elementary_passed_tests_sample)
+                                                  file_path=file_path, disable_elementary_passed_tests_samples=disable_elementary_passed_tests_samples)
         track_cli_end(anonymous_tracking, 'monitor-report', data_monitoring.properties(), ctx.command.name)
         if not success:
             return 1
@@ -281,7 +281,7 @@ def report(ctx, days_back, config_dir, profiles_dir, update_dbt_package, profile
     help='Set the number of invocations shown for each test in the "Test Runs" report'
 )
 @click.option(
-    '--disable-elemetary-passed-tests-samples',
+    '--disable-elementary-passed-tests-samples',
     type=bool,
     default=False,
     help="If true, elementary won't query sample data for elementary passed tests (can improve report run time)."
@@ -298,7 +298,7 @@ def send_report(
         slack_channel_name,
         profile_target,
         executions_limit,
-        disable_elementary_passed_tests_sample
+        disable_elementary_passed_tests_samples
 ):
     config = Config(config_dir, profiles_dir, profile_target)
     anonymous_tracking = AnonymousTracking(config)
@@ -318,7 +318,7 @@ def send_report(
         command_succeeded = False
         generated_report_successfully, elementary_html_path = data_monitoring.generate_report(days_back=days_back,
                                                                                               test_runs_amount=executions_limit,
-                                                                                              disable_elementary_passed_tests_sample=disable_elementary_passed_tests_sample)
+                                                                                              disable_elementary_passed_tests_samples=disable_elementary_passed_tests_samples)
         if generated_report_successfully and elementary_html_path:
             command_succeeded = data_monitoring.send_report(elementary_html_path)
         return 0 if command_succeeded else 1

--- a/monitor/cli.py
+++ b/monitor/cli.py
@@ -2,6 +2,7 @@ import os
 from os.path import expanduser
 
 import click
+from traitlets import default
 
 from config.config import Config
 from monitor.data_monitoring import DataMonitoring
@@ -193,15 +194,21 @@ def monitor(
     type=str,
     help="The file path where Elementary's report will be saved."
 )
+@click.option(
+    '--disable-elemetary-passed-tests-samples',
+    type=bool,
+    default=False,
+    help="If true, elementary won't query sample data for elementary passed tests (can improve report run time)."
+)
 @click.pass_context
-def report(ctx, days_back, config_dir, profiles_dir, update_dbt_package, profile_target, executions_limit, file_path):
+def report(ctx, days_back, config_dir, profiles_dir, update_dbt_package, profile_target, executions_limit, file_path, disable_elementary_passed_tests_sample):
     config = Config(config_dir, profiles_dir, profile_target)
     anonymous_tracking = AnonymousTracking(config)
     track_cli_start(anonymous_tracking, 'monitor-report', get_cli_properties(), ctx.command.name)
     try:
         data_monitoring = DataMonitoring(config, update_dbt_package)
         success = data_monitoring.generate_report(days_back=days_back, test_runs_amount=executions_limit,
-                                                  file_path=file_path)
+                                                  file_path=file_path, disable_elementary_passed_tests_sample=disable_elementary_passed_tests_sample)
         track_cli_end(anonymous_tracking, 'monitor-report', data_monitoring.properties(), ctx.command.name)
         if not success:
             return 1
@@ -273,6 +280,12 @@ def report(ctx, days_back, config_dir, profiles_dir, update_dbt_package, profile
     default=30,
     help='Set the number of invocations shown for each test in the "Test Runs" report'
 )
+@click.option(
+    '--disable-elemetary-passed-tests-samples',
+    type=bool,
+    default=False,
+    help="If true, elementary won't query sample data for elementary passed tests (can improve report run time)."
+)
 @click.pass_context
 def send_report(
         ctx,
@@ -284,7 +297,8 @@ def send_report(
         slack_token,
         slack_channel_name,
         profile_target,
-        executions_limit
+        executions_limit,
+        disable_elementary_passed_tests_sample
 ):
     config = Config(config_dir, profiles_dir, profile_target)
     anonymous_tracking = AnonymousTracking(config)
@@ -303,7 +317,8 @@ def send_report(
         )
         command_succeeded = False
         generated_report_successfully, elementary_html_path = data_monitoring.generate_report(days_back=days_back,
-                                                                                              test_runs_amount=executions_limit)
+                                                                                              test_runs_amount=executions_limit,
+                                                                                              disable_elementary_passed_tests_sample=disable_elementary_passed_tests_sample)
         if generated_report_successfully and elementary_html_path:
             command_succeeded = data_monitoring.send_report(elementary_html_path)
         return 0 if command_succeeded else 1

--- a/monitor/cli.py
+++ b/monitor/cli.py
@@ -195,20 +195,20 @@ def monitor(
     help="The file path where Elementary's report will be saved."
 )
 @click.option(
-    '--disable-elementary-passed-tests-samples',
+    '--disable-passed-test-metrics',
     type=bool,
     default=False,
-    help="If true, elementary won't query sample data for elementary passed tests (can improve report run time)."
+    help="If set to true elementary report won't show data metrics for passed tests (this can improve report creation time)."
 )
 @click.pass_context
-def report(ctx, days_back, config_dir, profiles_dir, update_dbt_package, profile_target, executions_limit, file_path, disable_elementary_passed_tests_samples):
+def report(ctx, days_back, config_dir, profiles_dir, update_dbt_package, profile_target, executions_limit, file_path, disable_passed_test_metrics):
     config = Config(config_dir, profiles_dir, profile_target)
     anonymous_tracking = AnonymousTracking(config)
     track_cli_start(anonymous_tracking, 'monitor-report', get_cli_properties(), ctx.command.name)
     try:
         data_monitoring = DataMonitoring(config, update_dbt_package)
         success = data_monitoring.generate_report(days_back=days_back, test_runs_amount=executions_limit,
-                                                  file_path=file_path, disable_elementary_passed_tests_samples=disable_elementary_passed_tests_samples)
+                                                  file_path=file_path, disable_passed_test_metrics=disable_passed_test_metrics)
         track_cli_end(anonymous_tracking, 'monitor-report', data_monitoring.properties(), ctx.command.name)
         if not success:
             return 1
@@ -281,10 +281,10 @@ def report(ctx, days_back, config_dir, profiles_dir, update_dbt_package, profile
     help='Set the number of invocations shown for each test in the "Test Runs" report'
 )
 @click.option(
-    '--disable-elementary-passed-tests-samples',
+    '--disable-passed-test-metrics',
     type=bool,
     default=False,
-    help="If true, elementary won't query sample data for elementary passed tests (can improve report run time)."
+    help="If set to true elementary report won't show data metrics for passed tests (this can improve report creation time)."
 )
 @click.pass_context
 def send_report(
@@ -298,7 +298,7 @@ def send_report(
         slack_channel_name,
         profile_target,
         executions_limit,
-        disable_elementary_passed_tests_samples
+        disable_passed_test_metrics
 ):
     config = Config(config_dir, profiles_dir, profile_target)
     anonymous_tracking = AnonymousTracking(config)
@@ -318,7 +318,7 @@ def send_report(
         command_succeeded = False
         generated_report_successfully, elementary_html_path = data_monitoring.generate_report(days_back=days_back,
                                                                                               test_runs_amount=executions_limit,
-                                                                                              disable_elementary_passed_tests_samples=disable_elementary_passed_tests_samples)
+                                                                                              disable_passed_test_metrics=disable_passed_test_metrics)
         if generated_report_successfully and elementary_html_path:
             command_succeeded = data_monitoring.send_report(elementary_html_path)
         return 0 if command_succeeded else 1

--- a/monitor/data_monitoring.py
+++ b/monitor/data_monitoring.py
@@ -121,7 +121,7 @@ class DataMonitoring:
         return self.success
 
     def generate_report(self, days_back: Optional[int] = None, test_runs_amount: Optional[int] = None,
-                        file_path: Optional[str] = None, disable_elementary_passed_tests_sample: bool = False) -> Tuple[
+                        file_path: Optional[str] = None, disable_elementary_passed_tests_samples: bool = False) -> Tuple[
         bool, str]:
         now_utc = get_now_utc_str()
         html_path = self._get_report_file_path(now_utc, file_path)
@@ -129,7 +129,7 @@ class DataMonitoring:
             output_data = {'creation_time': now_utc}
             test_results, test_results_totals, test_runs_totals = self._get_test_results_and_totals(
                 days_back=days_back, test_runs_amount=test_runs_amount,
-                disable_elementary_passed_tests_sample=disable_elementary_passed_tests_sample)
+                disable_elementary_passed_tests_samples=disable_elementary_passed_tests_samples)
             models, dbt_sidebar = self._get_dbt_models_and_sidebar()
             models_coverages = self._get_dbt_models_test_coverages()
             lineage = self._get_lineage()
@@ -178,11 +178,11 @@ class DataMonitoring:
         lineage_api = LineageAPI(dbt_runner=self.dbt_runner)
         return lineage_api.get_lineage()
 
-    def _get_test_results_and_totals(self, days_back: Optional[int] = None, test_runs_amount: Optional[int] = None, disable_elementary_passed_tests_sample: bool = False):
+    def _get_test_results_and_totals(self, days_back: Optional[int] = None, test_runs_amount: Optional[int] = None, disable_elementary_passed_tests_samples: bool = False):
         tests_api = TestsAPI(dbt_runner=self.dbt_runner)
         try:
             tests_metadata = tests_api.get_tests_metadata(days_back=days_back)
-            tests_sample_data = tests_api.get_tests_sample_data(days_back=days_back, disable_elementary_passed_tests_sample=disable_elementary_passed_tests_sample)
+            tests_sample_data = tests_api.get_tests_sample_data(days_back=days_back, disable_elementary_passed_tests_samples=disable_elementary_passed_tests_samples)
             invocations = tests_api.get_invocations(invocations_per_test=test_runs_amount, days_back=days_back)
             tests_results = self._create_tests_results(
                 tests_metadata=tests_metadata,

--- a/monitor/data_monitoring.py
+++ b/monitor/data_monitoring.py
@@ -121,7 +121,7 @@ class DataMonitoring:
         return self.success
 
     def generate_report(self, days_back: Optional[int] = None, test_runs_amount: Optional[int] = None,
-                        file_path: Optional[str] = None, disable_elementary_passed_tests_samples: bool = False) -> Tuple[
+                        file_path: Optional[str] = None, disable_passed_test_metrics: bool = False) -> Tuple[
         bool, str]:
         now_utc = get_now_utc_str()
         html_path = self._get_report_file_path(now_utc, file_path)
@@ -129,7 +129,7 @@ class DataMonitoring:
             output_data = {'creation_time': now_utc}
             test_results, test_results_totals, test_runs_totals = self._get_test_results_and_totals(
                 days_back=days_back, test_runs_amount=test_runs_amount,
-                disable_elementary_passed_tests_samples=disable_elementary_passed_tests_samples)
+                disable_passed_test_metrics=disable_passed_test_metrics)
             models, dbt_sidebar = self._get_dbt_models_and_sidebar()
             models_coverages = self._get_dbt_models_test_coverages()
             lineage = self._get_lineage()
@@ -178,11 +178,11 @@ class DataMonitoring:
         lineage_api = LineageAPI(dbt_runner=self.dbt_runner)
         return lineage_api.get_lineage()
 
-    def _get_test_results_and_totals(self, days_back: Optional[int] = None, test_runs_amount: Optional[int] = None, disable_elementary_passed_tests_samples: bool = False):
+    def _get_test_results_and_totals(self, days_back: Optional[int] = None, test_runs_amount: Optional[int] = None, disable_passed_test_metrics: bool = False):
         tests_api = TestsAPI(dbt_runner=self.dbt_runner)
         try:
             tests_metadata = tests_api.get_tests_metadata(days_back=days_back)
-            tests_sample_data = tests_api.get_tests_sample_data(days_back=days_back, disable_elementary_passed_tests_samples=disable_elementary_passed_tests_samples)
+            tests_sample_data = tests_api.get_tests_sample_data(days_back=days_back, disable_passed_test_metrics=disable_passed_test_metrics)
             invocations = tests_api.get_invocations(invocations_per_test=test_runs_amount, days_back=days_back)
             tests_results = self._create_tests_results(
                 tests_metadata=tests_metadata,

--- a/monitor/data_monitoring.py
+++ b/monitor/data_monitoring.py
@@ -121,14 +121,15 @@ class DataMonitoring:
         return self.success
 
     def generate_report(self, days_back: Optional[int] = None, test_runs_amount: Optional[int] = None,
-                        file_path: Optional[str] = None) -> Tuple[
+                        file_path: Optional[str] = None, disable_elementary_passed_tests_sample: bool = False) -> Tuple[
         bool, str]:
         now_utc = get_now_utc_str()
         html_path = self._get_report_file_path(now_utc, file_path)
         with open(html_path, 'w') as html_file:
             output_data = {'creation_time': now_utc}
             test_results, test_results_totals, test_runs_totals = self._get_test_results_and_totals(
-                days_back=days_back, test_runs_amount=test_runs_amount)
+                days_back=days_back, test_runs_amount=test_runs_amount,
+                disable_elementary_passed_tests_sample=disable_elementary_passed_tests_sample)
             models, dbt_sidebar = self._get_dbt_models_and_sidebar()
             models_coverages = self._get_dbt_models_test_coverages()
             lineage = self._get_lineage()
@@ -177,11 +178,11 @@ class DataMonitoring:
         lineage_api = LineageAPI(dbt_runner=self.dbt_runner)
         return lineage_api.get_lineage()
 
-    def _get_test_results_and_totals(self, days_back: Optional[int] = None, test_runs_amount: Optional[int] = None):
+    def _get_test_results_and_totals(self, days_back: Optional[int] = None, test_runs_amount: Optional[int] = None, disable_elementary_passed_tests_sample: bool = False):
         tests_api = TestsAPI(dbt_runner=self.dbt_runner)
         try:
             tests_metadata = tests_api.get_tests_metadata(days_back=days_back)
-            tests_sample_data = tests_api.get_tests_sample_data(days_back=days_back)
+            tests_sample_data = tests_api.get_tests_sample_data(days_back=days_back, disable_elementary_passed_tests_sample=disable_elementary_passed_tests_sample)
             invocations = tests_api.get_invocations(invocations_per_test=test_runs_amount, days_back=days_back)
             tests_results = self._create_tests_results(
                 tests_metadata=tests_metadata,

--- a/monitor/dbt_project/macros/get_tests_sample_data.sql
+++ b/monitor/dbt_project/macros/get_tests_sample_data.sql
@@ -1,4 +1,4 @@
-{% macro get_tests_sample_data(days_back = 7, metrics_sample_limit = 5) %}
+{% macro get_tests_sample_data(days_back = 7, metrics_sample_limit = 5, disable_elementary_passed_tests_sample = false) %}
     {% set select_test_results %}
         with elemetary_test_results as (
             select * from {{ ref('elementary', 'elementary_test_results') }}
@@ -35,7 +35,11 @@
         {% set status = elementary.insensitive_get_dict_value(test, 'status') | lower %}
 
         {% set test_rows_sample = none %}
-        {%- if (test_type == 'dbt_test' and status in ['fail', 'warn']) or (test_type != 'dbt_test' and status != 'error') -%}
+        {% set elementary_tests_filtered_status = ['error'] %}
+        {% if disable_elementary_passed_tests_sample %}
+            {% do elementary_tests_filtered_status.append('pass') %}
+        {% endif %}
+        {%- if (test_type == 'dbt_test' and status in ['fail', 'warn']) or (test_type != 'dbt_test' and status not in disable_elementary_passed_tests_sample) -%}
             {% set test_rows_sample = elementary_internal.get_test_rows_sample(test_results_query, test_type, metrics_sample_limit) %}
         {%- endif -%}
         {% set sub_test_unique_id = get_sub_test_unique_id(

--- a/monitor/dbt_project/macros/get_tests_sample_data.sql
+++ b/monitor/dbt_project/macros/get_tests_sample_data.sql
@@ -1,4 +1,4 @@
-{% macro get_tests_sample_data(days_back = 7, metrics_sample_limit = 5, disable_elementary_passed_tests_samples = false) %}
+{% macro get_tests_sample_data(days_back = 7, metrics_sample_limit = 5, disable_passed_test_metrics = false) %}
     {% set select_test_results %}
         with elemetary_test_results as (
             select * from {{ ref('elementary', 'elementary_test_results') }}
@@ -35,11 +35,11 @@
         {% set status = elementary.insensitive_get_dict_value(test, 'status') | lower %}
 
         {% set test_rows_sample = none %}
-        {% set elementary_tests_filtered_status = ['error'] %}
-        {% if disable_elementary_passed_tests_samples %}
-            {% do elementary_tests_filtered_status.append('pass') %}
+        {% set elementary_tests_allowlist_status = ['fail', 'warn']  %}
+        {% if not disable_passed_test_metrics %}
+            {% do elementary_tests_allowlist_status.append('pass') %}
         {% endif %}
-        {%- if (test_type == 'dbt_test' and status in ['fail', 'warn']) or (test_type != 'dbt_test' and status not in elementary_tests_filtered_status) -%}
+        {%- if (test_type == 'dbt_test' and status in ['fail', 'warn']) or (test_type != 'dbt_test' and status in elementary_tests_allowlist_status) -%}
             {% set test_rows_sample = elementary_internal.get_test_rows_sample(test_results_query, test_type, metrics_sample_limit) %}
         {%- endif -%}
         {% set sub_test_unique_id = get_sub_test_unique_id(

--- a/monitor/dbt_project/macros/get_tests_sample_data.sql
+++ b/monitor/dbt_project/macros/get_tests_sample_data.sql
@@ -1,4 +1,4 @@
-{% macro get_tests_sample_data(days_back = 7, metrics_sample_limit = 5, disable_elementary_passed_tests_sample = false) %}
+{% macro get_tests_sample_data(days_back = 7, metrics_sample_limit = 5, disable_elementary_passed_tests_samples = false) %}
     {% set select_test_results %}
         with elemetary_test_results as (
             select * from {{ ref('elementary', 'elementary_test_results') }}
@@ -36,10 +36,10 @@
 
         {% set test_rows_sample = none %}
         {% set elementary_tests_filtered_status = ['error'] %}
-        {% if disable_elementary_passed_tests_sample %}
+        {% if disable_elementary_passed_tests_samples %}
             {% do elementary_tests_filtered_status.append('pass') %}
         {% endif %}
-        {%- if (test_type == 'dbt_test' and status in ['fail', 'warn']) or (test_type != 'dbt_test' and status not in disable_elementary_passed_tests_sample) -%}
+        {%- if (test_type == 'dbt_test' and status in ['fail', 'warn']) or (test_type != 'dbt_test' and status not in elementary_tests_filtered_status) -%}
             {% set test_rows_sample = elementary_internal.get_test_rows_sample(test_results_query, test_type, metrics_sample_limit) %}
         {%- endif -%}
         {% set sub_test_unique_id = get_sub_test_unique_id(


### PR DESCRIPTION
Added a flag to disable sampling for elementary passed tests.
An empty result test will look like:
<img width="1361" alt="image" src="https://user-images.githubusercontent.com/48473443/180263145-0fac697d-f077-4321-a883-54cf1e9462cf.png">
