### PR TITLE
Support `--dbt-vars` in sub commands of `edr monitor`

### DIFF
--- a/docs/understand-elementary/cli-commands.mdx
+++ b/docs/understand-elementary/cli-commands.mdx
@@ -186,3 +186,11 @@ Here is a list of all the available options:
 ```shell
 --env [dev|prod]
 ```
+
+- **dbt variables:**
+  The JSON object as string is passed to the `--vars` options of a  dbt command internally executed by Elementary,
+  if you want to pass dbt variables rather than `dbt_project.yml`.
+
+```shell
+--dbt-vars TEXT
+```

--- a/elementary/clients/dbt/dbt_runner.py
+++ b/elementary/clients/dbt/dbt_runner.py
@@ -172,17 +172,19 @@ class DbtRunner:
             env.update(self.dbt_env_vars)
         return env
 
-    def debug(self, quiet: bool = False) -> bool:
-        success, _ = self._run_command(command_args=["debug"], quiet=quiet)
+    def debug(self, quiet: bool = False, vars: Optional[dict] = None) -> bool:
+        success, _ = self._run_command(command_args=["debug"], quiet=quiet, vars=vars)
         return success
 
-    def ls(self, select: Optional[str] = None) -> list:
+    def ls(self, select: Optional[str] = None, vars: Optional[dict] = None) -> list:
         command_args = ["ls"]
         if select:
             command_args.extend(["-s", select])
         try:
             success, command_output_string = self._run_command(
-                command_args=command_args, json_logs=True
+                command_args=command_args,
+                json_logs=True,
+                vars=vars,
             )
             command_outputs = command_output_string.splitlines()
             # ls command didn't match nodes.
@@ -202,5 +204,5 @@ class DbtRunner:
         except DbtCommandError:
             raise DbtLsCommandError(select)
 
-    def source_freshness(self):
-        self._run_command(command_args=["source", "freshness"])
+    def source_freshness(self, vars: Optional[dict] = None):
+        self._run_command(command_args=["source", "freshness"], vars=vars)

--- a/elementary/config/config.py
+++ b/elementary/config/config.py
@@ -170,7 +170,7 @@ class Config:
     def has_gcs(self):
         return self.gcs_bucket_name and self.has_gcloud
 
-    def validate_monitor(self):
+    def validate_monitor(self, dbt_vars: Optional[dict] = None):
         self._validate_internal_dbt_project()
         self._validate_timezone()
         if not self.has_slack:
@@ -178,17 +178,17 @@ class Config:
                 "Either a Slack token and a channel or a Slack webhook is required."
             )
 
-    def validate_report(self):
-        self._validate_internal_dbt_project()
+    def validate_report(self, dbt_vars: Optional[dict] = None):
+        self._validate_internal_dbt_project(dbt_vars=dbt_vars)
 
-    def validate_send_report(self):
-        self._validate_internal_dbt_project()
+    def validate_send_report(self, dbt_vars: Optional[dict] = None):
+        self._validate_internal_dbt_project(dbt_vars=dbt_vars)
         if not self.has_send_report_platform:
             raise InvalidArgumentsError(
                 "You must provide a platform to upload the report to (Slack token / S3 / GCS)."
             )
 
-    def _validate_internal_dbt_project(self):
+    def _validate_internal_dbt_project(self, dbt_vars: Optional[dict] = None):
         dbt_runner = DbtRunner(
             dbt_project_utils.PATH,
             self.profiles_dir,


### PR DESCRIPTION
## Overview
We internally execute `dbt debug` when running sub commands of `edr monitor` like `edr monitor report`. If we have to pass dbt variables outside of `dbt_project.yml`, the sub commands don't work because of the lack of dbt variables. So, I would like to enable to pass dbt variables to the commands related to `edr monitor`. 