### PR TITLE
Fix Slack webhook client - added un-implemented methods

### DIFF
--- a/clients/slack/client.py
+++ b/clients/slack/client.py
@@ -150,3 +150,11 @@ class SlackWebhookClient(SlackClient):
         else:
             logger.error(f"Could not post message to slack via webhook - {self.webhook}. Error: {response.body}")
             return False
+
+    def send_file(self, **kwargs):
+        logger.error(
+            f"Slack webhook does not support sending files. Please use Slack token instead (see documentation on how to configure a slack token)")
+
+    def send_report(self, **kwargs):
+        logger.error(
+            f"Slack webhook does not support sending reports. Please use Slack token instead (see documentation on how to configure a slack token)")


### PR DESCRIPTION
A change we did in the Slack webhook client removed implementation of abstract methods from it.
This caused a bug in the webhook client that makes it break down on initial.
Added the implementation of the missing methods.