### PR TITLE
Using 'include_package_data' instead of 'package_data'.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,7 @@ setup(
         edr=cli.cli:cli
     ''',
     author="Elementary",
-    package_data={"": ["header.html", "index.html", "dbt_project/*", "dbt_project/macros/*", "dbt_project/models/*",
-                       "dbt_project/models/alerts/*"]},
+    include_package_data=True,
     keyword="data, lineage, data lineage, data warehouse, DWH, observability, data monitoring, data observability, "
             "Snowflake, BigQuery, Redshift, data reliability, analytics engineering",
     long_description=README,


### PR DESCRIPTION
Tested.

Using 'include_package_data' instead of 'package_data' to avoid missing files on builds.

Information on [include_package_data](https://setuptools.pypa.io/en/latest/userguide/datafiles.html#include-package-data).