### PR TITLE
support test description both on the report and the alerts

### DIFF
--- a/elementary/monitor/alerts/alert.py
+++ b/elementary/monitor/alerts/alert.py
@@ -26,6 +26,7 @@ class Alert:
         subscribers: Optional[List[str]] = None,
         slack_channel: Optional[str] = None,
         timezone: Optional[str] = None,
+        meta: Optional[dict] = None,
         **kwargs,
     ):
         self.id = id
@@ -43,6 +44,7 @@ class Alert:
         self.schema_name = schema_name
         self.owners = prettify_json_str_set(owners)
         self.tags = prettify_json_str_set(tags)
+        self.meta = meta
         self.status = status
         self.subscribers = subscribers
         self.slack_channel = slack_channel

--- a/elementary/monitor/alerts/test.py
+++ b/elementary/monitor/alerts/test.py
@@ -85,6 +85,7 @@ class DbtTestAlert(TestAlert):
         self.test_results_description = (
             test_results_description.capitalize() if test_results_description else ""
         )
+        self.test_description = self.meta.get("description") if self.meta else ""
         self.error_message = self.test_results_description
         self.column_name = column_name or ""
         self.severity = severity
@@ -115,6 +116,10 @@ class DbtTestAlert(TestAlert):
         self._add_fields_section_to_slack_msg(
             slack_message,
             [f"*Status*\n{self.status}", f"*Test name*\n{self.test_name}"],
+        )
+        self._add_fields_section_to_slack_msg(
+            slack_message,
+            [f"*Description*\n{self.test_description}"],
         )
         self._add_fields_section_to_slack_msg(
             slack_message, [f"*Owners*\n{self.owners}", f"*Tags*\n{self.tags}"]
@@ -181,6 +186,7 @@ class DbtTestAlert(TestAlert):
                 "test_query": self.test_results_query,
                 "test_params": self.test_params,
                 "test_created_at": self.test_created_at,
+                "description": self.test_description,
             },
             "test_results": {
                 "display_name": self.test_display_name + " - failed results sample",
@@ -226,6 +232,10 @@ class ElementaryTestAlert(DbtTestAlert):
                 f"*Test name*\n{self.test_name}",
                 f"*{sub_type_title}:*\n{self.test_sub_type_display_name}",
             ],
+        )
+        self._add_fields_section_to_slack_msg(
+            slack_message,
+            [f"*Description*\n{self.test_description}"],
         )
         self._add_fields_section_to_slack_msg(
             slack_message, [f"*Owners*\n{self.owners}", f"*Tags*\n{self.tags}"]
@@ -302,6 +312,7 @@ class ElementaryTestAlert(DbtTestAlert):
                 "test_query": self.test_results_query,
                 "test_params": test_params,
                 "test_created_at": self.test_created_at,
+                "description": self.test_description,
             },
             "test_results": test_alerts,
             "test_runs": test_runs,

--- a/elementary/monitor/api/tests/schema.py
+++ b/elementary/monitor/api/tests/schema.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Optional
 from pydantic import BaseModel, validator
 
@@ -22,6 +23,7 @@ class TestMetadataSchema(BaseModel):
     test_results_description: Optional[str]
     owners: Optional[str]
     tags: Optional[str]
+    meta: Optional[dict]
     test_results_query: Optional[str] = None
     other: Optional[str]
     test_name: str
@@ -34,6 +36,10 @@ class TestMetadataSchema(BaseModel):
     @validator("detected_at", pre=True)
     def format_detected_at(cls, detected_at):
         return convert_partial_iso_format_to_full_iso_format(detected_at)
+
+    @validator("meta", pre=True)
+    def load_meta(cls, meta):
+        return json.loads(meta) if meta else {}
 
 
 class InvocationSchema(BaseModel):

--- a/elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql
+++ b/elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql
@@ -253,7 +253,7 @@
         test_results.test_params,
         test_results.severity,
         test_results.status,
-        tests.meta
+        tests.meta,
         first_occurred.first_time_occurred as test_created_at
     from elementary_test_results test_results
     join dbt_tests tests on test_results.test_unique_id = tests.unique_id

--- a/elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql
+++ b/elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql
@@ -202,10 +202,11 @@
         test_results.status,
         test_results.test_short_name,
         test_results.test_alias,
+        tests.meta,
         first_occurred.first_time_occurred as test_created_at
     from elementary_test_results_with_final_unique_id test_results
     left join first_time_test_occurred first_occurred on test_results.elementary_unique_id = first_occurred.elementary_unique_id
-  
+    left join dbt_tests_with_final_unique_id tests on test_results.elementary_unique_id = tests.elementary_unique_id
 {% endmacro %}
 
 
@@ -252,6 +253,7 @@
         test_results.test_params,
         test_results.severity,
         test_results.status,
+        tests.meta
         first_occurred.first_time_occurred as test_created_at
     from elementary_test_results test_results
     join dbt_tests tests on test_results.test_unique_id = tests.unique_id

--- a/elementary/monitor/dbt_project/macros/get_test_results.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_results.sql
@@ -29,6 +29,7 @@
             test_results_description,
             owners,
             tags,
+            meta,
             test_results_query,
             other,
             test_name,


### PR DESCRIPTION
1. Extract meta field when query tests run results
2. Use the meta field to extract test description
3. Pass test description both to the UI and the alerts