### PR TITLE
Add email parsing for slack handle alerts

### DIFF
--- a/elementary/clients/slack/client.py
+++ b/elementary/clients/slack/client.py
@@ -60,6 +60,12 @@ class SlackClient(ABC):
         raise NotImplementedError
 
 
+    @abstractmethod
+    def get_user_id_from_email(self, email: str):
+        raise NotImplementedError
+
+
+
 class SlackWebClient(SlackClient):
     def _initial_client(self):
         return WebClient(token=self.token)
@@ -111,6 +117,14 @@ class SlackWebClient(SlackClient):
         else:
             logger.error("Failed to send report to Slack.")
         return send_succeed
+
+    def get_user_id_from_email(self, email: str) -> str:
+        logger.info(f"Attempting to get slack id of user: {email}")
+        try:
+            return self.client.users_lookupByEmail(email=email)["user"]["id"]
+        except SlackApiError as e:
+            logger.error(f"Slack client error: {e.response['error']}")
+        return ""
 
     def _get_channel_id(self, channel_name: str) -> Optional[str]:
         try:
@@ -206,4 +220,7 @@ class SlackWebhookClient(SlackClient):
         raise NotImplementedError
 
     def send_report(self, **kwargs):
+        raise NotImplementedError
+
+    def get_user_id_from_email(self, **kwargs):
         raise NotImplementedError

--- a/elementary/monitor/data_monitoring.py
+++ b/elementary/monitor/data_monitoring.py
@@ -91,11 +91,19 @@ class DataMonitoring:
 
             return re.fullmatch(email_regex, potential_email_str)
 
+        def _validate_owner(owner):
+            validated_owner = self.slack_client.get_user_id_from_email(owner)
+            if validated_owner:
+                owner_handle = f'<@{validated_owner}>'
+            else:
+                owner_handle = owner
+            return owner_handle
+
         if owners_str != [] and owners_str != '':
             owners_list = [owner.strip() for owner in owners_str.split(',')]
             owners_validated = [
-                f'<@{self.slack_client.get_user_id_from_email(owner)}>' if _regex_match_owner_email(owner) else owner
-                for owner in owners_list]
+                _validate_owner(owner) if _regex_match_owner_email(owner) else owner for owner in owners_list
+            ]
             parsed_owners_str = ", ".join(set(owners_validated))
             return parsed_owners_str
         else:


### PR DESCRIPTION
This is needed for Slack Enterprise customers for whom simple `@josh.elston-green` tags do not work and need to use the Slack User IDs like `<@U123456>` 