### PR TITLE
Fix event_freshness_anomalies examples

### DIFF
--- a/docs/guides/add-elementary-tests.mdx
+++ b/docs/guides/add-elementary-tests.mdx
@@ -159,7 +159,7 @@ version: 2
 models:
   - name: < model name >
     tests:
-      - elementary.freshness_anomalies:
+      - elementary.event_freshness_anomalies:
           event_timestamp_column: < timestamp column >          # Mandatory
           update_timestamp_column: < timestamp column >         # Optional
           where_expression: < sql expression >
@@ -174,7 +174,7 @@ version: 2
 models:
   - name: login_events
     tests:
-      - elementary.freshness_anomalies:
+      - elementary.event_freshness_anomalies:
           event_timestamp_column: 'occurred_at'
           update_timestamp_column: 'updated_at'
           # optional - use tags to run elementary tests on a dedicated run


### PR DESCRIPTION
## Fix event_freshness_anomalies examples

The `event_freshness_anomalies` doc section have the same example as the `freshness_anomalies` causing an error if the user copy/paste into their code:

```bash
dbt.exceptions.CompilationException: Compilation Error in test elementary_freshness_anomalies_<redacted>_updated_at__update_ts_dms_at (models/staging/<redacted>/schema.yml)                                                                                                               
  macro 'dbt_macro__test_freshness_anomalies' takes no keyword argument 'event_timestamp_column'
``` 