### PR TITLE
Don't put "pass"ed test as  warning, with a unit test

### DIFF
--- a/elementary/monitor/data_monitoring/report/slack_report_summary_message_builder.py
+++ b/elementary/monitor/data_monitoring/report/slack_report_summary_message_builder.py
@@ -146,10 +146,12 @@ class SlackReportSummaryMessageBuilder(SlackMessageBuilder):
                 failed_tests_details.extend(
                     self._get_test_result_details_block(test, include_description)
                 )
-            else:
+            elif test.status == "warning":
                 warning_tests_details.extend(
                     self._get_test_result_details_block(test, include_description)
                 )
+            else:  # test status is "pass" i.e. success
+                pass
 
         details_blocks = []
         if failed_tests_details:

--- a/tests/unit/monitor/data_monitoring/report/test_slack_report_summary_message_builder.py
+++ b/tests/unit/monitor/data_monitoring/report/test_slack_report_summary_message_builder.py
@@ -40,7 +40,12 @@ def test_add_details_to_slack_alert_attachments_limit(test_results_summary):
 
     # Over attachments limitation
     message_builder = SlackReportSummaryMessageBuilder()
-    message_builder._add_details_to_slack_alert((test_results_summary * 5)[0:40])
+    nonsuccessful_parts_of_fixture = [
+        x for x in test_results_summary if x.status != "pass"
+    ]
+    message_builder._add_details_to_slack_alert(
+        (nonsuccessful_parts_of_fixture * 50)[0:40]
+    )
     attachments_as_string = json.dumps(
         message_builder.slack_message.get("attachments")[0].get("blocks")
     )
@@ -67,6 +72,21 @@ def test_owners_tags_and_subscribers_of_passed_tests_are_filtered_out(
     assert "Jack" not in attachments_as_string
     assert "subscriber22" not in attachments_as_string
     assert "staging" not in attachments_as_string
+
+
+def test_passed_tests_filtered_out_of_details_view(
+    test_results_summary,
+):
+    # Within attachments limitation
+    message_builder = SlackReportSummaryMessageBuilder()
+    passed_tests_from_fixture = [x for x in test_results_summary if x.status == "pass"]
+    message_builder._add_preview_to_slack_alert(passed_tests_from_fixture)
+    message_builder._add_details_to_slack_alert(passed_tests_from_fixture)
+    attachments_as_string = json.dumps(
+        message_builder.slack_message.get("attachments")[0].get("blocks")
+    )
+    assert "Warning" not in attachments_as_string
+    assert "*table_3* | first_test" not in attachments_as_string
 
 
 @pytest.fixture


### PR DESCRIPTION
re opening to fix git commit mayham. 
Coments from prev CR: 
Or - add a unit test
Idan - make "warning" be in `elif` and the everything else should be skipped