### PR TITLE
Specify encoding style

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 HERE = pathlib.Path(__file__).parent
 
 # The text of the README file.
-README = (HERE / "README.md").read_text()
+README = (HERE / "README.md").read_text(encoding="UTF-8")
 
 ADAPTER_EXTRA_REQUIREMENTS = {
     "snowflake": ["dbt-snowflake>=0.20,<2.0.0"],


### PR DESCRIPTION
Fixes #868 

Specified encoding style=UTF-8 to read README.md file inside setup.py. 