### PR TITLE
Use absolute links for faster page loading

### DIFF
--- a/docs/dbt/dbt-artifacts.mdx
+++ b/docs/dbt/dbt-artifacts.mdx
@@ -2,7 +2,7 @@
 title: "dbt artifacts"
 ---
 
-The [Elementary dbt package](../quickstart#install-the-dbt-package) includes uploading and modeling of dbt artifacts.
+The [Elementary dbt package](/quickstart#install-the-dbt-package) includes uploading and modeling of dbt artifacts.
 
 <Accordion title="What are dbt artifacts?">
 Each dbt invocation generates artifacts, with details about the project resources, configuration and execution. Most are in json format. The artifacts are practically the metadata and logs of the dbt project.
@@ -16,11 +16,11 @@ The Elementary dbt package includes macros that extract specific fields from the
 Some artifacts are updated by an [on-run-end](https://docs.getdbt.com/reference/project-configs/on-run-start-on-run-end) hook when you run `dbt run / test / build`, and some only when you run the models:
 
 - **On run end:**
-    - `elementary_test_results` - Results of all dbt tests (including elementary and other packages, such as dbt_expectations and dbt_utils).
-    - `dbt_run_results` - Results of all dbt executions.
+  - `elementary_test_results` - Results of all dbt tests (including elementary and other packages, such as dbt_expectations and dbt_utils).
+  - `dbt_run_results` - Results of all dbt executions.
 - **`dbt run` that includes elementary models:**
-    - `dbt_models`, `dbt_tests`, `dbt_sources`, `dbt_exposures`, `dbt_metrics` - Metadata and configuration. It is recommended to run these models when you make changes in your projects.
-    
+  - `dbt_models`, `dbt_tests`, `dbt_sources`, `dbt_exposures`, `dbt_metrics` - Metadata and configuration. It is recommended to run these models when you make changes in your projects.
+
 ## Which artifacts are uploaded and modeled?
 
 Elementary uploads fields from the run-results, and the graph object (includes data of manifest, catalog and sources).

--- a/docs/general/troubleshooting.mdx
+++ b/docs/general/troubleshooting.mdx
@@ -11,10 +11,10 @@ If you get an empty report, there are several steps to understand what went wron
 
 - **Check that dbt package version is the latest**
 
-- Refer to the [dbt package installation guide](../quickstart#install-the-dbt-package), and validate that your version in packages.yml is the one mentioned there. If not, upgrade and run `dbt deps`. Make sure to execute `dbt run --select elementary` for the package tables to be created.
+- Refer to the [dbt package installation guide](/quickstart#install-the-dbt-package), and validate that your version in packages.yml is the one mentioned there. If not, upgrade and run `dbt deps`. Make sure to execute `dbt run --select elementary` for the package tables to be created.
 
 - **Check if the table `elementary_test_results` exists and has data**
-- If the table does not exist - refer to the [dbt package installation guide](../quickstart#install-the-dbt-package). Make sure to execute `dbt run --select elementary` for the package tables to be created.
+- If the table does not exist - refer to the [dbt package installation guide](/quickstart#install-the-dbt-package). Make sure to execute `dbt run --select elementary` for the package tables to be created.
 - If the table exists but has no data - Did you execute `dbt test` since deploying the package and creating the models?
 - If yes, make sure the table was created as an incremental table (not a regular table or view).
 - If not, there is a materialization configuration in your `dbt_project.yml` file that overrides the package config. Remove it, and run `dbt run --select elementary --full refresh` to recreate the tables. After that run `dbt test` again and check if there is data.
@@ -140,6 +140,7 @@ After that restart your CMD and try `edr` again.
 This means the installation was not completed successfully. This is usually a Python dependencies issue.
 
 Please try installing again on a clean virtual env:
+
 ```shell
 pip install virtualenv
 python3 -m venv virtualenv_elementary
@@ -150,7 +151,6 @@ python3 -m pip install elementary-data
 python3 -m pip install elementary-data[<adapter>]
 ```
 
-
 </Accordion>
 
 <Accordion title="I changed `days back` but the results are the same">
@@ -160,11 +160,11 @@ If you change it after executing elementary tests, you will need to run a full r
 The steps are:
 
 1. Change var `days_back` in your `dbt_project.yml`.
-2. Full refresh of the model 'data_monitoring_metrics' by running ``` dbt run --select data_monitoring_metrics --full-refresh```.
+2. Full refresh of the model 'data_monitoring_metrics' by running ` dbt run --select data_monitoring_metrics --full-refresh`.
 3. Running the elementary tests again.
 
 If you want the Elementary UI to show data for a longer period of time, use the days-back option of the CLI:
-```edr monitor report --days-back 45```
+`edr monitor report --days-back 45`
 
 </Accordion>
 
@@ -173,7 +173,6 @@ If you want the Elementary UI to show data for a longer period of time, use the 
 If you're experiencing issues of any kind, please contact us on the [#support](https://elementary-community.slack.com/archives/C02CTC89LAX) channel.
 
 </Accordion>
-  
 
 ## Other issues?
 

--- a/docs/guides/add-elementary-tests.mdx
+++ b/docs/guides/add-elementary-tests.mdx
@@ -2,7 +2,7 @@
 title: "Add anomaly detection tests"
 ---
 
-After you [install the dbt package](../quickstart#install-the-dbt-package) and related configuration, you can add Elementary data tests.
+After you [install the dbt package](/quickstart#install-the-dbt-package) and related configuration, you can add Elementary data tests.
 
 ## Data monitors as dbt tests
 
@@ -24,7 +24,7 @@ _Note_: Anomaly detection is not yet supported on Databricks in dbt Cloud.
 
 `elementary.table_anomalies`
 
-Executes table level monitors and anomaly detection. Specific monitors are [detailed here](./data-anomaly-detection#tests-and-monitors-types) and can be configured using the `table_anomalies` key.
+Executes table level monitors and anomaly detection. Specific monitors are [detailed here](/data-anomaly-detection#tests-and-monitors-types) and can be configured using the `table_anomalies` key.
 By default, the freshness test will use the `timestamp_column` provided. If you need to test for freshness by another column (e.g. if your table is partitioned), add the key `freshness_column` to the test.
 
 <CodeGroup>
@@ -136,7 +136,7 @@ models:
 
 `elementary.all_columns_anomalies`
 
-Executes column level monitors and anomaly detection on all the columns of the table. Specific monitors are [detailed here](./data-anomaly-detection#tests-and-monitors-types) and can be configured using the `all_columns_anomalies` key.
+Executes column level monitors and anomaly detection on all the columns of the table. Specific monitors are [detailed here](/guides/data-anomaly-detection#tests-and-monitors-types) and can be configured using the `all_columns_anomalies` key.
 
 <CodeGroup>
 
@@ -178,8 +178,8 @@ models:
 
 Executes schema changes monitor that alerts on deleted table, deleted or added columns, or change of data type of a column.
 
-*Not supported in Databricks.*
-  
+_Not supported in Databricks._
+
 <CodeGroup>
 
 ```yml Models
@@ -219,7 +219,7 @@ models:
 
 `elementary.column_anomalies`
 
-Executes column level monitors and anomaly detection. Specific monitors are [detailed here](./data-anomaly-detection#tests-and-monitors-types) and can be configured using the `column_anomalies` key.
+Executes column level monitors and anomaly detection. Specific monitors are [detailed here](/guides/data-anomaly-detection#tests-and-monitors-types) and can be configured using the `column_anomalies` key.
 
 <CodeGroup>
 
@@ -293,11 +293,11 @@ Elementary tests are added to models / sources / columns of your dbt project jus
 
 Elementary tests have three levels of configurations:
 
-1. [Test arguments](./elementary-tests-configuration#test-arguments) - Test specific arguments.
+1. [Test arguments](/guides/elementary-tests-configuration#test-arguments) - Test specific arguments.
 2. Table configuration - Configure the timestamp column and details of a monitored table.
-3. [Global vars](./elementary-tests-configuration#data-monitoring-global-vars) - Optional configuration parameters of the operation.
+3. [Global vars](/guides/elementary-tests-configuration#data-monitoring-global-vars) - Optional configuration parameters of the operation.
 
-More on data tests configuration [here](./elementary-tests-configuration).
+More on data tests configuration [here](/guides/elementary-tests-configuration).
 
 We recommend adding a tag to the tests so you could execute these in a dedicated run using the selection parameter `--select tag:elementary`.
 If you wish to only be warned on anomalies, configure the severity of the tests to warn.
@@ -442,7 +442,7 @@ At the end of the `dbt test` run, all results and collected metrics are merged i
 
 ## What does it mean when a test fails?
 
-When a test fail, it means that an anomaly was detected on this metric and dataset. To learn more, refer to [anomaly detection](./data-anomaly-detection#anomaly-detection).
+When a test fail, it means that an anomaly was detected on this metric and dataset. To learn more, refer to [anomaly detection](/guides/data-anomaly-detection#anomaly-detection).
 
 ## Where are Elementary tests results stored?
 
@@ -454,4 +454,4 @@ At the end of the `dbt test` run, all results and collected metrics are merged i
 
 ## Alerts on detected anomalies (failed tests)
 
-To get Slack notifications, refer to the [Slack integration](../integrations/slack).
+To get Slack notifications, refer to the [Slack integration](/integrations/slack).

--- a/docs/guides/data-anomaly-detection.mdx
+++ b/docs/guides/data-anomaly-detection.mdx
@@ -13,7 +13,7 @@ _Note_: Anomaly detection is not yet supported on Databricks in dbt Cloud.
 
 ## How to use Elementary to monitor data?
 
-Elementary data monitoring includes a [dbt package](../guides/modules-overview/dbt-package) and CLI.
+Elementary data monitoring includes a [dbt package](/guides/modules-overview/dbt-package) and CLI.
 The dbt package is added to your project. It includes models, tests, and [dbt artifacts](https://docs.getdbt.com/reference/artifacts/dbt-artifacts) uploader.
 
 After you add the package to your project, you can add Elementary tests to your models and sources configuration.
@@ -26,17 +26,17 @@ After your `dbt run` and `dbt test`, execute the Elementary CLI `edr monitor` co
 
 ## Install elementary dbt package
 
-[Elementary dbt package](../quickstart#install-the-dbt-package)
+[Elementary dbt package](/quickstart#install-the-dbt-package)
 
 ## Execution and usage overview
 
 The usage flow is as follows:
 
 1. Install the dbt package and related configuration. (Not a dbt user? you can still use Elementary, reach out to us on [Slack](https://join.slack.com/t/elementary-community/shared_invite/zt-uehfrq2f-zXeVTtXrjYRbdE_V6xq4Rg) and we will help).
-2. [Configure data monitors as tests](./elementary-tests-configuration), just like you configure your native dbt tests.
+2. [Configure data monitors as tests](/guides/elementary-tests-configuration), just like you configure your native dbt tests.
 3. Run `dbt run` as usual (the models in this run have minimal performance impact).
 4. Run `dbt test` as usual, but this time Elementary data monitoring and anomaly detection will run as part of your tests.
-5. [Configure Slack Webhook](../integrations/slack).
+5. [Configure Slack Webhook](/integrations/slack).
 6. Run `edr monitor` to aggregate the results and get Slack alerts.
 
 ---
@@ -104,7 +104,7 @@ According to the [empirical rule](https://www.statisticshowto.com/probability-an
 - **~99.7%** of values have an absolute **z-score of 3 or less.**
 
 Values with a **standard score of 3 and above are [considered outliers](https://www.ctspedia.org/do/view/CTSpedia/OutLier)**, and this is a recommended threshold for anomaly detection.
-This is the default Elementary uses as well, and it can be changed using the var `anomaly_score_threshold` in the [global configuration](./elementary-tests-configuration).
+This is the default Elementary uses as well, and it can be changed using the var `anomaly_score_threshold` in the [global configuration](/guides/elementary-tests-configuration).
 
 You can use the model `anomaly_sensitivity` to see if values of metrics from your last run would have been considered anomalies in different scores. **This can help you decide if there is a need to adjust the sensitivity:**
 

--- a/docs/guides/elementary-tests-configuration.mdx
+++ b/docs/guides/elementary-tests-configuration.mdx
@@ -46,7 +46,7 @@ If undefined, default is null (no time buckets).
 <Accordion title="sensitivity">
 `sensitivity`: [int]
 
-Threshold for the anomaly sensitivity, the [global default](../guides/add-elementary-tests) is 3. If defined for a test, the test param is used instead of the global one.
+Threshold for the anomaly sensitivity, the [global default](/guides/add-elementary-tests) is 3. If defined for a test, the test param is used instead of the global one.
 A higher number means less sensitivity (less anomalies), and a lower number means more sensitivity (more anomalies).
 
 </Accordion>
@@ -187,7 +187,7 @@ You can change their defaults by adding them with a new value in your `dbt_proje
 <Accordion title="days_back">
 `days_back`: [int]
 
-The maximum timeframe for running [time buckets](./data-anomaly-detection#tests-and-monitors-types) monitors, as well as to calculate a baseline for anomaly detection.
+The maximum timeframe for running [time buckets](/guides/data-anomaly-detection#tests-and-monitors-types) monitors, as well as to calculate a baseline for anomaly detection.
 This limit is applied in three cases: - On the first run of elementary or on full refresh (first run for all tables). - For each new table that is added to the monitoring (first run for table). - On each new metric that is added to the configuration (first run of new metric). - If there was a gap bigger than this limit since the last run.
 If undefined, _default is 14 days back_.
 
@@ -204,7 +204,7 @@ If undefined, _default is 2 buckets_.
 <Accordion title="anomaly_sensitivity">
 `anomaly_sensitivity`: [int]
 
-This threshold determines the sensitivity level for anomaly detection. Elementary uses [statistical analysis](./data-anomaly-detection#anomaly-detection) to grade deviations of recent metrics from historical metrics. Increasing this threshold makes the detection less sensitive for anomalies, and reducing makes it more sensitive (smaller deviations will be flagged as anomalies).
+This threshold determines the sensitivity level for anomaly detection. Elementary uses [statistical analysis](/guides/data-anomaly-detection#anomaly-detection) to grade deviations of recent metrics from historical metrics. Increasing this threshold makes the detection less sensitive for anomalies, and reducing makes it more sensitive (smaller deviations will be flagged as anomalies).
 If undefined, _default threshold is 3_.
 
 </Accordion>
@@ -226,8 +226,8 @@ These results are later merged to the incremental tables in the main elementary 
 # optional #
 # Global vars for data monitoring#
 vars:
-  days_back: 14   # maximum timeframe for collecting metrics and analyzing anomalies
-  anomaly_sensitivity: 3   # sensitivity of anomaly detection
-  backfill_days: 2   # days to backfill on each run, adjust to your data delays
-  tests_schema_name: '__tests'  # suffix for elementary tests temp results schema  
+  days_back: 14 # maximum timeframe for collecting metrics and analyzing anomalies
+  anomaly_sensitivity: 3 # sensitivity of anomaly detection
+  backfill_days: 2 # days to backfill on each run, adjust to your data delays
+  tests_schema_name: "__tests" # suffix for elementary tests temp results schema
 ```

--- a/docs/guides/modules-overview/dbt-package.mdx
+++ b/docs/guides/modules-overview/dbt-package.mdx
@@ -17,14 +17,14 @@ Some packages we recommend you check out: [dbt_utils](https://github.com/dbt-lab
 
 </Accordion>
 
-To start, refer to the [installation guide](../../quickstart#how-to-install-elementary-dbt-package) of the dbt package.
+To start, refer to the [installation guide](/quickstart#how-to-install-elementary-dbt-package) of the dbt package.
 
 The code of the Elementary dbt package can be found here: [https://github.com/elementary-data/dbt-data-reliability](https://github.com/elementary-data/dbt-data-reliability)
-
 
 # Elementary dbt package schemas
 
 The Elementary dbt package stores data in 2 schemas:
+
 - Elementary models schema
 - Elementary temp tests results schema
 
@@ -32,44 +32,47 @@ The Elementary dbt package stores data in 2 schemas:
 
 # Elementary dbt package models
 
-
 ## Run results
 
 ### dbt_run_results
-*Incremental model*
+
+_Incremental model_
 
 Run results of dbt invocations, inserted at the end of each invocation.
 Each row is the invocation result of a single resource (model, test, snapshot, etc).
 New data is loaded to this model on an on-run-end hook named `elementary.upload_run_results` from each invocation that produces a result object.
 
 ### dbt_invocations
-*Incremental model*
+
+_Incremental model_
 
 Attributes associated with each dbt invocation. Inserted at the end of each invocation.
 Each row is the result of a single invocation (dbt run, dbt test, dbt build, etc).
 New data is loaded to this model on an on-run-end hook named `elementary.upload_run_results`.
 
 ### model_run_results
-*View*
+
+_View_
 
 Run results of dbt models, enriched with models metadata.
 Each row is the result of a single model.
 This is a view that joins data from `dbt_run_results` and `dbt_models`.
 
 ### snapshot_run_results
-*View*
+
+_View_
 
 Run results of dbt snapshots, enriched with snapshots metadata.
 Each row is the result of a single snapshot.
 This is a view that joins data from `dbt_run_results` and `dbt_snapshots`.
 
 ### elementary_test_results
-*Incremental model*
 
-Run results of all dbt tests, with fields and metadata needed to produce the [Elementary report](../understand-elementary/elementary-report-ui).
+_Incremental model_
+
+Run results of all dbt tests, with fields and metadata needed to produce the [Elementary report](/understand-elementary/elementary-report-ui).
 Each row is the result of a single test, including native dbt tests, packages tests and elementary tests.
 New data is loaded to this model on an on-run-end hook named `elementary.handle_tests_results`.
-
 
 ## dbt artifacts
 
@@ -78,74 +81,83 @@ The dbt artifacts models are created as empty tables, and a post-hook macro inse
 It is recommended to execute these models every time a change is merged to the project.
 
 ### dbt_models
-*Table*
+
+_Table_
 
 Metadata about all the models in the project and project packages.
 Each row contains information about the properties of a single model, including columns like tags, owner, materialization, depends_on, and description.
 
 ### dbt_tests
-*Table*
+
+_Table_
 
 Metadata about all the tests in the project and project packages.
 Each row contains information about the properties of a single test, including columns like severity, parent model unique id, tags and owner of the parent model, test params, and the test compiled query.
 
 ### dbt_sources
-*Table*
+
+_Table_
 
 Metadata about the sources configured in the project and project packages.
 Each row contains information about the properties of a single source, including columns like tags, owner, freshness configuration, database and schema.
 
 ### dbt_exposures
-*Table*
+
+_Table_
 
 Metadata about the exposures configured in the project and project packages.
 Each row contains information about the properties of a single exposure, including columns like tags, owner, url and depends on.
 
 ### dbt_metrics
-*Table*
+
+_Table_
 
 Metadata about the metrics configured in the project and project packages.
 Each row contains information about the properties of a single metric, including columns like tags, owner, sql, and depends on.
 
 ### dbt_snapshots
-*Table*
+
+_Table_
 
 Metadata about all the snapshots in the project and project packages.
 Each row contains information about the properties of a single snapshot, including columns like tags, owner, depends_on, and description.
 
-
 ## Alerts views
 
 ### alerts_dbt_models
-*View*
+
+_View_
 
 A view that is used by the Elementary CLI to generate models alerts, including all the fields the alert will include such as owner, tags, error message, etc.
 It joins data about models and snapshots run results, and filters alerts according to configuration.
 
 ### alerts_dbt_tests
-*View*
+
+_View_
 
 A view that is used by the Elementary CLI to generate dbt tests alerts, including all the fields the alert will include such as owner, tags, error message, etc.
 This view includes data about all dbt tests except elementary tests.
 It filters alerts according to configuration.
 
 ### alerts_anomaly_detection
-*View*
+
+_View_
 
 A view that is used by the Elementary CLI to generate alerts on data anomalies detected using the elementary anomaly detection tests.
 The view filters alerts according to configuration.
 
 ### alerts_schema_changes
-*View*
+
+_View_
 
 A view that is used by the Elementary CLI to generate alerts on schema changes detected using elementary tests.
 The view filters alerts according to configuration.
 
-
 ## Anomaly detection
 
 ### data_monitoring_metrics
-*Incremental model*
+
+_Incremental model_
 
 Elementary anomaly detection tests monitor metrics such as volume, freshness and data quality metrics.
 This incremental table is used to store the metrics over time.
@@ -153,42 +165,47 @@ On each anomaly detection test, the test queries this table for historical metri
 The table is updated with new metrics on the on-run-end named `handle_test_results` that is executed at the end of dbt test invocations.
 
 ### metrics_anomaly_score
-*View*
+
+_View_
 
 This is a view on `data_monitoring_metrics` that runs the same query the anomaly detection tests run to calculate anomaly scores.
 The purpose of this view is to provide visibility to the results of anomaly detection tests.
 
 ### anomaly_threshold_sensitivity
-*View*
+
+_View_
 
 This is a view on `metrics_anomaly_score` that calculates if values of metrics from the latest runs would have been considered anomalies in different anomaly scores.
 This can help you decide if there is a need to adjust the `anomaly_score_threshold`.
 
 ### monitors_runs
-*View*
+
+_View_
 
 This is a view on `data_monitoring_metrics` that is used to determine when a specific anomaly detection test was last executed.
 Each anomaly detection test queries this view to decide on a start time for collecting metrics.
 
-
 ## Schema changes
 
 ### schema_columns_snapshot
-*Incremental model*
+
+_Incremental model_
 
 Stores the schema details for tables that are monitored with elementary schema changes test.
 In order to compare current schema to previous state, we must store the previous state.
 The data is from a view that queries the data warehouse information schema.
 
 ### filtered_information_schema_columns
-*View*
+
+_View_
 
 Queries the columns view from the information schema of the schemas in the project.
 This view is generated using an adapter specific macro, as information schema is different between platforms.
 This is a view to make the work with the information schema more convenient.
 
 ### filtered_information_schema_tables
-*View*
+
+_View_
 
 Queries the tables and schemas views from the information schema of the schemas in the project.
 This view is generated using an adapter specific macro, as information schema is different between platforms.

--- a/docs/integrations/dbt.mdx
+++ b/docs/integrations/dbt.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'dbt core & dbt cloud'
+title: "dbt core & dbt cloud"
 ---
 
 import ConnectionProfile from "../snippets/faq/question-connection-profile.mdx";
@@ -7,22 +7,21 @@ import ProfilePermissions from "../snippets/faq/question-profile-permissions.mdx
 
 Elementary integrates with dbt core (1.0.0 and above) and dbt cloud, as long as the data warehouse is supported.
 
-Both dbt core and cloud users need to [deploy the dbt package](../quickstart) first in the monitored project. 
+Both dbt core and cloud users need to [deploy the dbt package](/quickstart) first in the monitored project.
 
 ### dbt core
 
-After deploying the dbt package, use [this guide](../quickstart-cli) to install the CLI, and add an `elementary` profile.
+After deploying the dbt package, use [this guide](/quickstart-cli) to install the CLI, and add an `elementary` profile.
 
-When you [deploy to production](../deployment-and-configuration/elementary-in-production), you could orchestrate the CLI on the same system you use for running dbt core.
+When you [deploy to production](/deployment-and-configuration/elementary-in-production), you could orchestrate the CLI on the same system you use for running dbt core.
 
 ### dbt cloud
 
 After deploying the dbt package, you will need to create a `profiles.yml` file on the machine you are using to run Elementary.
 This file contains the connection details for the CLI to access your DWH.
 
-Use to create the profile, [this guide](../quickstart-cli) install the CLI, and run it.
+Use to create the profile, [this guide](/quickstart-cli) install the CLI, and run it.
 
 <ConnectionProfile />
 
 <ProfilePermissions />
-

--- a/docs/integrations/slack.mdx
+++ b/docs/integrations/slack.mdx
@@ -4,7 +4,7 @@ title: "Slack"
 
 import SetupSlackIntegration from "../snippets/setup-slack-integration.mdx";
 
-Elementary Slack integration includes sending [Slack alerts](../understand-elementary/elementary-alerts) on failures in dbt tests and models, and the option to distribute the [data observability report](../understand-elementary/elementary-report-ui) as a message attachment.
+Elementary Slack integration includes sending [Slack alerts](/understand-elementary/elementary-alerts) on failures in dbt tests and models, and the option to distribute the [data observability report](/understand-elementary/elementary-report-ui) as a message attachment.
 
 ## Token vs Webhook
 

--- a/docs/quickstart-cli.mdx
+++ b/docs/quickstart-cli.mdx
@@ -8,7 +8,6 @@ import AddConnectionProfile from "./snippets/add-connection-profile.mdx";
 import ConnectionProfile from "./snippets/faq/question-connection-profile.mdx";
 import ProfilePermissions from "./snippets/faq/question-profile-permissions.mdx";
 
-
 Before installing the CLI, make sure to complete the steps dbt package installation, including executing `dbt run` with the Elementary package models.
 
 <Accordion title="dbt package installation">
@@ -16,7 +15,6 @@ Before installing the CLI, make sure to complete the steps dbt package installat
 <InstallDbtPackage />
 
 </Accordion>
-
 
 <AddConnectionProfile />
 
@@ -26,9 +24,9 @@ Before installing the CLI, make sure to complete the steps dbt package installat
 
 <InstallCLI />
 
-
 ## What's next?
+
 1. Use the CLI to:
-    - [Visualize all dbt test results and runs in a report](./quickstart/generate-report-ui) ✨
-    - [Send informative Slack alerts](../quickstart/send-slack-alerts) 📣
-2. [Add data anomaly detection dbt tests](../guides/add-elementary-tests) 📈
+   - [Visualize all dbt test results and runs in a report](/quickstart/generate-report-ui) ✨
+   - [Send informative Slack alerts](/quickstart/send-slack-alerts) 📣
+2. [Add data anomaly detection dbt tests](/guides/add-elementary-tests) 📈

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -144,13 +144,13 @@ models:
 
 ### What happens now?
 
-Once the elementary dbt package has been installed and configured, your test results, run results and [dbt artifacts](./dbt/dbt-artifacts) will be loaded to elementary schema tables.
+Once the elementary dbt package has been installed and configured, your test results, run results and [dbt artifacts](/dbt/dbt-artifacts) will be loaded to elementary schema tables.
 
 If you see data in these models you completed the package deployment (Congrats! 🎉).
 
 ## What's next?
 
-1. [Install the Elementary CLI](./quickstart-cli) to:
-   - [Visualize all dbt test results and runs in a report](./quickstart/generate-report-ui) ✨
-   - [Send informative Slack alerts](../quickstart/send-slack-alerts) 📣
-2. [Add data anomaly detection dbt tests](../guides/add-elementary-tests) 📈
+1. [Install the Elementary CLI](/quickstart-cli) to:
+   - [Visualize all dbt test results and runs in a report](/quickstart/generate-report-ui) ✨
+   - [Send informative Slack alerts](/quickstart/send-slack-alerts) 📣
+2. [Add data anomaly detection dbt tests](/guides/add-elementary-tests) 📈

--- a/docs/quickstart/generate-report-ui.mdx
+++ b/docs/quickstart/generate-report-ui.mdx
@@ -7,7 +7,7 @@ import ShareReport from "../snippets/share-report.mdx";
 import InstallCLI from "../snippets/install-cli.mdx";
 import AddConnectionProfile from "../snippets/add-connection-profile.mdx";
 
-Elementary [data observability report](../understand-elementary/elementary-report-ui) can be used for visualization and exploration of data from the dbt-package tables. That includes dbt test results, Elementary anomaly detection results, dbt artifacts, tests runs, etc.
+Elementary [data observability report](/understand-elementary/elementary-report-ui) can be used for visualization and exploration of data from the dbt-package tables. That includes dbt test results, Elementary anomaly detection results, dbt artifacts, tests runs, etc.
 
 <Frame>
   <img
@@ -18,7 +18,7 @@ Elementary [data observability report](../understand-elementary/elementary-repor
 
 ## Before you start
 
-Before you can start using the report, make sure to install the dbt package, configure a profile and install the CLI. 
+Before you can start using the report, make sure to install the dbt package, configure a profile and install the CLI.
 This is **required for the report to work.**
 
 <Accordion title="dbt package installation">
@@ -38,7 +38,6 @@ This is **required for the report to work.**
 <InstallCLI />
 
 </Accordion>
-
 
 ## Generate Tests Report UI
 

--- a/docs/quickstart/share-report-ui.mdx
+++ b/docs/quickstart/share-report-ui.mdx
@@ -8,7 +8,7 @@ All arguments can be passed either as CLI arguments or in the `config.yml` file.
 
 ## Slack
 
-After you [set up a Slack app and token](../integrations/slack#slack-integration-setup) you can run the command:
+After you [set up a Slack app and token](/integrations/slack#slack-integration-setup) you can run the command:
 
 ```shell
 edr monitor send-report --slack-token <SLACK_TOKEN> --slack-channel-name <CHANNEL_NAME>
@@ -23,8 +23,8 @@ If you prefer to use `config.yml` file, you can add the following configuration 
 
 ```yml
 slack:
-  token: [ Slack token ]
-  channel_name: [ Slack channel ]
+  token: [Slack token]
+  channel_name: [Slack channel]
 ```
 
 ## Amazon S3
@@ -66,10 +66,10 @@ If you prefer to use `config.yml` file, you can add the following configuration 
 
 ```yml
 aws:
-  profile_name: [ AWS profile name ]
-  s3_bucket_name: [ S3 bucket name ]
+  profile_name: [AWS profile name]
+  s3_bucket_name: [S3 bucket name]
 
-update_bucket_website: [ true | false ]
+update_bucket_website: [true | false]
 ```
 
 ## Google Cloud Storage (GCS)
@@ -113,10 +113,10 @@ If you prefer to use `config.yml` file, you can add the following configuration 
 
 ```yml
 google:
-  service_account_path: [ Google service account path ]
-  gcs_bucket_name: [ GCS bucket name ]
+  service_account_path: [Google service account path]
+  gcs_bucket_name: [GCS bucket name]
 
-update_bucket_website: [ true | false ]
+update_bucket_website: [true | false]
 ```
 
 ## Missing something?

--- a/docs/snippets/install-cli.mdx
+++ b/docs/snippets/install-cli.mdx
@@ -17,4 +17,4 @@ pip install 'elementary-data[databricks]'
 
 Run `edr --help` in order to ensure the installation was successful.
 
-If you're receiving `command not found: edr` please check our [troubleshooting guide](../general/troubleshooting).
+If you're receiving `command not found: edr` please check our [troubleshooting guide](/general/troubleshooting).

--- a/docs/snippets/install-dbt-package.mdx
+++ b/docs/snippets/install-dbt-package.mdx
@@ -13,4 +13,4 @@
 
 ## Full installation guide
 
-For the full Elementary dbt package installation guide, refer to [Quickstart: Data Observability](../quickstart).
+For the full Elementary dbt package installation guide, refer to [Quickstart: Data Observability](/quickstart).

--- a/docs/snippets/setup-slack-integration.mdx
+++ b/docs/snippets/setup-slack-integration.mdx
@@ -36,7 +36,7 @@ Here is the Elementary icon for your use (click to download):
 
 </Accordion>
 
-Based on the method you selected, create a [token or webhook](../integrations/slack#token-vs-webhook):
+Based on the method you selected, create a [token or webhook](/integrations/slack#token-vs-webhook):
 
 <Accordion title="Create Slack Token">
 

--- a/docs/snippets/share-report.mdx
+++ b/docs/snippets/share-report.mdx
@@ -6,4 +6,4 @@ Elementary offers 3 methods that make it easy to share the report with others:
 - Host on Amazon S3
 - Host on Google Cloud Storage (GCS)
 
-Refer to [this guide](../quickstart/share-report-ui) for detailed instructions.
+Refer to [this guide](/quickstart/share-report-ui) for detailed instructions.

--- a/docs/tutorial/setup.mdx
+++ b/docs/tutorial/setup.mdx
@@ -10,16 +10,15 @@ In this step you will setup the environment needed for running the tutorial and 
   
   **Prerequisites**
 
-  For the tutorial you will need:
-  1. Working Python installation
-  2. [pip installer](https://pip.pypa.io/en/stable/) for Python 
-  3. Access and credentials to a data warehouse supported by Elementary
+For the tutorial you will need:
 
-  We also reccomend you work with a [Python virtual environment](https://docs.python.org/3/library/venv.html). 
-  
+1. Working Python installation
+2. [pip installer](https://pip.pypa.io/en/stable/) for Python
+3. Access and credentials to a data warehouse supported by Elementary
+
+We also reccomend you work with a [Python virtual environment](https://docs.python.org/3/library/venv.html).
+
 </Info>
-
-
 
 ## Setup tutorial dbt project
 
@@ -91,4 +90,4 @@ dbt run-operation elementary.generate_elementary_cli_profile
 
 Copy the output, fill in the missing fields and add the profile to your `profiles.yml`.
 
-You can see the full guide for configure Elementary profile [here](../quickstart-cli.mdx).
+You can see the full guide for configure Elementary profile [here](/quickstart-cli).

--- a/docs/understand-elementary/cli-commands.mdx
+++ b/docs/understand-elementary/cli-commands.mdx
@@ -10,19 +10,19 @@ edr --help
 
 ## CLI commands
 
-Read from the test results table and send new [alerts to Slack](./elementary-alerts):
+Read from the test results table and send new [alerts to Slack](/understand-elementary/elementary-alerts):
 
 ```shell
 edr monitor
 ```
 
-Read from the test results table and generate the [Elementary UI](./elementary-report-ui):
+Read from the test results table and generate the [Elementary UI](/understand-elementary/elementary-report-ui):
 
 ```shell
 edr monitor report
 ```
 
-Read from the test results table and generate the [Elementary UI](./elementary-report-ui) and send it to external
+Read from the test results table and generate the [Elementary UI](/understand-elementary/elementary-report-ui) and send it to external
 platforms such as Slack, S3, GCS:
 
 ```shell

--- a/docs/understand-elementary/cli-install.mdx
+++ b/docs/understand-elementary/cli-install.mdx
@@ -36,7 +36,7 @@ Elementary CLI requires a connection profile to connect to DWH. Additional confi
 - **Required:** `HOME_DIR/.dbt/profiles.yml` - Connection details to the data warehouse, in the format of dbt connection profile named `elementary`.
 - **Optional:** `HOME_DIR/.edr/config.yml` - Elementary configuration.
 
-(These default paths and names may be changed using the [CLI options](./cli-commands#cli-advanced-options)).
+(These default paths and names may be changed using the [CLI options](/understand-elementary/cli-commands#cli-advanced-options)).
 
 <Accordion title="How to create 'profiles.yml'?">
 

--- a/docs/understand-elementary/elementary-alerts.mdx
+++ b/docs/understand-elementary/elementary-alerts.mdx
@@ -6,12 +6,13 @@ Elementary has a Slack integration to send alerts about failures in dbt tests, E
 
 The alerts include information for fast triage.
 Also, you can add configuration for each test / model in your `.yml` files:
+
 - Custom channels - distribute alerts based on their context
 - Owners - tag the owner of the model
 - Subscribers - let users subscribe to models and tests they care about
 - dbt Tags - add custom context to the alert
 
-In order to send Slack alerts after you deploy the [dbt-package](../general/contributions#contributing-to-the-dbt-package) and configure tests, use the [CLI](./cli-install) and the [Slack](../integrations/slack) integration.
+In order to send Slack alerts after you deploy the [dbt-package](/general/contributions#contributing-to-the-dbt-package) and configure tests, use the [CLI](/understand-elementary/cli-install) and the [Slack](/integrations/slack) integration.
 
 After installing and configuring the CLI, execute the command:
 
@@ -21,4 +22,7 @@ edr monitor
 
 The command will use the provided connection profile to access the data warehouse, read from the Elementary tables, and send informative alerts to Slack.
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304885/elementary/slack-alert-format_rgcg1p.png" alt="New Slack alert format" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304885/elementary/slack-alert-format_rgcg1p.png"
+  alt="New Slack alert format"
+/>

--- a/docs/understand-elementary/elementary-overview.mdx
+++ b/docs/understand-elementary/elementary-overview.mdx
@@ -10,19 +10,19 @@ Our goal is to provide data teams **immediate visibility**, **detection of data 
 
 Set up monitoring for your warehouse in minutes, collect test results and data quality metrics, detect data issues before your users do.
 
-Data monitoring includes a [dbt package](../guides/modules-overview/dbt-package) and the edr CLI for generating the report.
+Data monitoring includes a [dbt package](/guides/modules-overview/dbt-package) and the edr CLI for generating the report.
 
 ## Data anomalies detection as dbt tests
 
 Continuous monitoring of data quality metrics, freshness, volume and schema changes, including anomaly detection, configured and executed as dbt tests.
 
-Data anomalies tests are included in the [dbt package](../guides/modules-overview/dbt-package).
+Data anomalies tests are included in the [dbt package](/guides/modules-overview/dbt-package).
 
 ## dbt artifacts uploader
 
 Monitor the operations of your dbt easily. Collect dbt artifacts, run and test results as part of your runs.
 
-The dbt artifacts uploader is included in the [dbt package](../guides/modules-overview/dbt-package).
+The dbt artifacts uploader is included in the [dbt package](/guides/modules-overview/dbt-package).
 
 ## Slack alerts
 
@@ -34,4 +34,7 @@ Tracing the actual upstream & downstream dependencies in the data warehouse, wit
 
 Data lineage is operated with the edr CLI and creates a browser visualization.
 
-<img src="https://res.cloudinary.com/mintlify/image/upload/v1659304881/elementary/High-level-flow_d21jfj.png" alt="High Level Flow" />
+<img
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304881/elementary/High-level-flow_d21jfj.png"
+  alt="High Level Flow"
+/>

--- a/docs/understand-elementary/elementary-report-ui.mdx
+++ b/docs/understand-elementary/elementary-report-ui.mdx
@@ -3,12 +3,12 @@ title: "Data observability report"
 ---
 
 Elementary has a UI for visualization and exploration of data from
-the [dbt-package](../general/contributions#contributing-to-the-dbt-package) tables, which includes dbt
+the [dbt-package](/general/contributions#contributing-to-the-dbt-package) tables, which includes dbt
 test results, Elementary anomaly detection results, dbt artifacts, etc.
 
 In order to visualize the data from
-the [dbt-package](../general/contributions#contributing-to-the-dbt-package) tables, use
-the [CLI](./cli-install) you can generate the Elementary UI.
+the [dbt-package](/general/contributions#contributing-to-the-dbt-package) tables, use
+the [CLI](/understand-elementary/cli-install) you can generate the Elementary UI.
 After installing and configuring the CLI, execute the command:
 
 ```shell
@@ -19,8 +19,8 @@ The command will use the provided connection profile to access the data warehous
 generate the UI as an HTML file.
 
 <img
-src="https://raw.githubusercontent.com/elementary-data/elementary/master/static/report_ui.gif"
-alt="Demo"
+  src="https://raw.githubusercontent.com/elementary-data/elementary/master/static/report_ui.gif"
+  alt="Demo"
 />
 
 ## Report Screens
@@ -28,7 +28,7 @@ alt="Demo"
 ### Test Results
 
 The `Test results` tab shows the latest result for each dbt or Elementary test that was executed in the last 7 days (Can
-be changed by passing `--days-back` param to the [CLI](../understand-elementary/cli-commands)).
+be changed by passing `--days-back` param to the [CLI](/understand-elementary/cli-commands)).
 
 Initially, the report presents all tests, sorted by status (failures on top) and last run time. The grey header on the
 top of the screen shows the total amount of results of each status.
@@ -52,15 +52,15 @@ The rows are expandable, and on expansion show information that can help underst
 - For schema changes tests - detected schema changes.
 
 <img
-src="https://res.cloudinary.com/mintlify/image/upload/v1659304887/elementary/data-observability-ui-test-results-screen_vgk121.gif"
-alt="Data observability UI Test Result Screen"
+  src="https://res.cloudinary.com/mintlify/image/upload/v1659304887/elementary/data-observability-ui-test-results-screen_vgk121.gif"
+  alt="Data observability UI Test Result Screen"
 />
 
 ## Test runs
 
 The `Test runs` tab shows the last 30 runs (can be changed by passing `--executions-limit` param to
-the [CLI](../understand-elementary/cli-commands#cli-advanced-options)) for each dbt or Elementary test that was executed in the last 7 days (
-can be changed by passing `--days-back` param to the [CLI](../understand-elementary/cli-commands#cli-advanced-options)).
+the [CLI](/understand-elementary/cli-commands#cli-advanced-options)) for each dbt or Elementary test that was executed in the last 7 days (
+can be changed by passing `--days-back` param to the [CLI](/understand-elementary/cli-commands#cli-advanced-options)).
 
 Initially, the report presents all tests, sorted by results (results containing failures on top), fail rate and last run
 time. The grey header on the top of the screen shows the total amount of runs for each status.
@@ -90,7 +90,7 @@ The rows are expandable, and on expansion show information about the last runs o
 When selecting a dbt model/source in the navigation bar, a lineage icon will appear next to the
 selected dbt model/source:
 
-<img class="m-0 float-right" src="../pics/lineage_icon.png" width="18" />
+<img class="m-0 float-right" src="/pics/lineage_icon.png" width="18" />
 
 </div>
 
@@ -102,15 +102,13 @@ This is useful when trying to find the root cause of a test failure or when tryi
 test failure, for example on an exposure or a dashboard in the data stack.
 
 <img
-src="../pics/elementary-data-lineage-gif.gif"
-alt="Data lineage navigation bar"
+  src="/pics/elementary-data-lineage-gif.gif"
+  alt="Data lineage navigation bar"
 />
-
-
 
 ## Configure report sharing
 
 The data tests report UI can be sent via Slack, Google Cloud Storage, or Amazon S3 when you
 run `edr monitor send-report`.
 
-Refer to [this guide](../quickstart/share-report-ui) for detailed instructions.
+Refer to [this guide](/quickstart/share-report-ui) for detailed instructions.


### PR DESCRIPTION
Mintlify uses Next Link to optimize navigating between pages. However, because of our multi-tenant setup, Next Link only works with absolute links. That is, `/folder/page` instead of `../page`. You do not need to add the https:// nor your site's URL.

This PR changes all your links to absolute links to benefit from our optimizations. Prettier ran on some of your files, so there are some spacing changes too.