### PR TITLE
Fix Loom video not showing

### DIFF
--- a/docs/snippets/add-connection-profile.mdx
+++ b/docs/snippets/add-connection-profile.mdx
@@ -15,13 +15,7 @@ Copy the output, fill in the missing fields and add the profile to your `profile
 Here is a demonstration:
 
 <Frame>
-  <div
-    style={{
-      position: "relative",
-      paddingBottom: "64.98194945848375%",
-      height: 0,
-    }}
-  >
+  <div style={{ paddingBottom: "64.98194945848375%" }}>
     <iframe
       src="https://www.loom.com/embed/6eacaed618a746658a3c8e920d1d46b2"
       frameborder="0"


### PR DESCRIPTION
## Summary
This is the same bug we had with the other Loom video except in a different location. I scanned the code and I think this is the only instance of it. I don't think this will be a problem anymore!
![image](https://user-images.githubusercontent.com/55263191/191605973-2e8fadea-9536-4488-9be2-3c9e59f52033.png)
