### PR TITLE
`compiled_sql` is optional on the `ModelRunsSchema`.

### DIFF
--- a/elementary/monitor/api/models/schema.py
+++ b/elementary/monitor/api/models/schema.py
@@ -90,7 +90,7 @@ class ModelRunsSchema(BaseModel):
     name: str
     status: str
     last_exec_time: float
-    compiled_sql: str
+    compiled_sql: Optional[str]
     median_exec_time: float
     exec_time_change_rate: float
     totals: TotalsModelRunsSchema


### PR DESCRIPTION
If a user has a model that he didn't run since Elementary 0.4.9, in which `compiled_sql` was added to `dbt_run_results`, the schema will try to initialize with an empty `compiled_sql` which will raise an error and crash the report unnecessarily. This change makes this property optional.