### PR TITLE
Rename TipInfo to Info

### DIFF
--- a/docs/guides/add-elementary-tests.mdx
+++ b/docs/guides/add-elementary-tests.mdx
@@ -9,10 +9,10 @@ After you [install the dbt package](../quickstart#install-the-dbt-package) and r
 Elementary is the first solution that delivers **data monitoring and anomaly detection as [dbt tests](https://docs.getdbt.com/docs/building-a-dbt-project/tests)**. Elementary dbt tests are actually data monitors that collect metrics and metadata over time. On each execution, the tests analyze the new data, compare it to historical metrics, and alert on anomalies and outliers.
 These tests are configured and executed like any other tests in your project.
 
-<TipInfo>
+<Info>
   Elementary tests can only be used with the elementary models, so you must run
   "dbt run --select elementary" to create the Elementary package models.
-</TipInfo>
+</Info>
 
 ## Elementary available monitors as tests
 

--- a/docs/integrations/slack.mdx
+++ b/docs/integrations/slack.mdx
@@ -12,10 +12,10 @@ There are two integration options: Token or Webhook.
 Both methods let you receive alerts from Elementary, but there are several features that are only supported in one of the two.
 Below is features support comparison table, to help you select the integration method.
 
-<TipInfo>
+<Info>
   If possible, Token is the preferred way. It allows more flexibility and
   supports more features than Webhook.
-</TipInfo>
+</Info>
 
 | Slack integration | Elementary alerts | Elementary tests report | Multiple channels | Slack workflows |
 | ----------------- | ----------------- | ----------------------- | ----------------- | --------------- |

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -41,11 +41,11 @@ Some packages we recommend you check out: [dbt_utils](https://github.com/dbt-lab
 
 Add the following to your `packages.yml` file (if missing, create it where `dbt_project.yml` is):
 
-<TipInfo>
+<Info>
   
 Make sure to copy the packages that are relevant to your dbt version.
 
-</TipInfo>
+</Info>
 
 **For dbt 1.2.0 and above:**
 
@@ -74,12 +74,12 @@ packages:
 
 ### 2. Add to your `dbt_project.yml`
 
-<TipInfo>
+<Info>
 This means Elementary models will have their own schema.
 
 Make sure your user has permissions to create schemas.
 
-</TipInfo>
+</Info>
 
 ```yml dbt_project.yml
 models:


### PR DESCRIPTION
Mintlify is simplifying the `<TipInfo>` syntax to just `<Info>`.

This PR renames your components to use the latest syntax.