### PR TITLE
Prepare for Mintlify upgrades

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,12 +1,15 @@
+---
+title: "Introduction"
+---
+
 <Frame>
-  <div class="dark:bg-slate-200 rounded-md p-4">
+  <div class="dark:bg-white rounded-md p-4">
     <img
       src="https://res.cloudinary.com/mintlify/image/upload/v1659304877/elementary/Logo_V2_chbdpu.png"
       alt="Elementary Logo"
     />
   </div>
 </Frame>
-
 
 ## What is Elementary?
 
@@ -21,7 +24,6 @@ visibility, detect data issues, send actionable alerts, and understand the impac
     alt="Demo"
   />
 </Frame>
-
 
 ## Key features
 
@@ -49,13 +51,12 @@ visibility, detect data issues, send actionable alerts, and understand the impac
 
   Inspect upstream and downstream dependencies to understand impact and root cause of data issues.
 
-
 ## How it works?
 
-For the data monitoring and dbt artifacts collection, we developed a [dbt package](./quickstart#install-the-dbt-package).
+For the data monitoring and dbt artifacts collection, we developed a [dbt package](/quickstart#install-the-dbt-package).
 The monitoring configuration is configured in your dbt project, and the monitors are dbt macros and models. All the collected data is saved to an elementary schema in your DWH.
 
-[Elementary CLI](./understand-elementary/cli-install#install-and-configure) is used to generate the UI report and send Slack alerts.
+[Elementary CLI](/understand-elementary/cli-install#install-and-configure) is used to generate the UI report and send Slack alerts.
 
 <img
   src="https://res.cloudinary.com/mintlify/image/upload/v1659304881/elementary/High-level-flow_d21jfj.png"
@@ -74,7 +75,7 @@ For additional information and help, you can use one of these channels:
 
 Thank you 🧡 Whether it’s a bug fix, new feature, or documentation changes - we greatly appreciate contributions!
 
-Check out the [contributions guide](./general/contributions).
+Check out the [contributions guide](/general/contributions).
 
 ## Integrations
 
@@ -82,12 +83,14 @@ Check out the [contributions guide](./general/contributions).
 - dbt Cloud
 
 Data warehouses:
-- Snowflake 
+
+- Snowflake
 - BigQuery
 - Redshift
 - Databricks SQL
 
 Operations:
+
 - Slack
 - GitHub Actions
 - Amazon S3

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -19,11 +19,19 @@
   "topbarLinks": [
     {
       "name": "Blog",
-      "url": "https://www.elementary-data.com/blog"
+      "url": "https://www.elementary-data.com/blog",
+      "color": {
+        "from": "#FE8913",
+        "to": "#FE10B0"
+      }
     },
     {
       "name": "Support",
-      "url": "https://join.slack.com/t/elementary-community/shared_invite/zt-uehfrq2f-zXeVTtXrjYRbdE_V6xq4Rg"
+      "url": "https://join.slack.com/t/elementary-community/shared_invite/zt-uehfrq2f-zXeVTtXrjYRbdE_V6xq4Rg",
+      "color": {
+        "from": "#FE8913",
+        "to": "#FE10B0"
+      }
     }
   ],
   "anchors": [
@@ -116,9 +124,5 @@
     "posthog": {
       "apiKey": "phc_56XBEzZmh02mGkadqLiYW51eECyYKWPyecVwkGdGUfg"
     }
-  },
-  "classes": {
-    "anchors": "group-hover:bg-gradient-to-tr from-[#FE8913] to-[#FE10B0]",
-    "activeAnchors": "bg-gradient-to-tr"
   }
 }


### PR DESCRIPTION
We are launching major infrastructure changes to Mintlify that reduce page load times by 88%.

This PR has to be merged in before we can migrate Elementary's docs.

In the new Mintlify, Tailwind cannot detect Tailwind classes used outside the Mintlify framework. All custom styling should use regular CSS `style`. I changed your logo's background to `dark:bg-white` because that class is used by Mintlify and thus included in the list of available Tailwind classes. There's no easy way of knowing what classes are available to use though, so I recommend using `style` wherever possible in the future.

Since we cannot define custom Tailwind classes, anchor gradients have to be defined in the `anchor` config instead of the `customClasses` field. Your anchor gradients will be temporarily turned off after you merge in this PR, but they will show up again when we finish migrating your site.