### PR TITLE
Update anomaly-sensitivity.mdx

### DIFF
--- a/docs/guides/anomaly-detection-configuration/anomaly-sensitivity.mdx
+++ b/docs/guides/anomaly-detection-configuration/anomaly-sensitivity.mdx
@@ -34,7 +34,7 @@ models:
   - name: this_is_a_model
     tests:
       - elementary.volume_anomalies:
-          anomaly_sensitivity: 3
+          sensitivity: 3
 ```
 
 </RequestExample>


### PR DESCRIPTION
When adding sensitivity on a model level, it throws this keyword error:  `macro 'dbt_macro__test_volume_anomalies' takes no keyword argument 'anomaly_sensitivity'`

It should be `sensitivity` instead of an `anomaly_sensitivity`.