### PR TITLE
ELE-485 remove user DWH query for test result samples

### DIFF
--- a/elementary/monitor/api/report/report.py
+++ b/elementary/monitor/api/report/report.py
@@ -32,7 +32,6 @@ class ReportAPI(APIClient):
         disable_samples: bool = False,
         filter: SelectorFilterSchema = SelectorFilterSchema(),
         env: Optional[str] = None,
-        should_query_dwh_for_samples: bool = True,
     ) -> Tuple[ReportDataSchema, Optional[Exception]]:
         try:
             tests_api = TestsAPI(
@@ -40,7 +39,6 @@ class ReportAPI(APIClient):
                 days_back=days_back,
                 invocations_per_test=test_runs_amount,
                 disable_passed_test_metrics=disable_passed_test_metrics,
-                should_query_dwh_for_samples=should_query_dwh_for_samples,
             )
             models_api = ModelsAPI(dbt_runner=self.dbt_runner)
             sidebar_api = SidebarAPI(dbt_runner=self.dbt_runner)

--- a/elementary/monitor/api/tests/tests.py
+++ b/elementary/monitor/api/tests/tests.py
@@ -38,7 +38,6 @@ class TestsAPI(APIClient):
         invocations_per_test: int = 720,
         metrics_sample_limit: int = 5,
         disable_passed_test_metrics: bool = False,
-        should_query_dwh_for_samples: bool = True,
     ):
         super().__init__(dbt_runner)
         self.tests_fetcher = TestsFetcher(dbt_runner=self.dbt_runner)
@@ -48,7 +47,6 @@ class TestsAPI(APIClient):
             invocations_per_test=invocations_per_test,
             metrics_sample_limit=metrics_sample_limit,
             disable_passed_test_metrics=disable_passed_test_metrics,
-            should_query_dwh_for_samples=should_query_dwh_for_samples,
         )
 
     def _get_test_results_db_rows(
@@ -57,14 +55,12 @@ class TestsAPI(APIClient):
         invocations_per_test: int = 720,
         metrics_sample_limit: int = 5,
         disable_passed_test_metrics: bool = False,
-        should_query_dwh_for_samples: bool = True,
     ) -> List[TestResultDBRowSchema]:
         return self.tests_fetcher.get_all_test_results_db_rows(
             days_back=days_back,
             invocations_per_test=invocations_per_test,
             metrics_sample_limit=metrics_sample_limit,
             disable_passed_test_metrics=disable_passed_test_metrics,
-            should_query_dwh_for_samples=should_query_dwh_for_samples,
         )
 
     def get_test_results_summary(

--- a/elementary/monitor/dbt_project/macros/get_test_results.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_results.sql
@@ -1,4 +1,4 @@
-{%- macro get_test_results(days_back = 7, metrics_sample_limit = 5, invocations_per_test = 720, disable_passed_test_metrics = false, should_query_dwh_for_samples = true) -%}
+{%- macro get_test_results(days_back = 7, metrics_sample_limit = 5, invocations_per_test = 720, disable_passed_test_metrics = false) -%}
     {% set select_test_results %}
         with test_results as (
             {{ elementary_internal.current_tests_run_results_query(days_back=days_back) }}
@@ -63,7 +63,7 @@
                 {% do elementary_tests_allowlist_status.append('pass') %}
             {% endif %}
             {%- if (test_type == 'dbt_test' and status in ['fail', 'warn']) or (test_type != 'dbt_test' and status in elementary_tests_allowlist_status) -%}
-                {% set test_rows_sample = elementary_internal.get_test_rows_sample(test.result_rows, test_result_rows_agate.get(test.id), test_type, test.test_results_query, metrics_sample_limit, should_query_dwh_for_samples) %}
+                {% set test_rows_sample = elementary_internal.get_test_rows_sample(test.result_rows, test_result_rows_agate.get(test.id), test_type, test.test_results_query, metrics_sample_limit) %}
                 {# Dimension anomalies return multiple dimensions for the test rows sample, and needs to be handle differently. #}
                 {# Currently we show only the anomalous for all of the dimensions. #}
                 {% if test.test_sub_type == 'dimension' %}

--- a/elementary/monitor/dbt_project/macros/get_test_rows_sample.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_rows_sample.sql
@@ -26,5 +26,5 @@
         {{ return(result_rows) }}
     {% endif %}
 
-    {% do return(elementary.agate_to_dicts([])) %}
+    {% do return([]) %}
 {%- endmacro -%}

--- a/elementary/monitor/dbt_project/macros/get_test_rows_sample.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_rows_sample.sql
@@ -3,7 +3,7 @@
   legacy_result_rows: elementary_test_results.result_rows
   result_rows_agate: test_result_rows
 #}
-{%- macro get_test_rows_sample(legacy_result_rows, result_rows_agate, test_type, test_query, results_sample_limit=5, should_query_dwh=true) -%}
+{%- macro get_test_rows_sample(legacy_result_rows, result_rows_agate, test_type, test_query, results_sample_limit=5) -%}
     {% set should_limit_sample = test_type == 'dbt_test' %}
 
     {% if legacy_result_rows is defined and legacy_result_rows is not none %}
@@ -26,15 +26,5 @@
         {{ return(result_rows) }}
     {% endif %}
 
-    {% if should_query_dwh %}
-      {% set query %}
-        with test_results as (
-          {{ test_query }}
-        )
-        select * from test_results {% if should_limit_sample %} limit {{ results_sample_limit }} {% endif %}
-      {% endset %}
-      {% do return(elementary.agate_to_dicts(elementary.run_query(query))) %}  
-    {% else %}
-      {% do return(elementary.agate_to_dicts([])) %}
-    {% endif %}
+    {% do return(elementary.agate_to_dicts([])) %}
 {%- endmacro -%}

--- a/elementary/monitor/fetchers/tests/tests.py
+++ b/elementary/monitor/fetchers/tests/tests.py
@@ -19,7 +19,6 @@ class TestsFetcher(FetcherClient):
         invocations_per_test: int = 720,
         metrics_sample_limit: int = 5,
         disable_passed_test_metrics: bool = False,
-        should_query_dwh_for_samples: bool = True,
     ) -> List[TestResultDBRowSchema]:
         run_operation_response = self.dbt_runner.run_operation(
             macro_name="get_test_results",
@@ -28,7 +27,6 @@ class TestsFetcher(FetcherClient):
                 invocations_per_test=invocations_per_test,
                 metrics_sample_limit=metrics_sample_limit,
                 disable_passed_test_metrics=disable_passed_test_metrics,
-                should_query_dwh_for_samples=should_query_dwh_for_samples,
             ),
         )
         test_results = (


### PR DESCRIPTION
Reverting the changes of https://github.com/elementary-data/elementary/pull/736, and removing the backcomp support for fetching test result samples from the user DWH