### PR TITLE
Remove Imports from Documentation

### DIFF
--- a/docs/guides/add-data-monitoring-tests.mdx
+++ b/docs/guides/add-data-monitoring-tests.mdx
@@ -2,9 +2,6 @@
 title: "Add data monitoring tests"
 ---
 
-import { TipInfo } from "@/components/Tip";
-import { SnippetGroup } from "@/components/SnippetGroup";
-
 After you [install the dbt package](../quickstart#install-the-dbt-package) and related configuration, you can add Elementary data tests.
 
 ## Data monitors as dbt tests

--- a/docs/guides/elementary-tests-configuration.mdx
+++ b/docs/guides/elementary-tests-configuration.mdx
@@ -2,8 +2,6 @@
 title: "Test configuration"
 ---
 
-import { SnippetGroup } from "@/components/SnippetGroup";
-
 The data tests configuration is defined in `.yml` files in your dbt project.
 You can change and adjust the configuration anytime, and the elementary on-run-end macro will upload the most recent version on every `dbt run` you execute.
 

--- a/docs/integrations/bigquery.mdx
+++ b/docs/integrations/bigquery.mdx
@@ -3,8 +3,6 @@ title: "BigQuery"
 description: "Snowflake integration details"
 ---
 
-import { TipInfo } from "@/components/Tip";
-
 ## Data anomalies monitoring as dbt tests
 
 Supports Bigquery since version 0.3.4
@@ -86,7 +84,10 @@ For Elementary to be able to access the jobs by project in the information schem
 
 2. Click on 'CREATE ROLE'
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304875/elementary/create-role_wmdlzf.png" alt="Create role" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304875/elementary/create-role_wmdlzf.png"
+  alt="Create role"
+/>
 
 3. Give the role a title, description, etc.
 
@@ -94,7 +95,10 @@ For Elementary to be able to access the jobs by project in the information schem
 
 5. Using the filter, find and add the permissions bigquery.jobs.listall and bigquery.jobs.create, then click 'ADD':
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304878/elementary/permissions_kpls73.png" alt="Permissions" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304878/elementary/permissions_kpls73.png"
+  alt="Permissions"
+/>
 
 6. Click 'CREATE' and make sure the new role was created and is now in the roles list.
 
@@ -104,31 +108,49 @@ For Elementary to be able to access the jobs by project in the information schem
 
 2. Click on 'CREATE SERVICE ACCOUNT'
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304875/elementary/create-service-account_birda0.png" alt="Create service account" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304875/elementary/create-service-account_birda0.png"
+  alt="Create service account"
+/>
 
 3. Fill in the service account name ('elementary') and account description ('Elementary Data') and click 'CREATE AND CONTINUE':
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304876/elementary/create-continue_ai6ta9.png" alt="Create and Continue" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304876/elementary/create-continue_ai6ta9.png"
+  alt="Create and Continue"
+/>
 
 4. Now we need to configure the relevant permissions for this new service account. As described, at this point there are two options -
 1. Option 1 - Choose BigQuery Admin or Owner.
 1. Recommended: Option 2 - Choose the following 3 roles: BigQuery Data Editor + BigQuery User + custom role you created with these instructions:
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304878/elementary/roles_ug5z5a.png" alt="Roles" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304878/elementary/roles_ug5z5a.png"
+  alt="Roles"
+/>
 
 5. The last step is optional so skip it if you don't need to manage this service account with another service account, and press done.
 
 6. Press on the dots icon to the right of your screen for your new service account and select 'Manage keys':
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304878/elementary/dots-icon_aafqkv.png" alt="Manage keys" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304878/elementary/dots-icon_aafqkv.png"
+  alt="Manage keys"
+/>
 
 7. Press on 'ADD KEY' and select 'Create new key':
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304875/elementary/add-key_v4hztr.png" alt="Add Key" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304875/elementary/add-key_v4hztr.png"
+  alt="Add Key"
+/>
 
 8. Use the 'JSON' option radio button and press 'CREATE':
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304877/elementary/json_mybzda.png" alt="JSON" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304877/elementary/json_mybzda.png"
+  alt="JSON"
+/>
 
 9. This will automatically generate and download a JSON file with your private key information for this service account. This JSON file provides the credentials to programmatically connect and work with your BigQuery environment.
 

--- a/docs/integrations/slack.mdx
+++ b/docs/integrations/slack.mdx
@@ -2,8 +2,6 @@
 title: "Slack"
 ---
 
-import { TipInfo } from "@/components/Tip";
-
 For Slack alerts, you first need to install [Elementary CLI](../understand-elementary/cli-install), [configure](../understand-elementary/cli-install#cli-configuration) a connection profile for it, and create a config file for the Slack integration.
 
 <TipInfo>
@@ -22,7 +20,10 @@ There are 2 integration options:
 Go to the [Slack page to create apps](https://api.slack.com/apps?new_app=1) and create a new app (from scratch).
 Call it "[Elementary](#slack-app-display)" and connect it to the workspace of your choice.
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304879/elementary/slack-app_zpn7jc.png" alt="Slack app" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304879/elementary/slack-app_zpn7jc.png"
+  alt="Slack app"
+/>
 
 ## 2. Create a Slack token
 
@@ -34,13 +35,19 @@ Go to the "OAauth & Permissions" page for your newly-created app, and add the fo
 - `files:write` - Upload, edit, and delete files as \<app\>
 - `users:read` - View people in a workspace
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304884/elementary/slack-scopes_u5vnbj.png" alt="Slack scopes" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304884/elementary/slack-scopes_u5vnbj.png"
+  alt="Slack scopes"
+/>
 
 ## 3. Install app at your Workspace
 
 At the "OAuth & Permissions" page, press on "Install to Workspace" in order to generate Slack token:
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304881/elementary/slack-oauth_g6p5jj.png" alt="Slack OAuth" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304881/elementary/slack-oauth_g6p5jj.png"
+  alt="Slack OAuth"
+/>
 
 ## 4. Use Elementary CLI with your Slack token
 
@@ -68,17 +75,26 @@ slack:
 Go to the [Slack page to create apps](https://api.slack.com/apps?new_app=1) and create a new app (from scratch).
 Call it "[Elementary](#slack-app-display)" and connect it to the workspace of your choice.
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304879/elementary/slack-app_zpn7jc.png" alt="Slack app" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304879/elementary/slack-app_zpn7jc.png"
+  alt="Slack app"
+/>
 
 ## 2. Create a webhook
 
 Go to the 'Incoming Webhooks' page for your newly-created app and toggle 'Activate Incoming Webhooks' to turn it on. Then click on 'Add New Webhook to Workspace':
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304882/elementary/slack-webhook_gwjkte.png" alt="Slack webhook" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304882/elementary/slack-webhook_gwjkte.png"
+  alt="Slack webhook"
+/>
 
 Select the channel that the notifications will be posted to:
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304879/elementary/slack-channel_snyrwb.png" alt="Slack channel" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304879/elementary/slack-channel_snyrwb.png"
+  alt="Slack channel"
+/>
 
 ## 3. Add the Webhook to 'config.yml'
 
@@ -198,8 +214,14 @@ The alert format is:
 
 To change the display of the Elementary slack app, scroll down on the Slack app basic information page to the 'Display Information' section:
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304881/elementary/slack-display_utxkcu.png" alt="Slack display" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304881/elementary/slack-display_utxkcu.png"
+  alt="Slack display"
+/>
 
 Here is the Elementary icon for your use:
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304888/elementary/elementary_logo_512x512_iu1u4k.png" alt="Elementary logo" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304888/elementary/elementary_logo_512x512_iu1u4k.png"
+  alt="Elementary logo"
+/>

--- a/docs/integrations/snowflake.mdx
+++ b/docs/integrations/snowflake.mdx
@@ -1,9 +1,7 @@
 ---
-title: 'Snowflake'
-description: 'Snowflake integration details'
+title: "Snowflake"
+description: "Snowflake integration details"
 ---
-
-import { TipInfo } from '@/components/Tip'
 
 ## Data anomalies monitoring as dbt tests
 
@@ -17,18 +15,22 @@ Full support
 
 There are two main methods to pull query history in Snowflake, one is using the information schema query history and the other is using the account usage. The following table describes the differences between the sources:
 
-| Query history source | Information schema | Account usage |
-| - | - | - |
-| Time limit | Up to 7 days | Up to 1 year |
-| Queries limit | 10,000 | None |
-| Delay | None | Up to 45 minutes |
-| Permmisions | Monitor warehouse | Access to shared 'Snowflake' database (default only for account admin) |
+| Query history source | Information schema | Account usage                                                          |
+| -------------------- | ------------------ | ---------------------------------------------------------------------- |
+| Time limit           | Up to 7 days       | Up to 1 year                                                           |
+| Queries limit        | 10,000             | None                                                                   |
+| Delay                | None               | Up to 45 minutes                                                       |
+| Permmisions          | Monitor warehouse  | Access to shared 'Snowflake' database (default only for account admin) |
 
 Pulling the query history from the information schema is our default. There is no delay and new queries will be shown in the lineage graph right away.
 
 To generate a lineage graph that is based on queries the account usage, use the query_history_source parameter in the connection profile, as you can see in the example below, and type 'account_usage' as its value.
 
-<TipInfo>Note that each query source requires different permissions. If these are not granted, Elementary will create partial lineage only based on accessible queries, or will return an error if there is no access at all.</TipInfo>
+<TipInfo>
+  Note that each query source requires different permissions. If these are not
+  granted, Elementary will create partial lineage only based on accessible
+  queries, or will return an error if there is no access at all.
+</TipInfo>
 
 ### Snowflake connection profile
 
@@ -44,47 +46,47 @@ The profiles.yml file to connect to Snowflake should contain a profile in the fo
 ## For edr lineage:                                            ##
 ## Any database and schema will do.                            ##
 
-elementary: 
+elementary:
   outputs:
     default:
       type: snowflake
       account: [account id]
-        
+
       ## User/password auth, other options (Keypair/SSO) require other configs ##
       user: [username]
       password: [password]
-      
+
       role: [user role]
       database: [database name]
       warehouse: [warehouse name]
       schema: [schema name]
       threads: 4
-      ## OPTIONAL - if you want to create the lineage based on queries from more 
-      ## than the last 7 days or you have 10k or more queries in the history pulled during 
+      ## OPTIONAL - if you want to create the lineage based on queries from more
+      ## than the last 7 days or you have 10k or more queries in the history pulled during
       ## the requested dates range, add this parameter (NOTE: account_usage requires more permissions, see note below).
       query_history_source: account_usage
 ```
 
-We support the same format and connection methods (user password, key pair authentication, SSO) as dbt. Please refer to dbt's documentation of [Snowflake profile](https://docs.getdbt.com/reference/warehouse-profiles/snowflake-profile) for further details. 
+We support the same format and connection methods (user password, key pair authentication, SSO) as dbt. Please refer to dbt's documentation of [Snowflake profile](https://docs.getdbt.com/reference/warehouse-profiles/snowflake-profile) for further details.
 
 ### Data lineage Snowflake permissions
 
-The queries are pulled by default from the information schema, and you can use the 'query_history_source' parameter in the connection profile to change it to the account admin. 
+The queries are pulled by default from the information schema, and you can use the 'query_history_source' parameter in the connection profile to change it to the account admin.
 
 Each source requires different permissions:
 
 **Information schema permissions:**
 
-In order to create a lineage graph that includes the tables that are updated and created by all the users and services in Snowflake, the role of the user in the connection profile needs to have the right privileges. 
+In order to create a lineage graph that includes the tables that are updated and created by all the users and services in Snowflake, the role of the user in the connection profile needs to have the right privileges.
 
-For full lineage of up to 7 days back (depends on tier), the role of the user should have monitor privilege to the warehouse. 
+For full lineage of up to 7 days back (depends on tier), the role of the user should have monitor privilege to the warehouse.
 The following [command in Snowflake](https://docs.snowflake.com/en/sql-reference/sql/grant-privilege.html) grants this role:
 
 ```shell
 grant monitor on warehouse <warehouse> to role <your_role>;
 ```
 
-Note that granting monitor privilege on a warehouse does not provide access to all the data, just to the executed queries (without the results). 
+Note that granting monitor privilege on a warehouse does not provide access to all the data, just to the executed queries (without the results).
 
 **Account usage permissions:**
 

--- a/docs/quickstart-data-lineage.mdx
+++ b/docs/quickstart-data-lineage.mdx
@@ -2,8 +2,6 @@
 title: "Quickstart: Data Lineage"
 ---
 
-import { SnippetGroup } from "@/components/SnippetGroup";
-
 ## Install and configure
 
 Start by downloading and installing elementary-data CLI.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -2,8 +2,6 @@
 title: "Quickstart: Data Monitoring"
 ---
 
-import { TipInfo } from "@/components/Tip";
-
 To start using Elementary to monitor you dbt tests, executions and data, you need to add our dbt package to your dbt project.
 
 <details className="-mt-0 mb-6 rounded-xl border px-6 py-3 prose prose-slate open:pb-5 dark:prose-dark dark:border-slate-800">
@@ -17,6 +15,7 @@ Some packages we recommend you check out: [dbt_utils](https://github.com/dbt-lab
 </details>
 
 ## How to install Elementary dbt package?
+
 <Example resizeable>
   <div style="position: relative; padding-bottom: 64.98194945848375%; height: 0;">
     <iframe
@@ -56,7 +55,6 @@ models:
     +schema: "elementary"
 ```
 
-
 <details className="-mt-0 mb-6 rounded-xl border px-6 py-3 prose prose-slate open:pb-5 dark:prose-dark dark:border-slate-800"> <summary className="font-medium cursor-default select-none text-slate-900 dark:text-slate-200"><TipInfo>Important: Materialization config</TipInfo></summary>
 
 For elementary to work, it needs to create some of the models as incremental tables. Make sure that there are no global materialization configurations that affect elementary, such as:
@@ -68,14 +66,16 @@ materialized: "{{ 'table' if target.name == 'prod-cloud' else 'view' }}"
 Make sure to place the 'elementary' configuration under the models key, and other configs under your project name.
 
 Example:
+
 ```yml dbt_project.yml
 models:
   my_project:
     materialized: "{{ 'table' if target.name == 'prod-cloud' else 'view' }}"
-  
+
   elementary:
     +schema: "elementary"
 ```
+
 </details>
 
 ### 3. Import the package

--- a/docs/quickstart/add-elementary-tests.mdx
+++ b/docs/quickstart/add-elementary-tests.mdx
@@ -2,8 +2,6 @@
 title: "Add Elementary tests"
 ---
 
-import { SnippetGroup } from "@/components/SnippetGroup";
-
 Before you can start using Elementary monitors as tests, execute `dbt run` with the Elementary package models, which are **required for the tests to work.**
 
 ## Run the following command

--- a/docs/quickstart/generate-report-ui.mdx
+++ b/docs/quickstart/generate-report-ui.mdx
@@ -2,12 +2,14 @@
 title: "Generate report"
 ---
 
-import { SnippetGroup } from "@/components/SnippetGroup";
 import InstallCLI from "../snippets/install_cli.mdx";
 
 Elementary has a report for visualization and exploration of data from the dbt-package tables, which includes dbt test results, Elementary anomaly detection results, dbt artifacts, tests runs, etc.
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304880/elementary/Demo-2-screens_k98bdr.gif" alt="Demo" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304880/elementary/Demo-2-screens_k98bdr.gif"
+  alt="Demo"
+/>
 
 In order to visualize the data from the [dbt-package](../project-overview/contributions#guide-on-contributing-to-the-dbt-package) tables, you can use the [CLI](../understand-elementary/cli-install) to generate the Elementary report.
 

--- a/docs/quickstart/send-slack-alerts.mdx
+++ b/docs/quickstart/send-slack-alerts.mdx
@@ -2,8 +2,6 @@
 title: "Slack alerts and test reports"
 ---
 
-import { TipInfo } from "@/components/Tip";
-
 ## Get Slack alerts
 
 ### Configure Slack
@@ -67,7 +65,10 @@ edr monitor
 
 You can use the 'owner' and 'tags' fields in dbt yml files, to decide who should be mentioned in a Slack alert:
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304885/elementary/slack-alert-format_rgcg1p.png" alt="New Slack alert format" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304885/elementary/slack-alert-format_rgcg1p.png"
+  alt="New Slack alert format"
+/>
 
 ### Continuous alerting
 

--- a/docs/understand-elementary/cli-install.mdx
+++ b/docs/understand-elementary/cli-install.mdx
@@ -2,8 +2,6 @@
 title: "CLI Install & Configure"
 ---
 
-import { SnippetGroup } from "@/components/SnippetGroup";
-
 We recommend you install Elementary CLI using one of the following methods:
 
 ## Install & Configure

--- a/docs/understand-elementary/connection-profile.mdx
+++ b/docs/understand-elementary/connection-profile.mdx
@@ -1,28 +1,27 @@
 ---
-title: 'Connection Profile'
+title: "Connection Profile"
 ---
 
-import { SnippetGroup } from '@/components/SnippetGroup'
+In order to connect to your data warehouse, Elementary requires connection details and credentials. These are provided to the tool using a file named `profiles.yml`.
 
-In order to connect to your data warehouse, Elementary requires connection details and credentials. These are provided to the tool using a file named `profiles.yml`. 
-
-The details provided in the connection profile will be the credentials that Elementary will use, and the details of the database and schema that will be used for outputs (e.g. alerts, configuration tables). 
+The details provided in the connection profile will be the credentials that Elementary will use, and the details of the database and schema that will be used for outputs (e.g. alerts, configuration tables).
 
 **We recommend creating a dedicated database, or at least a schema.**
 
-## dbt users 
+## dbt users
 
 **Just add a profile with the relevant credentials, and name it elementary.**
 
-If you use [dbt](https://www.getdbt.com/), you don't even need to create the file, you already have it. In general, we support the same profiles format as dbt for our supported integrations, with the exception that in BigQuery we require 'location', and in dbt it is optional. 
+If you use [dbt](https://www.getdbt.com/), you don't even need to create the file, you already have it. In general, we support the same profiles format as dbt for our supported integrations, with the exception that in BigQuery we require 'location', and in dbt it is optional.
 
-## Required permissions 
+## Required permissions
 
 The provided credentials need to have permission to:
-- Read - query history, information schema and the tables configured for monitoring.,
-- Write - to the database and schema configured in Elementary connection profile. 
 
-If the credentials provided will not have access to the entire query history, a partial lineage graph will be generated based on the available queries (can be exported using the export query history option). 
+- Read - query history, information schema and the tables configured for monitoring.,
+- Write - to the database and schema configured in Elementary connection profile.
+
+If the credentials provided will not have access to the entire query history, a partial lineage graph will be generated based on the available queries (can be exported using the export query history option).
 
 The required connection details and permissions for each data warehouse are detailed in the relevant integration documentation under integrations.
 
@@ -40,23 +39,23 @@ The required connection details and permissions for each data warehouse are deta
 ## For edr lineage:                                            ##
 ## Any database and schema will do.                            ##
 
-elementary: 
+elementary:
   outputs:
     default:
       type: snowflake
       account: [account id]
-        
+
       ## User/password auth, other options (Keypair/SSO) require other configs ##
       user: [username]
       password: [password]
-      
+
       role: [user role]
       database: [database name]
       warehouse: [warehouse name]
       schema: [schema name]
       threads: 4
-      ## OPTIONAL - if you want to create the lineage based on queries from more 
-      ## than the last 7 days or you have 10k or more queries in the history pulled during 
+      ## OPTIONAL - if you want to create the lineage based on queries from more
+      ## than the last 7 days or you have 10k or more queries in the history pulled during
       ## the requested dates range, add this parameter (NOTE: account_usage requires more permissions, see note below).
       query_history_source: account_usage
 ```
@@ -71,16 +70,15 @@ elementary:
 ## For edr lineage:                                            ##
 ## Any database and schema will do.                            ##
 
-
-elementary: 
+elementary:
   outputs:
-    default:  
+    default:
       type: bigquery
-      
+
       ## Service account auth, other options require other configs ##
       method: service-account
       keyfile: [full path to your keyfile]
-      
+
       project: [project id]
       dataset: [dataset name]
       threads: 4
@@ -97,23 +95,28 @@ elementary:
 ## Check where 'elementary_test_results' is to find it.        ##
 ##                                                             ##
 
-elementary: 
+elementary:
   outputs:
     default:
       type: redshift
       host: [hostname, like hostname.region.redshift.amazonaws.com]
-        
+
       ## User/password auth, other options (IAM) require other configs ##
       user: [username]
       password: [password]
-      
+
       dbname: [database name]
       schema: [schema name]
       threads: 4
       keepalives_idle: 240 # default 240 seconds
       connect_timeout: 10 # default 10 seconds
       # search_path: public # optional, not recommended
-      sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
+      sslmode:
+        [
+          optional,
+          set the sslmode used to connect to the database (in case this parameter is set,
+          will look for ca in ~/.postgresql/root.crt),
+        ]
       ra3_node: true # enables cross-database sources
 ```
 

--- a/docs/understand-elementary/dbt-package.mdx
+++ b/docs/understand-elementary/dbt-package.mdx
@@ -2,8 +2,6 @@
 title: "dbt package"
 ---
 
-import { TipInfo } from "@/components/Tip";
-
 For the data monitoring and dbt artifacts collection, edr executes a dbt package we developed.
 The package adds modles, macros, and Elementary monitors as dbt tests to your project.
 
@@ -26,7 +24,6 @@ To start, refer to the [installation guide](../quickstart#install-the-dbt-packag
 The code of the Elementary dbt package can be found here:
 
 [GitHub - Elementary elementary-data / dbt-data-reliability](https://github.com/elementary-data/dbt-data-reliability)
-
 
 <details className="-mt-0 mb-6 rounded-xl border px-6 py-3 prose prose-slate open:pb-5 dark:prose-dark dark:border-slate-800">
   <summary className="font-medium cursor-default select-none text-slate-900 dark:text-slate-200">Have a question❓</summary>


### PR DESCRIPTION
Hey guys 👋

I know that Hahnbee usually contributes, but why does she deserve all the fun?

We just made an update that lets you use Mintlify [components](https://meta.mintlify.com/components/call-out) without importing them! This should make working with documentation a bit easier. I took the liberty to help remove them from your current docs

### Side note
- I have prettier configured for mdx files by default, so some of the smaller changes help make the markdown files a bit more readable. They won't make any differences in the display of the docs