### PR TITLE
Fix bug with the Loom video in quickstart not displaying

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -17,7 +17,7 @@ Some packages we recommend you check out: [dbt_utils](https://github.com/dbt-lab
 ## How to install Elementary dbt package?
 
 <Frame>
-  <div style="position: relative; padding-bottom: 64.98194945848375%; height: 0;">
+  <div style="padding-bottom: 64.98194945848375%;">
     <iframe
       src="https://www.loom.com/embed/5cf1aaa0708f43a993f8a2945473c7ac"
       frameborder="0"


### PR DESCRIPTION
Should work as expected again

<img width="1552" alt="Screen Shot 2022-09-12 at 12 34 02 PM" src="https://user-images.githubusercontent.com/44352119/189740193-b779d034-3bc5-432b-a98b-884fb484d956.png">
