### PR TITLE
Update quickstart.mdx: details about 2 schemas

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -73,9 +73,11 @@ packages:
 ### 2. Add to your `dbt_project.yml`
 
 <Info>
-This means Elementary models will have their own schema.
+This means Elementary models will have their own schemas.
+Depending on your project custom schemas rules (see [dbt custom schema docs](https://docs.getdbt.com/docs/build/custom-schemas)), the schemas will be named `elementary` & `elementary__tests` or `<target_schema>_elementary` & `<target_schema>_elementary__tests` (being `<target_schema> = analytics` very often).
 
-Make sure your user has permissions to create schemas.
+Make sure your user (or the orchestrator user) has permissions to create schemas.
+If not, ask your admin to create both schemas and grant permissions to the relevant users / groups.
 
 </Info>
 


### PR DESCRIPTION
Add details about need for 2 schemas: elementary & elementary__tests. Reference to dbt custom schema docs.
Permission to create schema reminder or ask admin to create them first and grant privileges.