### PR TITLE
Issue #301 : add support for `timezone` param in slack alerts

### DIFF
--- a/docs/snippets/setup-slack-integration.mdx
+++ b/docs/snippets/setup-slack-integration.mdx
@@ -121,6 +121,7 @@ Here is the format in the yml itself:
 slack:
   token: <your_slack_token>
   channel_name: <slack_channel_to_post_at>
+  timezone: <timezone_for_timestamps>
 ```
 
 ## Webhook:
@@ -130,6 +131,7 @@ slack:
   notification_webhook: <your_slack_webhook_url>
   # optional #
   workflows: false
+  timezone: <timezone_for_timestamps>
 ```
 
 </Accordion>

--- a/docs/snippets/setup-slack-integration.mdx
+++ b/docs/snippets/setup-slack-integration.mdx
@@ -121,7 +121,8 @@ Here is the format in the yml itself:
 slack:
   token: <your_slack_token>
   channel_name: <slack_channel_to_post_at>
-  timezone: <timezone_for_timestamps>
+
+timezone: <optional_timezone_for_timestamps>
 ```
 
 ## Webhook:
@@ -132,7 +133,7 @@ slack:
   # optional #
   workflows: false
 
-timezone: <timezone_for_timestamps>
+timezone: <optional_timezone_for_timestamps>
 ```
 
 </Accordion>

--- a/docs/snippets/setup-slack-integration.mdx
+++ b/docs/snippets/setup-slack-integration.mdx
@@ -131,7 +131,8 @@ slack:
   notification_webhook: <your_slack_webhook_url>
   # optional #
   workflows: false
-  timezone: <timezone_for_timestamps>
+
+timezone: <timezone_for_timestamps>
 ```
 
 </Accordion>

--- a/docs/snippets/setup-slack-integration.mdx
+++ b/docs/snippets/setup-slack-integration.mdx
@@ -122,6 +122,7 @@ slack:
   token: <your_slack_token>
   channel_name: <slack_channel_to_post_at>
 
+# optional #
 timezone: <optional_timezone_for_timestamps>
 ```
 
@@ -133,6 +134,7 @@ slack:
   # optional #
   workflows: false
 
