### PR TITLE
[Priority] Upgrading docs to MDX2

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -17,14 +17,20 @@ Some packages we recommend you check out: [dbt_utils](https://github.com/dbt-lab
 ## How to install Elementary dbt package?
 
 <Frame>
-  <div style="padding-bottom: 64.98194945848375%;">
+  <div style={{ paddingBottom: "64.98194945848375%" }}>
     <iframe
       src="https://www.loom.com/embed/5cf1aaa0708f43a993f8a2945473c7ac"
       frameborder="0"
       webkitallowfullscreen
       mozallowfullscreen
       allowfullscreen
-      style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+      }}
     ></iframe>
   </div>
 </Frame>
@@ -41,7 +47,7 @@ Make sure to copy the packages that are relevant to your dbt version.
 
 </TipInfo>
 
-**For dbt 1.2.0 and above:** 
+**For dbt 1.2.0 and above:**
 
 ```yml packages.yml
 packages:
@@ -51,7 +57,7 @@ packages:
     ## see docs: https://docs.elementary-data.com/
 ```
 
-**For dbt >=1.0.0 <1.2.0:**
+**For dbt >=1.0.0 \<1.2.0:**
 
 ```yml packages.yml
 packages:
@@ -60,12 +66,11 @@ packages:
     ## compatible with Elementary CLI version 0.4.11
     ## see docs: https://docs.elementary-data.com/
 
-   ## !! Important !! For dbt <1.2.0 ##
-   ## (Prevents dbt_utils versions exceptions) ##
+    ## !! Important !! For dbt <1.2.0 ##
+    ## (Prevents dbt_utils versions exceptions) ##
   - package: dbt-labs/dbt_utils
     version: [">=0.8.0", "<0.9.0"]
 ```
-
 
 ### 2. Add to your `dbt_project.yml`
 
@@ -98,7 +103,6 @@ dbt run --select elementary
 
 This will mostly create empty tables, that will be updated with artifacts, metrics and test results in your future dbt executions.
 
-
 ### 5. Run tests
 
 ```shell Terminal
@@ -109,7 +113,6 @@ You can also run only some tests.
 Only tests you run after the installation will show up in the UI.
 
 After you ran your tests, we recommend that you ensure that the results were loaded to `elementary_test_results` table.
-
 
 <ChangeElementarySchema />
 
@@ -138,7 +141,6 @@ models:
 **If you change materialization settings, make sure to run `dbt run -s elementary --full-refresh`.**
 
 </Accordion>
-
 
 ### What happens now?
 


### PR DESCRIPTION
Mintlify recently released the long awaited support for [MDX2](https://mdxjs.com/blog/v2/).
This PR updates a couple small breaking changes required to support the new setup.

With MDX2, you’ll be able to experience the following improvements
📝 **Improved syntax** makes it easier to use markdown in JSX. No more newlines between components in order to support markdowns
```js
<Note>
markdown. Here’s a [link](https://example.com/)
</Note>
```
Now, you can do it neatly inline without worrying that markdown won’t be properly rendered
```js
<Note>Here’s a [link](https://example.com/)</Note>
```
🧑‍💻 JavaScript expressions turn {2 * Math.PI} into 6.283185307179586. This will also allow allow for authenticated-only content as we support that in upcoming releases.
🏃‍♀️ Compiles at least **25% faster**
🚴 Generated code runs twice as fast (**100% faster**)
And many other improvements…
### Get Started
In order to support MDX2, all you have to do is merge this PR!