### PR TITLE
support browser authentication method

### DIFF
--- a/elementary/clients/dbt/dbt_runner.py
+++ b/elementary/clients/dbt/dbt_runner.py
@@ -79,18 +79,22 @@ class DbtRunner:
         if log_errors and not success:
             logger.error(f'Failed to run macro: "{macro_name}"')
         run_operation_results = []
+        # breakpoint()
         if json_logs:
             json_messages = command_output.splitlines()
             for json_message in json_messages:
-                log_message_dict = json.loads(json_message)
-                log_message_data_dict = log_message_dict.get('data')
-                if log_message_data_dict is not None:
-                    if log_errors and log_message_dict['level'] == 'error':
-                        logger.error(log_message_data_dict)
-                        continue
-                    log_message = log_message_data_dict.get('msg')
-                    if log_message is not None and log_message.startswith(self.ELEMENTARY_LOG_PREFIX):
-                        run_operation_results.append(log_message.replace(self.ELEMENTARY_LOG_PREFIX, ''))
+                try:
+                    log_message_dict = json.loads(json_message)
+                    log_message_data_dict = log_message_dict.get('data')
+                    if log_message_data_dict is not None:
+                        if log_errors and log_message_dict['level'] == 'error':
+                            logger.error(log_message_data_dict)
+                            continue
+                        log_message = log_message_data_dict.get('msg')
+                        if log_message is not None and log_message.startswith(self.ELEMENTARY_LOG_PREFIX):
+                            run_operation_results.append(log_message.replace(self.ELEMENTARY_LOG_PREFIX, ''))
+                except Exception:
+                    logger.debug(f'Unable to parse run-operation log message: {json_message}', exc_info=True)
         return run_operation_results
 
     def run(

--- a/elementary/clients/dbt/dbt_runner.py
+++ b/elementary/clients/dbt/dbt_runner.py
@@ -1,4 +1,5 @@
 import json
+from json import JSONDecodeError
 import subprocess
 from typing import List, Optional, Tuple
 
@@ -92,7 +93,7 @@ class DbtRunner:
                         log_message = log_message_data_dict.get('msg')
                         if log_message is not None and log_message.startswith(self.ELEMENTARY_LOG_PREFIX):
                             run_operation_results.append(log_message.replace(self.ELEMENTARY_LOG_PREFIX, ''))
-                except Exception:
+                except JSONDecodeError:
                     logger.debug(f'Unable to parse run-operation log message: {json_message}', exc_info=True)
         return run_operation_results
 

--- a/elementary/clients/dbt/dbt_runner.py
+++ b/elementary/clients/dbt/dbt_runner.py
@@ -79,7 +79,6 @@ class DbtRunner:
         if log_errors and not success:
             logger.error(f'Failed to run macro: "{macro_name}"')
         run_operation_results = []
-        # breakpoint()
         if json_logs:
             json_messages = command_output.splitlines()
             for json_message in json_messages:


### PR DESCRIPTION
Our dbt_runner expect the log messages of dbt run-operation to be in json format.
However, browser authentication scenario returns log messages as string.
So instead of failing on json parsing, I log the failure and the unsupported log message to our edr file.
This is OK because run-operation log message should be in json format as expected, so if anything is returning as string it is currently OK to ignore it.
And if something will break in the future, we will have the edr log to understand what happened and what we should change. 