### PR TITLE
Fix Deployment Issue due to Renames

### DIFF
--- a/docs/Archive/quickstart-data-lineage.mdx
+++ b/docs/Archive/quickstart-data-lineage.mdx
@@ -38,7 +38,7 @@ In order to connect, elementary needs a profile in a file named `profiles.yml`, 
 
 Here is an example for Snowflake and BigQuery profiles:
 
-<SnippetGroup>
+<CodeGroup>
 
 ```yml Snowflake
 ## SNOWFLAKE ##
@@ -100,7 +100,7 @@ elementary:
       priority: interactive
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 For further information and other authentication options, refer to the [connection profile guide](./understand-elementary/cli-install#cli-configuration).
 

--- a/docs/guides/add-elementary-tests.mdx
+++ b/docs/guides/add-elementary-tests.mdx
@@ -25,7 +25,7 @@ These tests are configured and executed like any other tests in your project.
 Executes table level monitors and anomaly detection. Specific monitors are [detailed here](./data-anomaly-detection#tests-and-monitors-types) and can be configured using the `table_anomalies` key.
 By default, the freshness test will use the `timestamp_column` provided. If you need to test for freshness by another column (e.g. if your table is partitioned), add the key `freshness_column` to the test.
 
-<SnippetGroup>
+<CodeGroup>
 
 ```yml Models
 version: 2
@@ -67,7 +67,8 @@ models:
       - elementary.table_anomalies
           tags: ['elementary']
 ```
-</SnippetGroup>
+
+</CodeGroup>
 
 </Accordion>
 
@@ -76,10 +77,10 @@ models:
 `elementary.dimension_anomalies`
 
 This test monitors the frequency of values in the configured dimension over time, and alerts on unexpected changes in the distribution.
-It is best to configure it on low-cardinality fields. 
+It is best to configure it on low-cardinality fields.
 The test counts rows grouped by given columns/expressions, and can be configured using the `dimensions` and `where_expression` keys.
 
-<SnippetGroup>
+<CodeGroup>
 
 ```yml Models
 version: 2
@@ -103,7 +104,7 @@ models:
   - name: login_events
     config:
       elementary:
-        timestamp_column: 'loaded_at'
+        timestamp_column: "loaded_at"
     tests:
       - elementary.dimension_anomalies:
           dimensions:
@@ -111,9 +112,9 @@ models:
             - country_name
           where_expression: "event_type in ('event_1', 'event_2') and country_name != 'unwanted country'"
           # optional - use tags to run elementary tests on a dedicated run
-          tags: ['elementary']
+          tags: ["elementary"]
           config:
-          # optional - change severity
+            # optional - change severity
             severity: warn
 
   - name: users
@@ -122,9 +123,10 @@ models:
       - elementary.dimension_anomalies:
           dimensions:
             - event_type
-          tags: ['elementary']
+          tags: ["elementary"]
 ```
-</SnippetGroup>
+
+</CodeGroup>
 
 </Accordion>
 
@@ -134,7 +136,7 @@ models:
 
 Executes column level monitors and anomaly detection on all the columns of the table. Specific monitors are [detailed here](./data-anomaly-detection#tests-and-monitors-types) and can be configured using the `all_columns_anomalies` key.
 
-<SnippetGroup>
+<CodeGroup>
 
 ```yml Models
 version: 2
@@ -156,14 +158,15 @@ models:
   - name: login_events
     config:
       elementary:
-        timestamp_column: 'loaded_at'
+        timestamp_column: "loaded_at"
     tests:
       - elementary.all_columns_anomalies:
-          tags: ['elementary']
+          tags: ["elementary"]
           # optional - change global sensitivity
           sensitivity: 3.5
 ```
-</SnippetGroup>
+
+</CodeGroup>
 
 </Accordion>
 
@@ -173,7 +176,7 @@ models:
 
 Executes schema changes monitor that alerts on deleted table, deleted or added columns, or change of data type of a column.
 
-<SnippetGroup>
+<CodeGroup>
 
 ```yml Models
 version: 2
@@ -194,17 +197,17 @@ models:
   - name: login_events
     config:
       elementary:
-        timestamp_column: 'loaded_at'
+        timestamp_column: "loaded_at"
     tests:
       - elementary.schema_changes:
-          tags: ['elementary']
+          tags: ["elementary"]
           config:
             severity: warn
 ```
-</SnippetGroup>
+
+</CodeGroup>
 
 </Accordion>
-
 
 ### Column test:
 
@@ -214,7 +217,7 @@ models:
 
 Executes column level monitors and anomaly detection. Specific monitors are [detailed here](./data-anomaly-detection#tests-and-monitors-types) and can be configured using the `column_anomalies` key.
 
-<SnippetGroup>
+<CodeGroup>
 
 ```yml Models
 version: 2
@@ -275,10 +278,10 @@ models:
                 - min_length
               tags: ['elementary']
 ```
-</SnippetGroup>
+
+</CodeGroup>
 
 </Accordion>
-
 
 ## How to configure your Elementary tests?
 
@@ -295,7 +298,7 @@ More on data tests configuration [here](./elementary-tests-configuration).
 We recommend adding a tag to the tests so you could execute these in a dedicated run using the selection parameter `--select tag:elementary`.
 If you wish to only be warned on anomalies, configure the severity of the tests to warn.
 
-<SnippetGroup>
+<CodeGroup>
 
 ```yml Models
 version: 2
