### PR TITLE
Fix deployment bug

### DIFF
--- a/docs/general/faq.mdx
+++ b/docs/general/faq.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'FAQ'
-description: 'This section is aimed at collecting common questions users have to provide documented answers.'
+title: "FAQ"
+description: "This section is aimed at collecting common questions users have to provide documented answers."
 ---
 
 <AccordionGroup>
@@ -9,12 +9,12 @@ description: 'This section is aimed at collecting common questions users have to
 The short answer is yes.
 We recommend that Elementary models will have their own schema, but it is not mandatory. 
 You can change the schema name by using dbt [custom schema configuration](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/using-custom-schemas) on your `dbt_project.yml`.
-In short, the default dbt `generate_schema_name` macro concatenate the value provided in `schema` configuration key to the target schema, as in: `<target_schema>_<custom_schema>`.
+In short, the default dbt `generate_schema_name` macro concatenate the value provided in `schema` configuration key to the target schema, as in: `target_schema_custom_schema`.
 
-If you want a different behaviour, like configuring a full name for the Elementary schema, you can override the default `generate_schema_name` macro with your logic. 
+If you want a different behaviour, like configuring a full name for the Elementary schema, you can override the default `generate_schema_name` macro with your logic.
 Before you do that, make sure that there isn't already a macro named `generate_schema_name.sql` in your project.
 
-Here is a macro you can use that would search for a config under `meta` named `schema_name`. 
+Here is a macro you can use that would search for a config under `meta` named `schema_name`.
 If it exists, that would be the schema name. If not - the original dbt logic would be followed:
 
 ```sql generate_schema_name.sql
@@ -43,17 +43,21 @@ If it exists, that would be the schema name. If not - the original dbt logic wou
 ```
 
 If you implement this macro and want to name the Elementary schema `elementary_data_observability`:
+
 ```yml dbt_project.yml
 models:
   elementary:
     +meta:
-      custom_schema: 'elementary_data_observability'  
+      custom_schema: "elementary_data_observability"
 ```
 
 </Accordion>
 
 <Accordion title="My question is not listed here">
-If you're experiencing issues of any kind, please contact us on the [#support](https://elementary-community.slack.com/archives/C02CTC89LAX) channel.
+If you're experiencing issues of any kind, please contact us on the
+[#support](https://elementary-community.slack.com/archives/C02CTC89LAX)
+channel.
+
 </Accordion>
 
 </AccordionGroup>

--- a/docs/snippets/change-elementary-schema.mdx
+++ b/docs/snippets/change-elementary-schema.mdx
@@ -1,5 +1,3 @@
-import { Accordion } from "@/components/Accordion";
-
 <Accordion title="Can I change Elementary schema?">
 The short answer is yes.
 We recommend that Elementary models will have their own schema, but it is not mandatory. 

--- a/docs/snippets/change-elementary-schema.mdx
+++ b/docs/snippets/change-elementary-schema.mdx
@@ -4,7 +4,7 @@ import { Accordion } from "@/components/Accordion";
 The short answer is yes.
 We recommend that Elementary models will have their own schema, but it is not mandatory. 
 You can change the schema name by using dbt [custom schema configuration](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/using-custom-schemas) on your `dbt_project.yml`.
-In short, the default dbt `generate_schema_name` macro concatenate the value provided in `schema` configuration key to the target schema, as in: `<target_schema>_<custom_schema>`.
+In short, the default dbt `generate_schema_name` macro concatenate the value provided in `schema` configuration key to the target schema, as in: `target_schema_custom_schema`.
 
 If you want a different behaviour, like configuring a full name for the Elementary schema, you can override the default `generate_schema_name` macro with your logic.
 Before you do that, make sure that there isn't already a macro named `generate_schema_name.sql` in your project.
@@ -38,11 +38,12 @@ If it exists, that would be the schema name. If not - the original dbt logic wou
 ```
 
 If you implement this macro and want to name the Elementary schema `elementary_data_observability`:
+
 ```yml dbt_project.yml
 models:
   elementary:
     +meta:
-      custom_schema: 'elementary_data_observability'  
+      custom_schema: "elementary_data_observability"
 ```
 
 </Accordion>

--- a/docs/snippets/have_question.mdx
+++ b/docs/snippets/have_question.mdx
@@ -1,5 +1,3 @@
-import { Accordion } from "@/components/Accordion";
-
 <Accordion title="Have a question❓">
 We are available on [Slack](https://join.slack.com/t/elementary-community/shared_invite/zt-uehfrq2f-zXeVTtXrjYRbdE_V6xq4Rg), reach out for any kind of help!
 

--- a/docs/snippets/install-dbt-package.mdx
+++ b/docs/snippets/install-dbt-package.mdx
@@ -1,7 +1,3 @@
-import { Example } from "@/components/Example";
-import { Accordion } from "@/components/Accordion";
-
-
 ## How to install Elementary dbt package?
 
 <Example>

--- a/docs/snippets/setup-slack-integration.mdx
+++ b/docs/snippets/setup-slack-integration.mdx
@@ -1,5 +1,3 @@
-import { Accordion } from "@/components/Accordion";
-
 First create a Slack app:
 
 <Accordion title="Create a Slack App">


### PR DESCRIPTION
### Primary cause of error:
- Using `<target_schema>_<custom_schema>`. They are treated as html elements, which causes the issue

## Short-term fix
- Replace `<target_schema>_<custom_schema>` with `target_schema_custom_schema`

## Long-term fix
- We're going to ship a patch that lets you render that normally this from happening

# Notes
- You don't need to import `Accordion` or `Example`
- In order for component to have markdown as children, the pattern needs to be
```mdx
<Accordion>
[link](https://example.com)
{/* note the extra line here and how nothing is indented */}
</Accordion>
```