### PR TITLE
Not using the newly added default argument of a macro.

### DIFF
--- a/monitor/dbt_project/macros/get_elementary_database_and_schema.sql
+++ b/monitor/dbt_project/macros/get_elementary_database_and_schema.sql
@@ -1,3 +1,3 @@
 {% macro get_elementary_database_and_schema() %}
-    {{ elementary.edr_log(elementary.get_package_database_and_schema()) }}
+    {{ elementary.edr_log(elementary.get_package_database_and_schema('elementary')) }}
 {% endmacro %}


### PR DESCRIPTION
In the new dbt package, the default argument of `get_package_database_and_schema` is `elementary`.  
However, if a user updates the CLI before the dbt package, this change wouldn't apply.  
This would still work and wouldn't crash for the user, it would just return `<elementary_database>.<elementary_schema>` because of this:

```py
        try:
            return utils.dbt.get_elementary_database_and_schema(self.dbt_runner)
        except Exception:
            logger.error("Failed to parse Elementary's database and schema.")
            return '<elementary_database>.<elementary_schema>'
```

This is only relevant if a user's query is too long and a query for the query is returned.