### PR TITLE
Remove component imports from snippets

### DIFF
--- a/docs/snippets/add-connection-profile.mdx
+++ b/docs/snippets/add-connection-profile.mdx
@@ -1,4 +1,3 @@
-import { Frame } from "@/components/Frame";
 import AllProfiles from "./profiles/all-profiles.mdx";
 
 ## Configure Elementary profile

--- a/docs/snippets/faq/question-change-elementary-schema.mdx
+++ b/docs/snippets/faq/question-change-elementary-schema.mdx
@@ -1,9 +1,7 @@
-import { Accordion } from "@/components/Accordion";
-
 <Accordion title="Can I change Elementary schema?">
 
 The short answer is yes.
-We recommend that Elementary models will have their own schema, but it is not mandatory. 
+We recommend that Elementary models will have their own schema, but it is not mandatory.
 You can change the schema name by using dbt [custom schema configuration](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/using-custom-schemas) on your `dbt_project.yml`.
 In short, the default dbt `generate_schema_name` macro concatenate the value provided in `schema` configuration key to the target schema, as in: `target_schema_custom_schema`.
 

--- a/docs/snippets/faq/question-cost.mdx
+++ b/docs/snippets/faq/question-cost.mdx
@@ -1,5 +1,3 @@
-import { Accordion } from "@/components/Accordion";
-
 <Accordion title="Is Elementary free? Does Elementary cost money?">
 
 No cost, it's free.
@@ -7,4 +5,3 @@ Everything that is open source is 100% free and will remain free!
 We are working on a SaaS offering ([sign up](https://www.elementary-data.com/cloud-beta) if you are interested), but are committed to building a great OSS product first.
 
 </Accordion>
-

--- a/docs/snippets/faq/question-dbt-cloud.mdx
+++ b/docs/snippets/faq/question-dbt-cloud.mdx
@@ -1,5 +1,3 @@
-import { Accordion } from "@/components/Accordion";
-
 <Accordion title="Can I use Elementary with dbt cloud?">
 
 Yes! All the functionality is available and supported for dbt cloud users as well.

--- a/docs/snippets/faq/question-schemas.mdx
+++ b/docs/snippets/faq/question-schemas.mdx
@@ -1,5 +1,3 @@
-import { Accordion } from "@/components/Accordion";
-
 <Accordion title="What schemas Elementary adds? What is '__tests' schema?">
 
 We recommend configuring a dedicated schema for the Elementary models.
@@ -9,8 +7,9 @@ As some users have hundreds of Elementary tests, we didn't want tons of small ta
 These results are later merged to the incremental tables in the main elementary schema.
 
 The schemas structure would be:
+
 - Your schemas
-- Elementary models schema - The schema name is configured under your `dbt_project.yml`.  
+- Elementary models schema - The schema name is configured under your `dbt_project.yml`.
 - Elementary temp test results schema - The Elementary schema name with `__test` suffix.
 
 </Accordion>

--- a/docs/snippets/faq/question-which-tests.mdx
+++ b/docs/snippets/faq/question-which-tests.mdx
@@ -1,5 +1,3 @@
-import { Accordion } from "@/components/Accordion";
-
 <Accordion title="Which tests can I see on Elementary report?">
 
 All your dbt tests - the built-in ones, Elementary test, and any other package tests (such as dbt_utils or dbt_expectations).

--- a/docs/snippets/install-dbt-package.mdx
+++ b/docs/snippets/install-dbt-package.mdx
@@ -1,5 +1,3 @@
-import { Frame } from "@/components/Frame";
-
 ## How to install Elementary dbt package?
 
 <Frame>

--- a/docs/snippets/profiles/all-profiles.mdx
+++ b/docs/snippets/profiles/all-profiles.mdx
@@ -1,5 +1,3 @@
-import { CodeGroup } from "@/components/CodeGroup";
-
 <CodeGroup>
 
 ```yml Snowflake
@@ -70,7 +68,7 @@ elementary:
       keepalives_idle: 240 # default 240 seconds
       connect_timeout: 10 # default 10 seconds
       # search_path: public # optional, not recommended
-      sslmode: [optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)]
+      sslmode: \[optional, set the sslmode used to connect to the database (in case this parameter is set, will look for ca in ~/.postgresql/root.crt)\]
       ra3_node: true # enables cross-database sources
 ```
 

--- a/docs/snippets/setup-slack-integration.mdx
+++ b/docs/snippets/setup-slack-integration.mdx
@@ -1,5 +1,3 @@
-import { Accordion } from "@/components/Accordion";
-
 First create a Slack app:
 
 <Accordion title="Create a Slack App">


### PR DESCRIPTION
# Summary
We recently launched a patched that made it so you don't need to import components in `snippets` like you with regular pages! This is a simple PR that removes the imports in the current `snippets` folder.

### Note
From now on, you no longer need to import components in `snippets`