### PR TITLE
Fixing incorrect group_by flag documentation for slack

### DIFF
--- a/docs/quickstart/send-slack-alerts.mdx
+++ b/docs/quickstart/send-slack-alerts.mdx
@@ -432,7 +432,7 @@ Elementary also supports grouping alerts by table. In this case, a single Slack 
 To group alerts by table:
 
 ```shell
-edr monitor --group_by table
+edr monitor --group-by table
 ```
 
 Grouping can also be configured through the yml files. To set it up globaly for your project, add the configuration to your models in the dbt_project.yml file:  


### PR DESCRIPTION
This PR fixes incorrect documentation about the group_by flag in Slack alerts. CLI takes the flag as `--group-by` instead of `--group_by`.

<img width="636" alt="image" src="https://user-images.githubusercontent.com/13641827/225349690-5f5756e6-d247-4394-afe2-c00719d4c3b7.png">
