### PR TITLE
Fix Errors for Documentation Deployment

### DIFF
--- a/docs/guides/elementary-tests-configuration.mdx
+++ b/docs/guides/elementary-tests-configuration.mdx
@@ -9,7 +9,6 @@ Elementary tests have three levels of configurations:
 2. [Table configuration](#configure-timestamp-column-for-dbt-models) - Configure the timestamp column and details of a monitored table.
 3. [Global vars](#data-monitoring-global-vars) - Optional configuration parameters of the operation.
 
-
 <details className="-mt-0 mb-6 rounded-xl border px-6 py-3 prose prose-slate open:pb-5 dark:prose-dark dark:border-slate-800">
     <summary className="font-medium cursor-default select-none text-slate-900 dark:text-slate-200">Data tests configuration priorities</summary>
 The configuration of Elementary monitors is dbt native, meaning we follow the format and priorities of `dbt configuration`.
@@ -76,7 +75,6 @@ Param for the `all_columns_anomalies` test only, which enables to exclude a colu
 
 </details>
 
-
 <details className="-mt-0 mb-6 rounded-xl border px-6 py-3 prose prose-slate open:pb-5 dark:prose-dark dark:border-slate-800">
     <summary className="font-medium cursor-default select-none text-slate-900 dark:text-slate-200">exclude_prefix</summary>
 
@@ -108,79 +106,79 @@ If undefined, default is null (no time buckets).
 
 <SnippetGroup>
 
-    ```yml properties.yml
-    version: 2
+```yml properties.yml
+version: 2
 
-    models:
-    - name: <model_name>
-    config:
-    elementary:
-    timestamp_column: < model timestamp column >
-    tests: < here you will add elementary monitors as tests >
+models:
+- name: <model_name>
+config:
+elementary:
+timestamp_column: < model timestamp column >
+tests: < here you will add elementary monitors as tests >
 
-    - name: <your model with no timestamp>
-    ## if no timestamp is configured, elementary will monitor without time filtering
-    tests: <here you will add elementary monitors as tests>
-    ```
+- name: <your model with no timestamp>
+## if no timestamp is configured, elementary will monitor without time filtering
+tests: <here you will add elementary monitors as tests>
+```
 
-    ```yml Example
-    version: 2
+```yml Example
+version: 2
 
-    models:
-    - name: login_events
-    config:
-    elementary:
-    timestamp_column: updated_at
-    tests:
-    - elementary.table_anomalies:
-    tags: ["elementary"]
-    - elementary.all_columns_anomalies:
-    tags: ["elementary"]
+models:
+- name: login_events
+config:
+elementary:
+timestamp_column: updated_at
+tests:
+- elementary.table_anomalies:
+tags: ["elementary"]
+- elementary.all_columns_anomalies:
+tags: ["elementary"]
 
-    - name: users
-    ## if no timestamp is configured, elementary will monitor without time filtering
-    tests:
-    - elementary.table_anomalies:
-    tags: ["elementary"]
-    ```
+- name: users
+## if no timestamp is configured, elementary will monitor without time filtering
+tests:
+- elementary.table_anomalies:
+tags: ["elementary"]
+```
 
-    ```yml sources_properties.yml
-    sources:
-    - name: < some name >
-    database: < datatbase >
-    schema: < schema >
-    tables:
-    - name: < table_name >
-    ## sources don't have config, so elementary config is placed under 'meta'
-    meta:
-    elementary:
-    timestamp_column: < source timestamp column >
-    tests: <here you will add elementary monitors as tests>
-    ```
+```yml sources_properties.yml
+sources:
+  - name: < some name >
+database: < datatbase >
+schema: < schema >
+tables:
+  - name: < table_name >
+## sources don't have config, so elementary config is placed under 'meta'
+meta:
+elementary:
+timestamp_column: < source timestamp column >
+tests: <here you will add elementary monitors as tests>
+```
 
-    ```yml Example
-    sources:
-    - name: 'my_non_dbt_table'
-    database: 'raw_events'
-    schema: 'product'
-    tables:
-    - name: 'raw_product_login_events'
-    ## sources don't have config, so elementary config is placed under 'meta'
-    meta:
-    elementary:
-    timestamp_column: 'loaded_at'
-    tests:
-    - elementary.table_anomalies
-    - elementary.all_columns_anomalies:
-    column_anomalies:
-    - null_count
-    - missing_count
-    - zero_count
-    columns:
-    - name: user_id
-    tests:
-    - elementary.column_anomalies
-    ```
+```yml Example
+sources:
+- name: 'my_non_dbt_table'
+database: 'raw_events'
+schema: 'product'
+tables:
+- name: 'raw_product_login_events'
+## sources don't have config, so elementary config is placed under 'meta'
+meta:
+elementary:
+timestamp_column: 'loaded_at'
+tests:
+- elementary.table_anomalies
+- elementary.all_columns_anomalies:
+column_anomalies:
+- null_count
+- missing_count
+- zero_count
+columns:
+- name: user_id
+tests:
+- elementary.column_anomalies
+```
 
 </SnippetGroup>
 

--- a/docs/integrations/slack.mdx
+++ b/docs/integrations/slack.mdx
@@ -2,25 +2,25 @@
 title: "Slack"
 ---
 
-import SetupSlackIntegration from "../snippets/stup-slack-integration.mdx";
+import SetupSlackIntegration from "../snippets/setup-slack-integration.mdx";
 
 Elementary Slack integration includes sending [Slack alerts](../understand-elementary/elementary-alerts) on failures in dbt tests and models, and the option to distribute the [data observability report](../understand-elementary/elementary-report-ui) as a message attachment.
 
 ## Token vs Webhook
+
 There are two integration options: Token or Webhook.
 Both methods let you receive alerts from Elementary, but there are several features that are only supported in one of the two.
 Below is features support comparison table, to help you select the integration method.
 
 <TipInfo>
-    If possible, Token is the preferred way. It allows more flexibility and
-    supports more features than Webhook.
+  If possible, Token is the preferred way. It allows more flexibility and
+  supports more features than Webhook.
 </TipInfo>
 
 | Slack integration | Elementary alerts | Elementary tests report | Multiple channels | Slack workflows |
 | ----------------- | ----------------- | ----------------------- | ----------------- | --------------- |
-| Token             | ✅                | ✅                      | ✅               | ❌              |
-| Webhook           | ✅                | ❌                      | ❌               | ✅              |
-
+| Token             | ✅                | ✅                      | ✅                | ❌              |
+| Webhook           | ✅                | ❌                      | ❌                | ✅              |
 
 ## Slack integration setup
 
@@ -54,4 +54,3 @@ The alert format is:
 ```
 
 ---
-

--- a/docs/mint.config.json
+++ b/docs/mint.config.json
@@ -46,10 +46,7 @@
   "navigation": [
     {
       "group": "Getting Started",
-      "pages": [
-        "introduction",
-        "quickstart"
-      ]
+      "pages": ["introduction", "quickstart"]
     },
     {
       "group": "Guides",
@@ -68,7 +65,7 @@
         "understand-elementary/dbt-package",
         "guides/dbt-artifacts",
         "understand-elementary/elementary-report-ui",
-        "understand-elementary/elementary-alerts",
+        "understand-elementary/elementary-alerts"
       ]
     },
     {

--- a/docs/mint.config.json
+++ b/docs/mint.config.json
@@ -38,9 +38,9 @@
       "url": "https://storage.googleapis.com/elementary_static/elementary_demo.html"
     },
     {
-      "name": "Contact Us",
-      "icon": "envelope",
-      "url": "mailto:team@elementary-data.com"
+      "name": "GitHub",
+      "icon": "github",
+      "url": "https://github.com/elementary-data/elementary"
     }
   ],
   "navigation": [

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -17,16 +17,16 @@ Some packages we recommend you check out: [dbt_utils](https://github.com/dbt-lab
 ## How to install Elementary dbt package?
 
 <Example resizeable>
-    <div style="position: relative; padding-bottom: 64.98194945848375%; height: 0;">
-        <iframe
-            src="https://www.loom.com/embed/5cf1aaa0708f43a993f8a2945473c7ac"
-            frameborder="0"
-            webkitallowfullscreen
-            mozallowfullscreen
-            allowfullscreen
-            style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
-        ></iframe>
-    </div>
+  <div style="position: relative; padding-bottom: 64.98194945848375%; height: 0;">
+    <iframe
+      src="https://www.loom.com/embed/5cf1aaa0708f43a993f8a2945473c7ac"
+      frameborder="0"
+      webkitallowfullscreen
+      mozallowfullscreen
+      allowfullscreen
+      style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
+    ></iframe>
+  </div>
 </Example>
 
 ### 1. Add elementary to `packages.yml`
@@ -44,7 +44,7 @@ packages:
 ### 2. Add to your `dbt_project.yml`
 
 <TipInfo>
-    This means Elementary will use `your_schema_elementary` as its schema.
+  This means Elementary will use `your_schema_elementary` as its schema.
 </TipInfo>
 
 ```yml dbt_project.yml
@@ -55,26 +55,27 @@ models:
     +schema: "elementary"
 ```
 
-<details className="-mt-0 mb-6 rounded-xl border px-6 py-3 prose prose-slate open:pb-5 dark:prose-dark dark:border-slate-800"> <summary className="font-medium cursor-default select-none text-slate-900 dark:text-slate-200"><TipInfo>Important: Materialization config</TipInfo></summary>
+<details className="-mt-0 mb-6 rounded-xl border px-6 py-3 prose prose-slate open:pb-5 dark:prose-dark dark:border-slate-800">
+<summary className="font-medium cursor-default select-none text-slate-900 dark:text-slate-200">Important: Materialization config</summary>
 
-    For elementary to work, it needs to create some of the models as incremental tables. Make sure that there are no global materialization configurations that affect elementary, such as:
+For elementary to work, it needs to create some of the models as incremental tables. Make sure that there are no global materialization configurations that affect elementary, such as:
 
-    ```yml dbt_project.yml
-    materialized: "{{ 'table' if target.name == 'prod-cloud' else 'view' }}"
-    ```
+```yml dbt_project.yml
+materialized: "{{ 'table' if target.name == 'prod-cloud' else 'view' }}"
+```
 
-    Make sure to place the 'elementary' configuration under the models key, and other configs under your project name.
+Make sure to place the 'elementary' configuration under the models key, and other configs under your project name.
 
-    Example:
+Example:
 
-    ```yml dbt_project.yml
-    models:
-    my_project:
-    materialized: "{{ 'table' if target.name == 'prod-cloud' else 'view' }}"
+```yml dbt_project.yml
+models:
+my_project:
+materialized: "{{ 'table' if target.name == 'prod-cloud' else 'view' }}"
 
-    elementary:
-    +schema: "elementary"
-    ```
+elementary:
++schema: "elementary"
+```
 
 </details>
 
@@ -91,7 +92,6 @@ dbt run --select elementary
 ```
 
 This will mostly create empty tables, that will be updated with artifacts, metrics and test results in your future dbt executions.
-
 
 ### What happens now?
 

--- a/docs/quickstart/send-slack-alerts.mdx
+++ b/docs/quickstart/send-slack-alerts.mdx
@@ -1,20 +1,22 @@
 ---
 title: "Slack alerts"
 ---
-import SetupSlackIntegration from "../snippets/stup-slack-integration.mdx";
+
+import SetupSlackIntegration from "../snippets/setup-slack-integration.mdx";
 
 Elementary has a Slack integration to send alerts about failures in dbt tests, Elementary tests, models runs and snapshots runs.
 
 The alerts include information for fast triage.
 Also, you can add configuration for each test / model in your `.yml` files:
+
 - Custom channels - distribute alerts based on their context
 - Owners - tag the owner of the model
 - Subscribers - let users subscribe to models and tests they care about
 - dbt Tags - add custom context to the alert
 
 <img
-    src="https://res.cloudinary.com/mintlify/image/upload/v1659304885/elementary/slack-alert-format_rgcg1p.png"
-    alt="New Slack alert format"
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304885/elementary/slack-alert-format_rgcg1p.png"
+  alt="New Slack alert format"
 />
 
 ## Setup Slack Integration
@@ -40,16 +42,17 @@ You can choose to disable alert types by adding a var to your `dbt_project.yml`.
 vars:
   # Alerts configuration vars   #
   # All set to false by default #
-    elementary:
-      disable_model_alerts: false
-      disable_test_alerts: false
-      disable_warn_alerts: false
+  elementary:
+    disable_model_alerts: false
+    disable_test_alerts: false
+    disable_warn_alerts: false
 ```
 
 ## Customize alerts: owners, tags and subscribers
 
 Elementary enriches alerts with dbt model/source/snapshot owners and tags ([see dbt's docs to learn more](https://docs.getdbt.com/reference/resource-configs/meta#designate-a-model-owner)).
 Also, you can use two custom Elementary fields:
+
 - Subscribers: to tag additional users except the owner in an alert.
 - Channel: to send the alert to additional Slack channel (only available for Slack token).
 
@@ -61,18 +64,18 @@ If you want to tag a model owner in a slack alert:
 
 ```yml properties.yml
 models:
-    - name: my_model_name
-      meta:
-        owner: "@jessica.jones"
+  - name: my_model_name
+    meta:
+      owner: "@jessica.jones"
 ```
 
 It is possible to tag multiple owners as well:
 
 ```yml properties.yml
 models:
-    - name: my_model_name
-      meta:
-        owner: ["@jessica.jones", "@joe.joseph"]
+  - name: my_model_name
+    meta:
+      owner: ["@jessica.jones", "@joe.joseph"]
 ```
 
 </details>
@@ -81,16 +84,16 @@ models:
     <summary className="font-medium cursor-default select-none text-slate-900 dark:text-slate-200">Tags</summary>
 
 if you want to tag a group or a channel in a slack alert:
+
 - Add it as model tag and use '#' as the prefix of the channel name.
 - For example, to tag the marketing team's data ops channel add the following to your `model schema.yml` / `properties.yml`.
 
-
 ```yml properties.yml
 models:
-    - name: my_model_name
-      meta:
-        owner: "@jessica.jones"
-        tags: ["#marketing-data-ops"]
+  - name: my_model_name
+    meta:
+      owner: "@jessica.jones"
+      tags: ["#marketing-data-ops"]
 ```
 
 </details>
@@ -103,24 +106,24 @@ If you want to tag users on a model / test / snapshot failure alert:
 
 ```yml properties.yml
 models:
-    - name: my_model_name
-      meta:
-        subscribers: "@jessica.jones"
-      columns:
-        - name: column_name
-          tests:
-            - unique:
-                meta:
-                  subscribers: "@luke.cage"
+  - name: my_model_name
+    meta:
+      subscribers: "@jessica.jones"
+    columns:
+      - name: column_name
+        tests:
+          - unique:
+              meta:
+                subscribers: "@luke.cage"
 ```
 
 It is possible to tag multiple subscribers as well:
 
 ```yml properties.yml
 models:
-    - name: my_model_name
-      meta:
-        subscribers: ["@jessica.jones", "@luke.cage"]
+  - name: my_model_name
+    meta:
+      subscribers: ["@jessica.jones", "@luke.cage"]
 ```
 
 </details>
@@ -135,19 +138,21 @@ If you configure a custom slack channel for a model, all the test alerts that be
 For example, this enables you to duplicate all your marketing model and test alerts to a specific marketing-data-ops channel.
 
 To set it up, simply add the relevant channel to your models in the properties.yml (can be done also for sources and snapshots).
+
 ```yml properties.yml
 models:
-    - name: marketing_leads
-      meta:
-        channel: marketing_data_ops
+  - name: marketing_leads
+    meta:
+      channel: marketing_data_ops
 ```
 
 If your models are in folders by department / team, another useful option is to configure the channel in your `dbt_project.yml` file.
+
 ```yml dbt_project.yml
-    models:
-      marketing_bi:
-        +meta:
-          +channel: marketing_data_ops
+models:
+  marketing_bi:
+    +meta:
+      +channel: marketing_data_ops
 ```
 
 </details>
@@ -156,4 +161,3 @@ If your models are in folders by department / team, another useful option is to 
 
 In order to monitor continuously, use your orchestrator to execute it regularly (we recommend running it right after your dbt job ends to monitor the latest data updates).
 If you need help or wish to consult on this, reach out to us on [Slack](https://join.slack.com/t/elementary-community/shared_invite/zt-uehfrq2f-zXeVTtXrjYRbdE_V6xq4Rg).
-

--- a/docs/snippets/install-dbt-package.mdx
+++ b/docs/snippets/install-dbt-package.mdx
@@ -1,16 +1,16 @@
-import { Example } from '@/components/Example';
+import { Example } from "@/components/Example";
 
 ## How to install Elementary dbt package?
 
 <Example>
-    <iframe
-        src="https://www.loom.com/embed/5cf1aaa0708f43a993f8a2945473c7ac"
-        frameborder="0"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen
-        class="w-full h-64"
-    ></iframe>
+  <iframe
+    src="https://www.loom.com/embed/5cf1aaa0708f43a993f8a2945473c7ac"
+    frameborder="0"
+    webkitallowfullscreen
+    mozallowfullscreen
+    allowfullscreen
+    class="w-full h-64"
+  ></iframe>
 </Example>
 
 ### 1. Add elementary to `packages.yml`
@@ -39,7 +39,8 @@ models:
     +schema: "elementary"
 ```
 
-<details className="-mt-0 mb-6 rounded-xl border px-6 py-3 prose prose-slate open:pb-5 dark:prose-dark dark:border-slate-800"> <summary className="font-medium cursor-default select-none text-slate-900 dark:text-slate-200"><TipInfo>Important: Materialization config</TipInfo></summary>
+<details className="-mt-0 mb-6 rounded-xl border px-6 py-3 prose prose-slate open:pb-5 dark:prose-dark dark:border-slate-800">
+<summary className="font-medium cursor-default select-none text-slate-900 dark:text-slate-200">Important: Materialization config</summary>
 
 For elementary to work, it needs to create some of the models as incremental tables. Make sure that there are no global materialization configurations that affect elementary, such as:
 


### PR DESCRIPTION
## Summary
Fix deployment issue for documentation

### Errors
- Remove extra comma in JSON
- Fixed import types
- Remove indent on SnippetGroup that's causing the issues

### Also included
- Replace GitHub icon
- Fix the dropdown in quickstart with TipInfo (the solution was just removing it because it doesn't support it well right now). We will be building a separate dropdown component that will make it work

### Notes
- There were also some prettier auto-fixes that were applied on. Let me know if you don't want them or don't want them in future PRs