### PR TITLE
fix parse emails to ids bug

### DIFF
--- a/elementary/monitor/alerts/alert.py
+++ b/elementary/monitor/alerts/alert.py
@@ -42,8 +42,8 @@ class Alert:
             logger.error(f'Failed to parse "detected_at" field.')
         self.database_name = database_name
         self.schema_name = schema_name
-        self.owners = prettify_json_str_set(owners)
-        self.tags = prettify_json_str_set(tags)
+        self.owners = owners
+        self.tags = tags
         self.meta = meta
         self.status = status
         self.subscribers = subscribers

--- a/elementary/monitor/alerts/model.py
+++ b/elementary/monitor/alerts/model.py
@@ -2,6 +2,7 @@ import json
 
 from elementary.clients.slack.schema import SlackMessageSchema
 from elementary.monitor.alerts.alert import Alert
+from elementary.utils.json_utils import prettify_json_str_set
 from elementary.utils.log import get_logger
 from elementary.utils.time import DATETIME_FORMAT
 
@@ -91,11 +92,16 @@ class ModelAlert(Alert):
             divider=True,
         )
         self._add_fields_section_to_slack_msg(
-            slack_message, [f"*Owners*\n{self.owners}", f"*Tags*\n{self.tags}"]
+            slack_message,
+            [
+                f"*Owners*\n{prettify_json_str_set(self.owners)}",
+                f"*Tags*\n{prettify_json_str_set(self.tags)}",
+            ],
         )
         if self.subscribers:
             self._add_fields_section_to_slack_msg(
-                slack_message, [f'*Subscribers*\n{", ".join(set(self.subscribers))}']
+                slack_message,
+                [f"*Subscribers*\n{prettify_json_str_set(self.subscribers)}"],
             )
         self._add_fields_section_to_slack_msg(
             slack_message, [f"*Status*\n{self.status}", f"*Path*\n{self.original_path}"]

--- a/elementary/monitor/alerts/source_freshness.py
+++ b/elementary/monitor/alerts/source_freshness.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from elementary.clients.slack.schema import SlackMessageSchema
 from elementary.monitor.alerts.alert import Alert
+from elementary.utils.json_utils import prettify_json_str_set
 from elementary.utils.log import get_logger
 from elementary.utils.time import (
     convert_datetime_utc_str_to_timezone_str,
@@ -104,11 +105,16 @@ class SourceFreshnessAlert(Alert):
             )
 
         self._add_fields_section_to_slack_msg(
-            slack_message, [f"*Owners*\n{self.owners}", f"*Tags*\n{self.tags}"]
+            slack_message,
+            [
+                f"*Owners*\n{prettify_json_str_set(self.owners)}",
+                f"*Tags*\n{prettify_json_str_set(self.tags)}",
+            ],
         )
         if self.subscribers:
             self._add_fields_section_to_slack_msg(
-                slack_message, [f'*Subscribers*\n{", ".join(set(self.subscribers))}']
+                slack_message,
+                [f"*Subscribers*\n{prettify_json_str_set(self.subscribers)}"],
             )
         self._add_fields_section_to_slack_msg(
             slack_message, [f"*Status*\n{self.status}", f"*Path*\n{self.path}"]

--- a/elementary/monitor/alerts/test.py
+++ b/elementary/monitor/alerts/test.py
@@ -6,7 +6,7 @@ from slack_sdk.models.blocks import SectionBlock
 
 from elementary.clients.slack.schema import SlackMessageSchema
 from elementary.monitor.alerts.alert import Alert
-from elementary.utils.json_utils import try_load_json
+from elementary.utils.json_utils import prettify_json_str_set, try_load_json
 from elementary.utils.log import get_logger
 from elementary.utils.time import DATETIME_FORMAT
 
@@ -133,11 +133,16 @@ class DbtTestAlert(TestAlert):
             f"*Description*\n{self.test_description if self.test_description else 'No description'}",
         )
         self._add_fields_section_to_slack_msg(
-            slack_message, [f"*Owners*\n{self.owners}", f"*Tags*\n{self.tags}"]
+            slack_message,
+            [
+                f"*Owners*\n{prettify_json_str_set(self.owners)}",
+                f"*Tags*\n{prettify_json_str_set(self.tags)}",
+            ],
         )
         if self.subscribers:
             self._add_fields_section_to_slack_msg(
-                slack_message, [f'*Subscribers*\n{", ".join(set(self.subscribers))}']
+                slack_message,
+                [f"*Subscribers*\n{prettify_json_str_set(self.subscribers)}"],
             )
         if self.error_message:
             self._add_text_section_to_slack_msg(
@@ -249,11 +254,16 @@ class ElementaryTestAlert(DbtTestAlert):
             f"*Description*\n{self.test_description if self.test_description else 'No description'}",
         )
         self._add_fields_section_to_slack_msg(
-            slack_message, [f"*Owners*\n{self.owners}", f"*Tags*\n{self.tags}"]
+            slack_message,
+            [
+                f"*Owners*\n{prettify_json_str_set(self.owners)}",
+                f"*Tags*\n{prettify_json_str_set(self.tags)}",
+            ],
         )
         if self.subscribers:
             self._add_fields_section_to_slack_msg(
-                slack_message, [f'*Subscribers*\n{", ".join(set(self.subscribers))}']
+                slack_message,
+                [f"*Subscribers*\n{prettify_json_str_set(self.subscribers)}"],
             )
         if self.error_message:
             self._add_text_section_to_slack_msg(

--- a/elementary/monitor/data_monitoring.py
+++ b/elementary/monitor/data_monitoring.py
@@ -37,6 +37,7 @@ from elementary.monitor.api.tests.schema import (
 from elementary.monitor.api.tests.tests import TestsAPI
 from elementary.tracking.anonymous_tracking import AnonymousTracking
 from elementary.utils import package
+from elementary.utils.json_utils import prettify_json_str_set
 from elementary.utils.log import get_logger
 from elementary.utils.time import get_now_utc_iso_format
 
@@ -87,30 +88,25 @@ class DataMonitoring:
         self.send_test_message_on_success = send_test_message_on_success
         self.disable_samples = disable_samples
 
-    def _parse_emails_to_ids(self, owners_str: str):
-        def _regex_match_owner_email(potential_email_str):
+    def _parse_emails_to_ids(self, emails: List[str]) -> str:
+        def _regex_match_owner_email(potential_email: str) -> bool:
             email_regex = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
 
-            return re.fullmatch(email_regex, potential_email_str)
+            return re.fullmatch(email_regex, potential_email)
 
-        def _validate_owner(owner):
-            validated_owner = self.slack_client.get_user_id_from_email(owner)
-            if validated_owner:
-                owner_handle = f"<@{validated_owner}>"
-            else:
-                owner_handle = owner
-            return owner_handle
+        def _get_user_id(email: str) -> str:
+            user_id = self.slack_client.get_user_id_from_email(email)
+            return f"<@{user_id}>" if user_id else email
 
-        if owners_str != [] and owners_str != "":
-            owners_list = [owner.strip() for owner in owners_str.split(",")]
-            owners_validated = [
-                _validate_owner(owner) if _regex_match_owner_email(owner) else owner
-                for owner in owners_list
+        if isinstance(emails, list) and emails != []:
+            ids = [
+                _get_user_id(email) if _regex_match_owner_email(email) else email
+                for email in emails
             ]
-            parsed_owners_str = ", ".join(set(owners_validated))
-            return parsed_owners_str
+            parsed_ids_str = prettify_json_str_set(ids)
+            return parsed_ids_str
         else:
-            return owners_str
+            return prettify_json_str_set(emails)
 
     def _send_alerts_to_slack(self, alerts: List[Alert], alerts_table_name: str):
         if not alerts:


### PR DESCRIPTION
We have a bug when trying yo parse emails to slack ids for our slack alerts.
When trying to parse subscribers, we got an error that broke the alerts.
