### PR TITLE
Re-enable feedback buttons

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -16,6 +16,10 @@
       "to": "#FE10B0"
     }
   },
+  "feedback": {
+    "suggestEdit": true,
+    "raiseIssue": true
+  },
   "topbarCtaButton": {
     "name": "Try Elementary cloud",
     "url": "mailto:cloud@elementary-data.com?subject=Tell me about Elementary cloud!&body=I'm interested in learning more about the Elementary cloud private beta. Please send me further details."


### PR DESCRIPTION
We recently updated the configuration schema to enable feedback buttons. This PR re-enables it for Elementary as it was previously

![CleanShot 2023-04-15 at 13 12 14@2x](https://user-images.githubusercontent.com/44352119/232251310-94599634-5e4b-4051-8b53-93341e2b559b.png)