@@ -426,7 +429,7 @@ sources:
               - elementary.column_anomalies
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 ## What happens on each test?
 

--- a/docs/guides/elementary-tests-configuration.mdx
+++ b/docs/guides/elementary-tests-configuration.mdx
@@ -95,7 +95,7 @@ If undefined, default is null (no time buckets).
 
 **Example configuration:**
 
-<SnippetGroup>
+<CodeGroup>
 
 ```yml properties.yml
 version: 2
@@ -171,7 +171,7 @@ sources:
               - elementary.column_anomalies
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 </Accordion>
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,8 +1,11 @@
-<Example>
+<Frame>
   <div class="dark:bg-slate-200 rounded-md p-4">
-    <img src="https://res.cloudinary.com/mintlify/image/upload/v1659304877/elementary/Logo_V2_chbdpu.png" alt="Elementary Logo" />
+    <img
+      src="https://res.cloudinary.com/mintlify/image/upload/v1659304877/elementary/Logo_V2_chbdpu.png"
+      alt="Elementary Logo"
+    />
   </div>
-</Example>
+</Frame>
 
 ## What is Elementary?
 
@@ -13,28 +16,30 @@ visibility, detect data issues, send actionable alerts, and understand the impac
 
 ## Key features
 
-- **Data observability report ([live demo](https://storage.googleapis.com/elementary_static/elementary_demo.html))** 
- 
+- **Data observability report ([live demo](https://storage.googleapis.com/elementary_static/elementary_demo.html))**
+
   Triage anomalies and dbt tests in a UI that visualizes results and provides all the information you need in a single place.
 
-- **Data anomaly detection as dbt tests** 
+- **Data anomaly detection as dbt tests**
 
   Monitoring of data quality metrics, freshness, volume and schema changes, including anomaly detection. Elementary data monitors are configured and executed like native tests in dbt your project!
 
-- **dbt artifacts and run results** 
- 
+- **dbt artifacts and run results**
+
   Uploading and modeling of dbt artifacts, run and test results to tables as part of your runs.
 
-- **Slack alerts** 
+- **Slack alerts**
 
   Get informative notifications on data issues, schema changes, models and tests failures.
 
-- **Data lineage** 
+- **Data lineage**
 
   Inspect upstream and downstream dependencies to understand impact and root cause of data issues.
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304880/elementary/Demo-2-screens_k98bdr.gif" alt="Demo" />
-
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304880/elementary/Demo-2-screens_k98bdr.gif"
+  alt="Demo"
+/>
 
 ## How it works?
 
@@ -43,8 +48,10 @@ The monitoring configuration is configured in your dbt project, and the monitors
 
 [Elementary CLI](./understand-elementary/cli-install#install-and-configure) is used to generate the UI report and send Slack alerts.
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304881/elementary/High-level-flow_d21jfj.png" alt="High Level Flow" />
-
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304881/elementary/High-level-flow_d21jfj.png"
+  alt="High Level Flow"
+/>
 
 ## Community & Support
 
@@ -71,6 +78,5 @@ Data warehouses:
 [x] BigQuery
 [x] Redshift
 [x] Databricks - Beta support
-
 
 Ask us for integrations on [Slack](https://join.slack.com/t/elementary-community/shared_invite/zt-uehfrq2f-zXeVTtXrjYRbdE_V6xq4Rg) or as a [Github](https://github.com/elementary-data/elementary) issue.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -16,7 +16,7 @@ Some packages we recommend you check out: [dbt_utils](https://github.com/dbt-lab
 
 ## How to install Elementary dbt package?
 
-<Example resizeable>
+<Frame>
   <div style="position: relative; padding-bottom: 64.98194945848375%; height: 0;">
     <iframe
       src="https://www.loom.com/embed/5cf1aaa0708f43a993f8a2945473c7ac"
@@ -27,7 +27,7 @@ Some packages we recommend you check out: [dbt_utils](https://github.com/dbt-lab
       style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
     ></iframe>
   </div>
-</Example>
+</Frame>
 
 ## Install dbt package
 
@@ -48,7 +48,8 @@ packages:
 <TipInfo>
 This means Elementary models will have their own schema.
 
-Make sure your user has permissions to create schemas. 
+Make sure your user has permissions to create schemas.
+
 </TipInfo>
 
 ```yml dbt_project.yml
@@ -73,12 +74,11 @@ dbt run --select elementary
 
 This will mostly create empty tables, that will be updated with artifacts, metrics and test results in your future dbt executions.
 
-
 <ChangeElementarySchema />
 
 <Accordion title="Important: Materialization config">
 
