### PR TITLE
Fix config and target directory path docs

### DIFF
--- a/docs/understand-elementary/cli-commands.mdx
+++ b/docs/understand-elementary/cli-commands.mdx
@@ -62,13 +62,13 @@ Here is a list of all the available options:
   The path of the directory in which your `config.yml` file is located. Default is `HOME_DIR/.edr`.
 
 ```shell
---target-path <PATH>
+-c, --config-dir <PATH>
 ```
 
-- **Configuration target directory path**
+- **Target directory path**
   The absolute path where all output files such as logs and reports will be saved. If not configured, the default is ./edr_target.
 ```shell
--c, --config-dir <PATH>
+--target-path <PATH>
 ```
 
 - **Profile target:**


### PR DESCRIPTION
The flags for setting both the config and target paths are the wrong way around.

Correcting the order here.