### PR TITLE
Let boto3 determine AWS credentials

### DIFF
--- a/elementary/config/config.py
+++ b/elementary/config/config.py
@@ -128,12 +128,6 @@ class Config:
         return self.slack_webhook or (self.slack_token and self.slack_channel_name)
 
     @property
-    def has_aws(self) -> bool:
-        return self.aws_profile_name or (
-            self.aws_access_key_id and self.aws_secret_access_key
-        )
-
-    @property
     def has_s3(self):
         return self.s3_bucket_name
 

--- a/elementary/config/config.py
+++ b/elementary/config/config.py
@@ -135,7 +135,7 @@ class Config:
 
     @property
     def has_s3(self):
-        return self.s3_bucket_name and self.has_aws
+        return self.s3_bucket_name
 
     @property
     def has_gcloud(self):


### PR DESCRIPTION
Let boto3 determine AWS credentials. user only need to provide s3 bucket name if they want to send report to s3 and make other aws arguments optional