### PR TITLE
Docs: add pointer from tutorial to doc on tests priorities

### DIFF
--- a/docs/tutorial/adding-elementary-tests.mdx
+++ b/docs/tutorial/adding-elementary-tests.mdx
@@ -110,7 +110,7 @@ We will use the **elementary.column_anomalies** test to monitor the count of cus
               timestamp_column: "signup_date"
 ```
 <Info>
-Notice that we already defined the **timestamp_column** at the model level, so we don't have to define it in the test.
+Notice that we already defined the **timestamp_column** at the model level, so we don't have to define it in the test. [This page](https://docs.elementary-data.com/guides/elementary-tests-configuration) has in-depth details on test priorities.
 </Info>
 </Accordion>
 <br/>


### PR DESCRIPTION
Before: 
<img width="686" alt="image" src="https://user-images.githubusercontent.com/25003091/233007537-90057043-9b90-4d2f-8040-a7bbc9280053.png">

After: 
<img width="686" alt="image" src="https://user-images.githubusercontent.com/25003091/233007607-cd38be72-61c5-4595-be8b-92736827ed5d.png">

The URL points to https://docs.elementary-data.com/guides/elementary-tests-configuration