### PR TITLE
ELE-740 - paginate upload of source freshness data

### DIFF
--- a/elementary/operations/upload_source_freshness.py
+++ b/elementary/operations/upload_source_freshness.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 import click
+from alive_progress import alive_it
 
 from elementary.clients.dbt.dbt_runner import DbtRunner
 from elementary.config.config import Config
@@ -39,7 +40,9 @@ class UploadSourceFreshnessOperation:
             self.config.profile_target,
         )
         chunk_size = 100
-        for chunk in range(0, len(results), chunk_size):
+        chunk_list = list(range(0, len(results), chunk_size))
+        upload_with_progress_bar = alive_it(chunk_list, title='Uploading source freshness results')
+        for chunk in upload_with_progress_bar:
             results_segment = results[chunk:chunk+chunk_size]
             dbt_runner.run_operation(
                 "elementary_internal.upload_source_freshness",

--- a/elementary/operations/upload_source_freshness.py
+++ b/elementary/operations/upload_source_freshness.py
@@ -38,11 +38,14 @@ class UploadSourceFreshnessOperation:
             self.config.profiles_dir,
             self.config.profile_target,
         )
-        dbt_runner.run_operation(
-            "elementary_internal.upload_source_freshness",
-            macro_args={"results": json.dumps(results)},
-            quiet=True,
-        )
+        chunk_size = 100
+        for chunk in range(0, len(results), chunk_size):
+            results_segment = results[chunk:chunk+chunk_size]
+            dbt_runner.run_operation(
+                "elementary_internal.upload_source_freshness",
+                macro_args={"results": json.dumps(results_segment)},
+                quiet=True,
+            )
 
     def get_target_path(self) -> Path:
         env_target_path = os.getenv("DBT_TARGET_PATH")


### PR DESCRIPTION
This solves issue [ELE-740](https://github.com/elementary-data/elementary/issues/836)

I am not really sure about what the best way to determine the `chunk_size` for the upload of the source data is. What I did:
- Looked up what the `MAX_ARG` for Linux systems is and according to some stackoverflow threads it's generally something between 100k and 200k characters - it's bigger for MacOS (this also finally explains why I wasn't getting the error locally, but it kept appearing in the GH action), but since we are running it in a Github instance and to go on the safe side, it obviously makes sense to go with the lesser value 
- Looking at the `sources.json` file from our project we have:
	- ~ 320k chars
	- ~ 470 sources 
- Using this as a reference the chunk size for each upload segment could be around 140 sources. To go on the super safe side, i determined it to be 100 sources.
I normally don't like the idea of hard coding it. We also could:
- Take the max argument size of the specific system (e.g.:`getconf ARG_MAX` on unix based systems)
- calculate the chunk sizes based on that
but IMO this would let the code hard to read and over engineered.
That said, if you have other suggestions, I'd be happy to hear them.

Then, I am simply running a `for` loop to call the command uploading the sources multiple times. Is there a better way to do this?

**Testing**
I didn't find any testing guidelines for the cli (justo for the dbt-package). What I did to test it, was to install the altered package and run the command on our dbt project. It's working as expected. Let me know how I can better test it.

**Comments**
From what I see the Elementary code isn't over commented, so I also didn't comment the steps in the code.

Please let me know what I could do better or am doing wrong.