### PR TITLE
add missing Permissions of a new slack app

### DIFF
--- a/docs/_snippets/setup-slack-integration.mdx
+++ b/docs/_snippets/setup-slack-integration.mdx
@@ -49,6 +49,7 @@ Go to the "OAauth & Permissions" page for your newly-created app, and add the fo
 - `chat:write` - Send messages as \<app\>
 - `files:write` - Upload, edit, and delete files as \<app\>
 - `users:read` - View people in a workspace
+- `users:read.email` - View email addresses of people in a workspace
 - `groups:read` - View basic information about private channels that your slack app has been added to
 
 <img


### PR DESCRIPTION
Installing without it makes the following warning apear:
```Sending alerts |                                        | ▄▆█ 0/1 [0%] in 0s (0.0/s, eta: -)2023-02-23 18:13:03 — ERROR — Unable to get Slack user ID from email: The request to the Slack API failed. (url: https://www.slack.com/api/users.lookupByEmail)
The server responded with: {'ok': False, 'error': 'missing_scope', 'needed': 'users:read.email', 'provided': 'channels:join,channels:read,chat:write,files:write,users:read,groups:read,channels:history'}.```