### PR TITLE
Bugfix: Renamed 'type' field on schema to 'artifact_type'.

### DIFF
--- a/elementary/monitor/api/models/models.py
+++ b/elementary/monitor/api/models/models.py
@@ -89,7 +89,7 @@ class ModelsAPI(APIClient):
         models = dict()
         if models_results:
             for model_result in json.loads(models_results[0]):
-                model_data = ModelSchema(**model_result, artifact_type='model')
+                model_data = ModelSchema(**model_result)
                 normalized_model = ModelsAPI._normalize_dbt_artifact_dict(model_data, artifact_type="model")
                 model_unique_id = normalized_model.unique_id
                 models[model_unique_id] = normalized_model
@@ -100,7 +100,7 @@ class ModelsAPI(APIClient):
         sources = dict()
         if sources_results:
             for source_result in json.loads(sources_results[0]):
-                source_data = SourceSchema(**source_result, artifact_type='source')
+                source_data = SourceSchema(**source_result)
                 normalized_source = self._normalize_dbt_artifact_dict(source_data, artifact_type="source")
                 source_unique_id = normalized_source.unique_id
                 sources[source_unique_id] = normalized_source
@@ -111,7 +111,7 @@ class ModelsAPI(APIClient):
         exposures = dict()
         if exposures_results:
             for exposure_result in json.loads(exposures_results[0]):
-                exposure_data = ExposureSchema(**exposure_result, artifact_type='exposure')
+                exposure_data = ExposureSchema(**exposure_result)
                 normalized_exposure = self._normalize_dbt_artifact_dict(exposure_data, artifact_type="exposure")
                 exposure_unique_id = normalized_exposure.unique_id
                 exposures[exposure_unique_id] = normalized_exposure

--- a/elementary/monitor/api/models/schema.py
+++ b/elementary/monitor/api/models/schema.py
@@ -10,7 +10,7 @@ class ArtifactSchema(BaseModel):
     package_name: Optional[str]
     description: Optional[str]
     full_path: str
-    type: str
+    artifact_type: str
 
 
 class ModelSchema(ArtifactSchema):
@@ -27,7 +27,7 @@ class SourceSchema(ArtifactSchema):
 
 class ExposureSchema(ArtifactSchema):
     url: Optional[str]
-    type: Optional[str]
+    artifact_type: Optional[str]
     maturity: Optional[str]
     owner_email: Optional[str]
 

--- a/elementary/monitor/api/models/schema.py
+++ b/elementary/monitor/api/models/schema.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+
 from pydantic import BaseModel, Field, validator
 
 
@@ -17,19 +18,22 @@ class ModelSchema(ArtifactSchema):
     database_name: str = None
     schema_name: str
     table_name: str
+    artifact_type = 'model'
 
 
 class SourceSchema(ArtifactSchema):
     database_name: str = None
     schema_name: str
     table_name: str
+    artifact_type = 'source'
 
 
 class ExposureSchema(ArtifactSchema):
     url: Optional[str]
-    artifact_type: Optional[str]
+    type: Optional[str]
     maturity: Optional[str]
     owner_email: Optional[str]
+    artifact_type = 'exposure'
 
 
 class NormalizedArtifactSchema(BaseModel):
@@ -94,4 +98,4 @@ class ModelRunsSchema(BaseModel):
     median_exec_time: float
     exec_time_change_rate: float
     totals: TotalsModelRunsSchema
-    runs: List[ModelRunSchema] 
+    runs: List[ModelRunSchema]


### PR DESCRIPTION
The problem is that an Exposure has a `type` property of its own which conflicts with Elementary's defined `type` (model, exposure, source).

```yaml
exposures:

  - name: weekly_jaffle_metrics
    type: dashboard
    maturity: high
    url: https://bi.tool/dashboards/1
    description: >
      Did someone say "exponential growth"?

    depends_on:
      - ref('fct_orders')
      - ref('dim_customers')
      - source('gsheets', 'goals')

    owner:
      name: Claire from Data
      email: data@jaffleshop.com
```

Here you can see that the `type` is `dashboard`.