### PR TITLE
fix: remove truncate_if_on_run_end param

### DIFF
--- a/elementary/monitor/dbt_project/macros/upload_source_freshness.sql
+++ b/elementary/monitor/dbt_project/macros/upload_source_freshness.sql
@@ -1,5 +1,5 @@
 {% macro upload_source_freshness(results) %}
   {% set source_freshess_results_dicts = fromjson(results) %}
   {% set source_freshness_results_relation = ref('dbt_source_freshness_results') %}
-  {% do elementary.upload_artifacts_to_table(source_freshness_results_relation, source_freshess_results_dicts, elementary.flatten_source_freshness, truncate_if_on_run_end=false, should_commit=true) %}
+  {% do elementary.upload_artifacts_to_table(source_freshness_results_relation, source_freshess_results_dicts, elementary.flatten_source_freshness, should_commit=true) %}
 {% endmacro %}

--- a/elementary/monitor/dbt_project/macros/upload_source_freshness.sql
+++ b/elementary/monitor/dbt_project/macros/upload_source_freshness.sql
@@ -1,5 +1,5 @@
 {% macro upload_source_freshness(results) %}
   {% set source_freshess_results_dicts = fromjson(results) %}
   {% set source_freshness_results_relation = ref('dbt_source_freshness_results') %}
-  {% do elementary.upload_artifacts_to_table(source_freshness_results_relation, source_freshess_results_dicts, elementary.flatten_source_freshness, should_commit=true) %}
+  {% do elementary.upload_artifacts_to_table(source_freshness_results_relation, source_freshess_results_dicts, elementary.flatten_source_freshness, append=True, should_commit=true) %}
 {% endmacro %}


### PR DESCRIPTION
Now we are using internal `upload_source_freshness` macro https://github.com/elementary-data/elementary/commit/fef59e5c6009e7a146d88c556fe38c201fe09838 and in that while calling `upload_artifacts_to_table` we pass `truncate_if_on_run_end` parameter which does not exist here https://github.com/elementary-data/dbt-data-reliability/blob/master/macros/edr/dbt_artifacts/upload_artifacts_to_table.sql

And because of that I'm getting following error,
`macro \'dbt_macro__upload_artifacts_to_table\' takes no keyword argument \'truncate_if_on_run_end\'`