### PR TITLE
Fix for ELE-699, None default for --group-by

### DIFF
--- a/elementary/monitor/cli.py
+++ b/elementary/monitor/cli.py
@@ -217,7 +217,7 @@ def get_cli_properties() -> dict:
 @click.option(
     "--group-by",
     type=click.Choice(["alert", "table"]),
-    default="alert",
+    default=None,
     help="Whether to group alerts by 'alert' or by 'table'",
 )
 @click.pass_context


### PR DESCRIPTION
To address issue #816 I've set the default value of `--group-by` option to None, since later on when the `Config` is instantiated, the `self.slack_group_alerts_by` gets `alert` as the last non-null value.
https://github.com/elementary-data/elementary/blob/2bc0204ca304f9205bfa6964a41937294e7ec3c8/elementary/config/config.py#L111-L115