### PR TITLE
Lowercasing agate's columns by default.

### DIFF
--- a/elementary/monitor/dbt_project/macros/alerts/update_sent_alerts.sql
+++ b/elementary/monitor/dbt_project/macros/alerts/update_sent_alerts.sql
@@ -5,6 +5,6 @@
             WHERE alert_id IN {{ elementary.strings_list_to_tuple(alert_ids) }} and suppression_status = 'pending' and
                 {{ elementary.cast_as_timestamp('detected_at') }} >= {{ get_alerts_time_limit() }}
         {% endset %}
-        {% do dbt.run_query(update_sent_alerts_query) %}
+        {% do elementary.run_query(update_sent_alerts_query) %}
     {% endif %}
 {% endmacro %}

--- a/elementary/monitor/dbt_project/macros/alerts/update_skipped_alerts.sql
+++ b/elementary/monitor/dbt_project/macros/alerts/update_skipped_alerts.sql
@@ -5,6 +5,6 @@
             WHERE alert_id IN {{ elementary.strings_list_to_tuple(alert_ids) }} and suppression_status = 'pending' and
                 {{ elementary.cast_as_timestamp('detected_at') }} >= {{ get_alerts_time_limit() }}
         {% endset %}
-        {% do dbt.run_query(update_skipped_alerts_query) %}
+        {% do elementary.run_query(update_skipped_alerts_query) %}
     {% endif %}
 {% endmacro %}

--- a/elementary/monitor/dbt_project/macros/get_latest_invocation.sql
+++ b/elementary/monitor/dbt_project/macros/get_latest_invocation.sql
@@ -9,7 +9,7 @@
   {% set get_pkg_version_query %}
     select * from {{ invocations_relation }} order by generated_at desc limit 1
   {% endset %}
-  {% set result = dbt.run_query(get_pkg_version_query) %}
+  {% set result = elementary.run_query(get_pkg_version_query) %}
   {% if not result %}
     {% do elementary.edr_log('') %}
     {% do return(none) %}

--- a/elementary/monitor/dbt_project/macros/get_test_last_invocation.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_last_invocation.sql
@@ -38,6 +38,6 @@
             from test_invocation
         {% endif %}
     {% endset %}
-    {% set result = elementary.agate_to_json(dbt.run_query(last_invocation_query)) %}
+    {% set result = elementary.agate_to_json(elementary.run_query(last_invocation_query)) %}
     {% do elementary.edr_log(result) %}
 {% endmacro %}


### PR DESCRIPTION
This is in order to avoid using `.insensitive_get_dict_value()` all the time throughout the code.