-For elementary to work, it needs to create some of the models as incremental tables. 
+For elementary to work, it needs to create some of the models as incremental tables.
 Make sure that there are no global materialization configurations that affect elementary, such as:
 
 ```yml dbt_project.yml
@@ -112,7 +112,6 @@ Running your tests will populate Elementary's models with the relevant informati
 You can also choose to run only some of your tests, but keep in mind that only tests that ran _after_ Elementary was installed will be monitored.
 
 After you ran your tests, we recommend that you ensure that the results were uploaded to the `elementary_test_results` table.
-
 
 ### What happens now?
 

--- a/docs/snippets/add-connection-profile.mdx
+++ b/docs/snippets/add-connection-profile.mdx
@@ -1,4 +1,4 @@
-import { Example } from "@/components/Example";
+import { Frame } from "@/components/Frame";
 import AllProfiles from "./profiles/all-profiles.mdx";
 
 ## Configure Elementary profile
@@ -15,7 +15,7 @@ dbt run-operation elementary.generate_elementary_cli_profile
 Copy the output, fill in the missing fields and add the profile to your `profiles.yml`.
 Here is a demonstration:
 
-<Example resizeable>
+<Frame>
   <div
     style={{
       position: "relative",
@@ -38,7 +38,7 @@ Here is a demonstration:
       }}
     ></iframe>
   </div>
-</Example>
+</Frame>
 
 ### Elementary profile details and format
 

--- a/docs/snippets/install-dbt-package.mdx
+++ b/docs/snippets/install-dbt-package.mdx
@@ -1,8 +1,8 @@
-import { Example } from '@/components/Example';
+import { Frame } from "@/components/Frame";
 
 ## How to install Elementary dbt package?
 
-<Example>
+<Frame>
   <iframe
     src="https://www.loom.com/embed/5cf1aaa0708f43a993f8a2945473c7ac"
     frameborder="0"
@@ -11,7 +11,7 @@ import { Example } from '@/components/Example';
     allowfullscreen
     class="w-full h-64"
   ></iframe>
-</Example>
+</Frame>
 
 ## Full installation guide
 

--- a/docs/snippets/profiles/all-profiles.mdx
+++ b/docs/snippets/profiles/all-profiles.mdx
@@ -70,12 +70,7 @@ elementary:
       keepalives_idle: 240 # default 240 seconds
       connect_timeout: 10 # default 10 seconds
       # search_path: public # optional, not recommended
-      sslmode:
-        [
-          optional,
-          set the sslmode used to connect to the database (in case this parameter is set,
-          will look for ca in ~/.postgresql/root.crt),
-        ]
+      sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
       ra3_node: true # enables cross-database sources
 ```
 

--- a/docs/snippets/profiles/all-profiles.mdx
+++ b/docs/snippets/profiles/all-profiles.mdx
@@ -1,6 +1,6 @@
-import { SnippetGroup } from "@/components/SnippetGroup";
+import { CodeGroup } from "@/components/CodeGroup";
 
-<SnippetGroup>
+<CodeGroup>
 
 ```yml Snowflake
 ## SNOWFLAKE ##
@@ -42,7 +42,7 @@ elementary:
       keyfile: [full path to your keyfile]
 
       project: [project id]
-      dataset: [dataset name]  # elementary dataset, usually [dataset name]_elementary
+      dataset: [dataset name] # elementary dataset, usually [dataset name]_elementary
       threads: 4
       location: [dataset location]
       priority: interactive
@@ -65,12 +65,17 @@ elementary:
       password: [password]
 
       dbname: [database name]
-      schema: [schema name]  # elementary schema, usually [schema name]_elementary
+      schema: [schema name] # elementary schema, usually [schema name]_elementary
       threads: 4
       keepalives_idle: 240 # default 240 seconds
       connect_timeout: 10 # default 10 seconds
       # search_path: public # optional, not recommended
-      sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
+      sslmode:
+        [
+          optional,
+          set the sslmode used to connect to the database (in case this parameter is set,
+          will look for ca in ~/.postgresql/root.crt),
+        ]
       ra3_node: true # enables cross-database sources
 ```
 
@@ -86,10 +91,9 @@ elementary:
       type: databricks
       host: [hostname, like <ID>.cloud.databricks.com]
       http_path: [like /sql/1.0/endpoints/<ID>]
-      schema: [schema name]  # elementary schema, usually [schema name]_elementary
-      token : [token]
+      schema: [schema name] # elementary schema, usually [schema name]_elementary
+      token: [token]
       threads: [number of threads like 8]
-
 ```
 
-</SnippetGroup>
+</CodeGroup>


### PR DESCRIPTION
Hi team, we undergone a refactor and realized that we had some backwards incompatibility issues that have been addressed by this PR. In the future, we'll be significantly more mindful when dealing with backwards compatibility.

## Summary
- Fix deployment issue caused by new component names
- Renamed `SnippetGroup` to `CodeGroup`
- Renamed `Example` to `Frame`

## Notes
- In the future, use `<CodeGroup>` instead of `SnippetGroup` (name change suggested by @Maayan-s). Import is now `import { CodeGroup } from '@/components/CodeGroup'`
- Use `<Frame>` instead of `<Example>`. Import is now `import { Frame } from '@/components/Frame'`

You will be able to refer to our [docs](https://meta.mintlify.com/introduction) as the source of truth on this matter