+# optional #
 timezone: <optional_timezone_for_timestamps>
 ```
 

--- a/elementary/config/config.py
+++ b/elementary/config/config.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from dateutil.zoneinfo import getzoneinfofile_stream, ZoneInfoFile
+from dateutil import tz
 
 from elementary.exceptions.exceptions import NoElementaryProfileError, NoProfilesFileError, InvalidArgumentsError
 from elementary.utils.ordered_yaml import OrderedYaml
@@ -95,6 +95,5 @@ class Config:
             raise NoProfilesFileError(self.profiles_dir)
 
     def validate_timezone(self):
-      if self.slack_timezone is not None:
-        if self.slack_timezone not in ZoneInfoFile(getzoneinfofile_stream()).zones.keys():
-            print('Please provide a valid timezone. list of available timezoned can be found here: <http://.......> ')
+      if not tz.gettz(self.slack_timezone):
+         raise InvalidArgumentsError('Please provide a valid timezone. list of available timezoned can be found here: <http://.......> ')

--- a/elementary/config/config.py
+++ b/elementary/config/config.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from dateutil.zoneinfo import getzoneinfofile_stream, ZoneInfoFile
 
 from elementary.exceptions.exceptions import NoElementaryProfileError, NoProfilesFileError, InvalidArgumentsError
 from elementary.utils.ordered_yaml import OrderedYaml
@@ -16,7 +17,7 @@ class Config:
 
     def __init__(self, config_dir: str = DEFAULT_CONFIG_DIR, profiles_dir: str = DEFAULT_PROFILES_DIR,
                  profile_target: str = None, update_bucket_website: bool = None, slack_webhook: str = None,
-                 slack_token: str = None, slack_channel_name: str = None, aws_profile_name: str = None,
+                 slack_token: str = None, slack_channel_name: str = None, slack_timezone: str = None, aws_profile_name: str = None,
                  aws_access_key_id: str = None, aws_secret_access_key: str = None, s3_bucket_name: str = None,
                  google_service_account_path: str = None, gcs_bucket_name: str = None):
         self.config_dir = config_dir
@@ -31,6 +32,7 @@ class Config:
         self.slack_webhook = slack_webhook or config.get(self._SLACK, {}).get('notification_webhook')
         self.slack_token = slack_token or config.get(self._SLACK, {}).get('token')
         self.slack_channel_name = slack_channel_name or config.get(self._SLACK, {}).get('channel_name')
+        self.slack_timezone = slack_timezone or config.get(self._SLACK, {}.get('timezone'))
         self.is_slack_workflow = config.get(self._SLACK, {}).get('workflows', False)
 
         self.aws_profile_name = aws_profile_name or config.get(self._AWS, {}).get('profile_name')
@@ -91,3 +93,8 @@ class Config:
                 raise NoElementaryProfileError
         except FileNotFoundError:
             raise NoProfilesFileError(self.profiles_dir)
+
+    def validate_timezone(self):
+      if self.slack_timezone is not None:
+        if self.slack_timezone not in ZoneInfoFile(getzoneinfofile_stream()).zones.keys():
+            print('Please provide a valid timezone. list of available timezoned can be found here: <http://.......> ')

--- a/elementary/config/config.py
+++ b/elementary/config/config.py
@@ -28,7 +28,7 @@ class Config:
         self.target_dir = config.get('target-path') or os.getcwd()
 
         self.update_bucket_website = update_bucket_website or config.get('update_bucket_website', False)
-        self.timezone = timezone or config.get('timezone', False)
+        self.timezone = timezone or config.get('timezone')
 
         self.slack_webhook = slack_webhook or config.get(self._SLACK, {}).get('notification_webhook')
         self.slack_token = slack_token or config.get(self._SLACK, {}).get('token')

--- a/elementary/config/config.py
+++ b/elementary/config/config.py
@@ -74,7 +74,7 @@ class Config:
 
     def validate_monitor(self):
         self._validate_elementary_profile()
-        self.validate_timezone()
+        self._validate_timezone()
         if not self.has_slack:
             raise InvalidArgumentsError('Either a Slack token and a channel or a Slack webhook is required.')
 
@@ -95,6 +95,6 @@ class Config:
         except FileNotFoundError:
             raise NoProfilesFileError(self.profiles_dir)
 
-    def validate_timezone(self):
+    def _validate_timezone(self):
       if self.timezone and not tz.gettz(self.timezone):
          raise InvalidArgumentsError('An invalid timezone was provided.')

--- a/elementary/config/config.py
+++ b/elementary/config/config.py
@@ -96,4 +96,4 @@ class Config:
 
     def validate_timezone(self):
       if self.timezone and not tz.gettz(self.timezone):
-         raise InvalidArgumentsError('An invalid timezone was provided to Slack alerts.')
+         raise InvalidArgumentsError('An invalid timezone was provided.')

--- a/elementary/config/config.py
+++ b/elementary/config/config.py
@@ -17,7 +17,7 @@ class Config:
 
     def __init__(self, config_dir: str = DEFAULT_CONFIG_DIR, profiles_dir: str = DEFAULT_PROFILES_DIR,
                  profile_target: str = None, update_bucket_website: bool = None, slack_webhook: str = None,
-                 slack_token: str = None, slack_channel_name: str = None, slack_timezone: str = None, aws_profile_name: str = None,
+                 slack_token: str = None, slack_channel_name: str = None, timezone: str = None, aws_profile_name: str = None,
                  aws_access_key_id: str = None, aws_secret_access_key: str = None, s3_bucket_name: str = None,
                  google_service_account_path: str = None, gcs_bucket_name: str = None):
         self.config_dir = config_dir
@@ -28,11 +28,11 @@ class Config:
         self.target_dir = config.get('target-path') or os.getcwd()
 
         self.update_bucket_website = update_bucket_website or config.get('update_bucket_website', False)
+        self.timezone = timezone or config.get('timezone', False)
 
         self.slack_webhook = slack_webhook or config.get(self._SLACK, {}).get('notification_webhook')
         self.slack_token = slack_token or config.get(self._SLACK, {}).get('token')
         self.slack_channel_name = slack_channel_name or config.get(self._SLACK, {}).get('channel_name')
-        self.slack_timezone = slack_timezone or config.get(self._SLACK, {}.get('timezone'))
         self.is_slack_workflow = config.get(self._SLACK, {}).get('workflows', False)
 
         self.aws_profile_name = aws_profile_name or config.get(self._AWS, {}).get('profile_name')
@@ -95,5 +95,5 @@ class Config:
             raise NoProfilesFileError(self.profiles_dir)
 
     def validate_timezone(self):
-      if self.slack_timezone and not tz.gettz(self.slack_timezone):
+      if self.timezone and not tz.gettz(self.timezone):
          raise InvalidArgumentsError('An invalid timezone was provided to Slack alerts.')

--- a/elementary/config/config.py
+++ b/elementary/config/config.py
@@ -74,6 +74,7 @@ class Config:
 
     def validate_monitor(self):
         self._validate_elementary_profile()
+        self.validate_timezone()
         if not self.has_slack:
             raise InvalidArgumentsError('Either a Slack token and a channel or a Slack webhook is required.')
 

--- a/elementary/monitor/alerts/alert.py
+++ b/elementary/monitor/alerts/alert.py
@@ -35,7 +35,7 @@ class Alert:
         try:
             detected_at_utc = datetime.fromisoformat(detected_at)
             self.detected_at_utc = detected_at_utc.strftime('%Y-%m-%d %H:%M:%S')
-            self.detected_at = convert_utc_time_to_timezone(utc_time=detected_at_utc, timezone=timezone).strftime('%Y-%m-%d %H:%M:%S')
+            self.detected_at = convert_utc_time_to_timezone(utc_time=detected_at_utc, timezone=self.timezone).strftime('%Y-%m-%d %H:%M:%S')
         except Exception:
             logger.error(f'Failed to parse "detect_at" field.')
         self.database_name = database_name

--- a/elementary/monitor/alerts/alert.py
+++ b/elementary/monitor/alerts/alert.py
@@ -6,7 +6,7 @@ from slack_sdk.models.blocks import SectionBlock
 from elementary.clients.slack.schema import SlackMessageSchema
 from elementary.utils.json_utils import prettify_json_str_set
 from elementary.utils.log import get_logger
-from elementary.utils.time import convert_utc_time_to_local_time
+from elementary.utils.time import convert_utc_time_to_timezone
 
 logger = get_logger(__name__)
 
@@ -24,18 +24,18 @@ class Alert:
             status: str = None,
             subscribers: Optional[List[str]] = None,
             slack_channel: Optional[str] = None,
-            slack_timezone: Optional[str] = None,
+            timezone: Optional[str] = None,
             **kwargs
     ):
         self.id = id
         self.elementary_database_and_schema = elementary_database_and_schema
         self.detected_at_utc = None
         self.detected_at = None
-        self.slack_timezone = slack_timezone
+        self.timezone = timezone
         try:
             detected_at_utc = datetime.fromisoformat(detected_at)
             self.detected_at_utc = detected_at_utc.strftime('%Y-%m-%d %H:%M:%S')
-            self.detected_at = convert_utc_time_to_local_time(slack_timezone, detected_at_utc).strftime('%Y-%m-%d %H:%M:%S')
+            self.detected_at = convert_utc_time_to_timezone(utc_time=detected_at_utc, timezone=timezone).strftime('%Y-%m-%d %H:%M:%S')
         except Exception:
             logger.error(f'Failed to parse "detect_at" field.')
         self.database_name = database_name

--- a/elementary/monitor/alerts/alert.py
+++ b/elementary/monitor/alerts/alert.py
@@ -24,16 +24,18 @@ class Alert:
             status: str = None,
             subscribers: Optional[List[str]] = None,
             slack_channel: Optional[str] = None,
+            slack_timezone: Optional[str] = None,
             **kwargs
     ):
         self.id = id
         self.elementary_database_and_schema = elementary_database_and_schema
         self.detected_at_utc = None
         self.detected_at = None
+        self.slack_timezone = slack_timezone
         try:
             detected_at_utc = datetime.fromisoformat(detected_at)
             self.detected_at_utc = detected_at_utc.strftime('%Y-%m-%d %H:%M:%S')
-            self.detected_at = convert_utc_time_to_local_time(detected_at_utc).strftime('%Y-%m-%d %H:%M:%S')
+            self.detected_at = convert_utc_time_to_local_time(slack_timezone, detected_at_utc).strftime('%Y-%m-%d %H:%M:%S')
         except Exception:
             logger.error(f'Failed to parse "detect_at" field.')
         self.database_name = database_name

--- a/elementary/monitor/api/alerts.py
+++ b/elementary/monitor/api/alerts.py
@@ -1,7 +1,7 @@
 import copy
 import json
 from typing import Callable, List, Optional
-
+from elementary.config.config import Config
 from elementary.clients.api.api import APIClient
 from elementary.clients.dbt.dbt_runner import DbtRunner
 from elementary.monitor.alerts.alerts import AlertsQueryResult, Alerts
@@ -15,10 +15,10 @@ logger = get_logger(__name__)
 
 
 class AlertsAPI(APIClient):
-    def __init__(self, dbt_runner: DbtRunner, elementary_database_and_schema: str, config):
+    def __init__(self, dbt_runner: DbtRunner, config: Config, elementary_database_and_schema: str):
         super().__init__(dbt_runner)
-        self.elementary_database_and_schema = elementary_database_and_schema
         self.config = config
+        self.elementary_database_and_schema = elementary_database_and_schema
 
     def query(self, days_back: int) -> Alerts:
         return Alerts(

--- a/elementary/monitor/cli.py
+++ b/elementary/monitor/cli.py
@@ -121,7 +121,7 @@ def monitor(
         slack_webhook,
         slack_token,
         slack_channel_name,
-		  timezone,
+		timezone,
         config_dir,
         profiles_dir,
         update_dbt_package,

--- a/elementary/monitor/cli.py
+++ b/elementary/monitor/cli.py
@@ -115,6 +115,7 @@ def monitor(
         slack_webhook,
         slack_token,
         slack_channel_name,
+		  slack_timezone,
         config_dir,
         profiles_dir,
         update_dbt_package,
@@ -133,7 +134,7 @@ def monitor(
         return
     vars = yaml.loads(dbt_vars) if dbt_vars else None
     config = Config(config_dir, profiles_dir, profile_target, slack_webhook=slack_webhook, slack_token=slack_token,
-                    slack_channel_name=slack_channel_name)
+                    slack_channel_name=slack_channel_name, slack_timezone=slack_timezone)
     anonymous_tracking = AnonymousTracking(config)
     anonymous_tracking.track_cli_start('monitor', get_cli_properties(), ctx.command.name)
     try:
@@ -204,6 +205,12 @@ def report(ctx, days_back, config_dir, profiles_dir, update_dbt_package, profile
     type=str,
     default=None,
     help="The slack channel which all alerts will be sent to.",
+)
+@click.option(
+    '--slack-timezone', '-tz',
+    type=str,
+    default=None,
+    help="The timezone of which all timestamps will be converted to. (default is user local timezone)",
 )
 @click.option(
     '--slack-file-name',
@@ -280,6 +287,7 @@ def send_report(
         update_dbt_package,
         slack_token,
         slack_channel_name,
+		  slack_timezone,
         slack_file_name,
         profile_target,
         executions_limit,
@@ -300,7 +308,7 @@ def send_report(
     """
 
     config = Config(config_dir, profiles_dir, profile_target, slack_token=slack_token,
-                    slack_channel_name=slack_channel_name, update_bucket_website=update_bucket_website,
+                    slack_channel_name=slack_channel_name, slack_timezone=slack_timezone, update_bucket_website=update_bucket_website,
                     aws_profile_name=aws_profile_name, aws_access_key_id=aws_access_key_id,
                     aws_secret_access_key=aws_secret_access_key, s3_bucket_name=s3_bucket_name,
                     google_service_account_path=google_service_account_path, gcs_bucket_name=gcs_bucket_name)

--- a/elementary/monitor/cli.py
+++ b/elementary/monitor/cli.py
@@ -90,6 +90,12 @@ def get_cli_properties() -> dict:
     help="The slack channel which all alerts will be sent to.",
 )
 @click.option(
+    '--timezone', '-tz',
+    type=str,
+    default=None,
+    help="The timezone of which all timestamps will be converted to. (default is user local timezone)",
+)
+@click.option(
     '--full-refresh-dbt-package', '-f',
     type=bool,
     default=False,
@@ -115,7 +121,7 @@ def monitor(
         slack_webhook,
         slack_token,
         slack_channel_name,
-		  slack_timezone,
+		  timezone,
         config_dir,
         profiles_dir,
         update_dbt_package,
@@ -134,7 +140,7 @@ def monitor(
         return
     vars = yaml.loads(dbt_vars) if dbt_vars else None
     config = Config(config_dir, profiles_dir, profile_target, slack_webhook=slack_webhook, slack_token=slack_token,
-                    slack_channel_name=slack_channel_name, slack_timezone=slack_timezone)
+                    slack_channel_name=slack_channel_name, timezone=timezone)
     anonymous_tracking = AnonymousTracking(config)
     anonymous_tracking.track_cli_start('monitor', get_cli_properties(), ctx.command.name)
     try:
@@ -205,12 +211,6 @@ def report(ctx, days_back, config_dir, profiles_dir, update_dbt_package, profile
     type=str,
     default=None,
     help="The slack channel which all alerts will be sent to.",
-)
-@click.option(
-    '--slack-timezone', '-tz',
-    type=str,
-    default=None,
-    help="The timezone of which all timestamps will be converted to. (default is user local timezone)",
 )
 @click.option(
     '--slack-file-name',
@@ -287,7 +287,6 @@ def send_report(
         update_dbt_package,
         slack_token,
         slack_channel_name,
-		  slack_timezone,
         slack_file_name,
         profile_target,
         executions_limit,
@@ -308,7 +307,7 @@ def send_report(
     """
 
     config = Config(config_dir, profiles_dir, profile_target, slack_token=slack_token,
-                    slack_channel_name=slack_channel_name, slack_timezone=slack_timezone, update_bucket_website=update_bucket_website,
+                    slack_channel_name=slack_channel_name, update_bucket_website=update_bucket_website,
                     aws_profile_name=aws_profile_name, aws_access_key_id=aws_access_key_id,
                     aws_secret_access_key=aws_secret_access_key, s3_bucket_name=s3_bucket_name,
                     google_service_account_path=google_service_account_path, gcs_bucket_name=gcs_bucket_name)

--- a/elementary/monitor/data_monitoring.py
+++ b/elementary/monitor/data_monitoring.py
@@ -50,7 +50,7 @@ class DataMonitoring:
         self.gcs_client = GCSClient.create_client(self.config)
         self._download_dbt_package_if_needed(force_update_dbt_package)
         self.elementary_database_and_schema = self.get_elementary_database_and_schema()
-        self.alerts_api = AlertsAPI(self.dbt_runner, self.elementary_database_and_schema, self.config)
+        self.alerts_api = AlertsAPI(self.dbt_runner, self.config, self.elementary_database_and_schema)
         self.sent_alert_count = 0
         self.success = True
         self.send_test_message_on_success = send_test_message_on_success

--- a/elementary/monitor/data_monitoring.py
+++ b/elementary/monitor/data_monitoring.py
@@ -109,7 +109,7 @@ class DataMonitoring:
             self.execution_properties['success'] = self.success
             return self.success
 
-        alerts = self.alerts_api.query(days_back)
+        alerts = self.alerts_api.query(days_back, timezone=self.config.timezone)
         self.execution_properties['elementary_test_count'] = alerts.get_elementary_test_count()
         self.execution_properties['alert_count'] = alerts.count
         malformed_alert_count = alerts.malformed_count

--- a/elementary/monitor/data_monitoring.py
+++ b/elementary/monitor/data_monitoring.py
@@ -50,7 +50,7 @@ class DataMonitoring:
         self.gcs_client = GCSClient.create_client(self.config)
         self._download_dbt_package_if_needed(force_update_dbt_package)
         self.elementary_database_and_schema = self.get_elementary_database_and_schema()
-        self.alerts_api = AlertsAPI(self.dbt_runner, self.elementary_database_and_schema)
+        self.alerts_api = AlertsAPI(self.dbt_runner, self.elementary_database_and_schema, self.config)
         self.sent_alert_count = 0
         self.success = True
         self.send_test_message_on_success = send_test_message_on_success
@@ -109,7 +109,7 @@ class DataMonitoring:
             self.execution_properties['success'] = self.success
             return self.success
 
-        alerts = self.alerts_api.query(days_back, timezone=self.config.timezone)
+        alerts = self.alerts_api.query(days_back)
         self.execution_properties['elementary_test_count'] = alerts.get_elementary_test_count()
         self.execution_properties['alert_count'] = alerts.count
         malformed_alert_count = alerts.malformed_count

--- a/elementary/utils/time.py
+++ b/elementary/utils/time.py
@@ -6,9 +6,12 @@ MILLISECONDS_IN_MIN = (1000 * 60)
 MILLISECONDS_IN_HOUR = (1000 * 60 * 60)
 
 
-def convert_utc_time_to_local_time(utc_time: 'datetime') -> 'datetime':
+def convert_utc_time_to_local_time(user_tz: str , utc_time: 'datetime') -> 'datetime':    
     from_zone = tz.tzutc()
-    to_zone = tz.tzlocal()
+    if(user_tz is not None):
+        to_zone = tz.gettz(user_tz)
+    else:
+        to_zone = tz.tzlocal()
     utc_time = utc_time.replace(tzinfo=from_zone)
     return utc_time.astimezone(to_zone)
 

--- a/elementary/utils/time.py
+++ b/elementary/utils/time.py
@@ -1,14 +1,15 @@
 from datetime import datetime
 from dateutil import tz
+from typing import Optional
 
 MILLISECONDS_IN_SEC = 1000
 MILLISECONDS_IN_MIN = (1000 * 60)
 MILLISECONDS_IN_HOUR = (1000 * 60 * 60)
 
 
-def convert_utc_time_to_local_time(user_tz: str , utc_time: 'datetime') -> 'datetime':    
+def convert_utc_time_to_timezone(utc_time: 'datetime', timezone: Optional[str] = None) -> 'datetime':    
     from_zone = tz.tzutc()
-    to_zone = tz.gettz(user_tz) if user_tz else tz.tzlocal()
+    to_zone = tz.gettz(timezone) if timezone else tz.tzlocal()
     utc_time = utc_time.replace(tzinfo=from_zone)
     return utc_time.astimezone(to_zone)
 

--- a/elementary/utils/time.py
+++ b/elementary/utils/time.py
@@ -8,10 +8,7 @@ MILLISECONDS_IN_HOUR = (1000 * 60 * 60)
 
 def convert_utc_time_to_local_time(user_tz: str , utc_time: 'datetime') -> 'datetime':    
     from_zone = tz.tzutc()
-    if(user_tz is not None):
-        to_zone = tz.gettz(user_tz)
-    else:
-        to_zone = tz.tzlocal()
+    to_zone = tz.gettz(user_tz) if user_tz else tz.tzlocal()
     utc_time = utc_time.replace(tzinfo=from_zone)
     return utc_time.astimezone(to_zone)
 


### PR DESCRIPTION
Providing support to set a `timezone` parameter in the `config.yml` for Slack alerts.

This why users are able to configure the timezone they want the timestamp will be converted to.
by default and for backwards competability in case the parameter was not set, we will still convert to the user local time.