### PR TITLE
Read result rows

### DIFF
--- a/elementary/clients/dbt/dbt_runner.py
+++ b/elementary/clients/dbt/dbt_runner.py
@@ -44,10 +44,11 @@ class DbtRunner:
         if vars:
             json_vars = json.dumps(vars)
             dbt_command.extend(["--vars", json_vars])
+        log_msg = f"Running {' '.join(dbt_command)}"
         if not quiet:
-            logger.info(f"Running {' '.join(dbt_command)} (this might take a while)")
+            logger.info(log_msg)
         else:
-            logger.debug(f"Running {' '.join(dbt_command)}")
+            logger.debug(log_msg)
         try:
             result = subprocess.run(
                 dbt_command,

--- a/elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql
+++ b/elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql
@@ -129,7 +129,8 @@
             severity,
             status,
             test_short_name,
-            test_alias
+            test_alias,
+            result_rows
         from elementary_test_results
     ),
 
@@ -161,7 +162,8 @@
             results.severity,
             results.status,
             results.test_short_name,
-            results.test_alias
+            results.test_alias,
+            results.result_rows
         from elementary_test_results_with_elementary_unique_id results
         join dbt_tests_with_same_name_count counter on results.elementary_unique_id = counter.elementary_unique_id
     ),
@@ -202,6 +204,7 @@
         test_results.status,
         test_results.test_short_name,
         test_results.test_alias,
+        test_results.result_rows,
         first_occurred.first_time_occurred as test_created_at
     from elementary_test_results_with_final_unique_id test_results
     left join first_time_test_occurred first_occurred on test_results.elementary_unique_id = first_occurred.elementary_unique_id

--- a/elementary/monitor/dbt_project/macros/get_new_test_alerts.sql
+++ b/elementary/monitor/dbt_project/macros/get_new_test_alerts.sql
@@ -36,7 +36,7 @@
 
         {% set test_rows_sample = none %}
         {%- if (test_type == 'dbt_test' and status in ['fail', 'warn']) or (test_type != 'dbt_test' and status != 'error') -%}
-            {% set test_rows_sample = elementary_internal.get_test_rows_sample(test_results_query, test_type, results_sample_limit) %}
+            {% set test_rows_sample = elementary_internal.get_test_rows_sample(test_result_alert_dict, test_results_query, test_type, results_sample_limit) %}
         {%- endif -%}
 
         {% set test_meta = elementary.insensitive_get_dict_value(test_result_alert_dict, 'test_meta') %}

--- a/elementary/monitor/dbt_project/macros/get_test_rows_sample.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_rows_sample.sql
@@ -1,5 +1,5 @@
 {%- macro get_test_rows_sample(test, test_results_query, test_type, results_sample_limit = 5) -%}
-    {% if test.result_rows %}
+    {% if test.result_rows is not none %}
       {% do return(fromjson(test.result_rows)) %}
     {% endif %}
 

--- a/elementary/monitor/dbt_project/macros/get_test_rows_sample.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_rows_sample.sql
@@ -1,4 +1,8 @@
-{%- macro get_test_rows_sample(test_results_query, test_type, results_sample_limit = 5) -%}
+{%- macro get_test_rows_sample(test, test_results_query, test_type, results_sample_limit = 5) -%}
+    {% if test.result_rows %}
+      {% do return(fromjson(test.result_rows)) %}
+    {% endif %}
+
     {% set test_rows_sample = none %}
     {% if test_results_query %}
         {% set test_rows_sample_query = test_results_query %}

--- a/elementary/monitor/dbt_project/macros/get_tests_sample_data.sql
+++ b/elementary/monitor/dbt_project/macros/get_tests_sample_data.sql
@@ -35,26 +35,15 @@
         {% set test_sub_type = elementary.insensitive_get_dict_value(test, 'test_sub_type') %}
         {% set status = elementary.insensitive_get_dict_value(test, 'status') | lower %}
 
-        {% set test_rows_sample = none %}
         {% set elementary_tests_allowlist_status = ['fail', 'warn']  %}
         {% if not disable_passed_test_metrics %}
             {% do elementary_tests_allowlist_status.append('pass') %}
         {% endif %}
+        {% set test_rows_sample = elementary_internal.get_test_rows_sample(test, test_results_query, test_type, metrics_sample_limit) %}
         {%- if (test_type == 'dbt_test' and status in ['fail', 'warn']) or (test_type != 'dbt_test' and status in elementary_tests_allowlist_status) -%}
             {# Dimension anomalies return multiple dimensions for the test rows sample, and needs to be handle differently. #}
             {# Currently we show only the anomalous for all of the dimensions. #}
             {% if test_sub_type == 'dimension' %}
-                {% set dimension_test_result_query %}
-                    with all_test_results as (
-                        select *
-                        from ({{test_results_query}})
-                    )
-
-                    select *
-                    from all_test_results
-                    where is_anomalous = TRUE
-                {% endset %}
-                {% set test_rows_sample = elementary_internal.get_test_rows_sample(test, dimension_test_result_query, test_type, metrics_sample_limit) %}
                 {% set anomalous_rows = [] %}
                 {% set headers = [{'id': 'anomalous_value_timestamp', 'display_name': 'timestamp', 'type': 'date'}] %}
                 {% for row in test_rows_sample %}
@@ -85,8 +74,6 @@
                     'headers': headers,
                     'test_rows_sample': anomalous_rows
                 } %}
-            {% else %}
-                {% set test_rows_sample = elementary_internal.get_test_rows_sample(test, test_results_query, test_type, metrics_sample_limit) %}
             {% endif %}
         {%- endif -%}
         {% set sub_test_unique_id = get_sub_test_unique_id(

--- a/elementary/monitor/dbt_project/macros/get_tests_sample_data.sql
+++ b/elementary/monitor/dbt_project/macros/get_tests_sample_data.sql
@@ -21,7 +21,8 @@
             test_sub_type,
             column_name,
             test_results_query,
-            status
+            status,
+            result_rows
         from latest_tests_in_the_last_chosen_days
     {%- endset -%}
     {% set tests_results_agate = run_query(select_test_results) %}
@@ -53,7 +54,7 @@
                     from all_test_results
                     where is_anomalous = TRUE
                 {% endset %}
-                {% set test_rows_sample = elementary_internal.get_test_rows_sample(dimension_test_result_query, test_type, metrics_sample_limit) %}
+                {% set test_rows_sample = elementary_internal.get_test_rows_sample(test, dimension_test_result_query, test_type, metrics_sample_limit) %}
                 {% set anomalous_rows = [] %}
                 {% set headers = [{'id': 'anomalous_value_timestamp', 'display_name': 'timestamp', 'type': 'date'}] %}
                 {% for row in test_rows_sample %}
@@ -85,7 +86,7 @@
                     'test_rows_sample': anomalous_rows
                 } %}
             {% else %}
-                {% set test_rows_sample = elementary_internal.get_test_rows_sample(test_results_query, test_type, metrics_sample_limit) %}
+                {% set test_rows_sample = elementary_internal.get_test_rows_sample(test, test_results_query, test_type, metrics_sample_limit) %}
             {% endif %}
         {%- endif -%}
         {% set sub_test_unique_id = get_sub_test_unique_id(


### PR DESCRIPTION
This is currently a breaking change as `result_rows` is queried from `elementary_test_results` which might not exist yet.
This can be bypassed by reading the Elementary's dbt package version and rendering the `result_rows` only if it's above a certain version.