### PR TITLE
Changed monitor's command title.

### DIFF
--- a/monitor/cli.py
+++ b/monitor/cli.py
@@ -109,7 +109,7 @@ def monitor(
         dbt_vars
 ):
     """
-    Monitor your warehouse and send alerts to Slack.
+    Monitor your warehouse.
     """
 
     click.echo(f"Any feedback and suggestions are welcomed! join our community here - "


### PR DESCRIPTION
In order to avoid confusion with the reports, `monitor` doesn't necessarily send Slack alerts.

<img width="1074" alt="image" src="https://user-images.githubusercontent.com/30181361/185696978-6a4391a8-8ab3-48a9-8865-5e3f1e779e83.png">
