### PR TITLE
ELE-890 workaround for redshift run operation regression - update alerts

### DIFF
--- a/elementary/monitor/dbt_project/macros/alerts/update_sent_alerts.sql
+++ b/elementary/monitor/dbt_project/macros/alerts/update_sent_alerts.sql
@@ -1,10 +1,12 @@
 {% macro update_sent_alerts(alert_ids, sent_at, table_name) %}
-    {% if alert_ids %}
-        {% set update_sent_alerts_query %}
-            UPDATE {{ ref(table_name) }} set suppression_status = 'sent', sent_at = {{ "'{}'".format(sent_at) }}, alert_sent = TRUE
-            WHERE alert_id IN {{ elementary.strings_list_to_tuple(alert_ids) }} and suppression_status = 'pending' and
-                {{ elementary.edr_cast_as_timestamp('detected_at') }} >= {{ get_alerts_time_limit() }}
-        {% endset %}
-        {% do elementary.run_query(update_sent_alerts_query) %}
+    {% if execute %}
+        {% if alert_ids %}
+            {% set update_sent_alerts_query %}
+                UPDATE {{ ref(table_name) }} set suppression_status = 'sent', sent_at = {{ "'{}'".format(sent_at) }}, alert_sent = TRUE
+                WHERE alert_id IN {{ elementary.strings_list_to_tuple(alert_ids) }} and suppression_status = 'pending' and
+                    {{ elementary.edr_cast_as_timestamp('detected_at') }} >= {{ get_alerts_time_limit() }}
+            {% endset %}
+            {% do elementary.run_query(update_sent_alerts_query) %}
+        {% endif %}
     {% endif %}
 {% endmacro %}

--- a/elementary/monitor/dbt_project/macros/alerts/update_skipped_alerts.sql
+++ b/elementary/monitor/dbt_project/macros/alerts/update_skipped_alerts.sql
@@ -1,10 +1,12 @@
 {% macro update_skipped_alerts(alert_ids, table_name) %}
-    {% if alert_ids %}
-        {% set update_skipped_alerts_query %}
-            UPDATE {{ ref(table_name) }} set suppression_status = 'skipped'
-            WHERE alert_id IN {{ elementary.strings_list_to_tuple(alert_ids) }} and suppression_status = 'pending' and
-                {{ elementary.edr_cast_as_timestamp('detected_at') }} >= {{ get_alerts_time_limit() }}
-        {% endset %}
-        {% do elementary.run_query(update_skipped_alerts_query) %}
+    {% if execute %}
+        {% if alert_ids %}
+            {% set update_skipped_alerts_query %}
+                UPDATE {{ ref(table_name) }} set suppression_status = 'skipped'
+                WHERE alert_id IN {{ elementary.strings_list_to_tuple(alert_ids) }} and suppression_status = 'pending' and
+                    {{ elementary.edr_cast_as_timestamp('detected_at') }} >= {{ get_alerts_time_limit() }}
+            {% endset %}
+            {% do elementary.run_query(update_skipped_alerts_query) %}
+        {% endif %}
     {% endif %}
 {% endmacro %}

--- a/elementary/monitor/dbt_project/macros/materializations/nothing.sql
+++ b/elementary/monitor/dbt_project/macros/materializations/nothing.sql
@@ -1,0 +1,10 @@
+{# Materialization that does not create any table at the end of it runs #}
+{# It is used when we can't update tables using run-operation so we workaround and run a model that updates an other table for example #}
+{% materialization nothing, default -%}
+  {# The main statement execute the model, but does not create any table / view on the DWH #}
+  {% call statement('main') -%}
+    {{ sql }}
+  {%- endcall %}
+  {{ adapter.commit() }}
+  {{ return({'relations': []}) }}
+{% endmaterialization %}

--- a/elementary/monitor/dbt_project/models/update_alerts/update_sent_alerts.sql
+++ b/elementary/monitor/dbt_project/models/update_alerts/update_sent_alerts.sql
@@ -1,3 +1,9 @@
+{{
+  config(
+    materialized = 'nothing',
+    )
+}}
+
 -- depends_on: {{ ref('alerts') }}
 -- depends_on: {{ ref('alerts_models') }}
 -- depends_on: {{ ref('alerts_source_freshness') }}

--- a/elementary/monitor/dbt_project/models/update_alerts/update_sent_alerts.sql
+++ b/elementary/monitor/dbt_project/models/update_alerts/update_sent_alerts.sql
@@ -1,0 +1,6 @@
+-- depends_on: {{ ref('alerts') }}
+-- depends_on: {{ ref('alerts_models') }}
+-- depends_on: {{ ref('alerts_source_freshness') }}
+
+{% do update_sent_alerts(var("alert_ids"), var("sent_at"), var("table_name")) %}
+{{ elementary.no_results_query() }}

--- a/elementary/monitor/dbt_project/models/update_alerts/update_skipped_alerts.sql
+++ b/elementary/monitor/dbt_project/models/update_alerts/update_skipped_alerts.sql
@@ -1,3 +1,9 @@
+{{
+  config(
+    materialized = 'nothing',
+    )
+}}
+
 -- depends_on: {{ ref('alerts') }}
 -- depends_on: {{ ref('alerts_models') }}
 -- depends_on: {{ ref('alerts_source_freshness') }}

--- a/elementary/monitor/dbt_project/models/update_alerts/update_skipped_alerts.sql
+++ b/elementary/monitor/dbt_project/models/update_alerts/update_skipped_alerts.sql
@@ -1,0 +1,6 @@
+-- depends_on: {{ ref('alerts') }}
+-- depends_on: {{ ref('alerts_models') }}
+-- depends_on: {{ ref('alerts_source_freshness') }}
+
+{% do update_skipped_alerts(var("alert_ids"), var("table_name")) %}
+{{ elementary.no_results_query() }}

--- a/elementary/monitor/fetchers/alerts/alerts.py
+++ b/elementary/monitor/fetchers/alerts/alerts.py
@@ -32,15 +32,15 @@ class AlertsFetcher(FetcherClient):
     ):
         alert_ids = [alert.id for alert in alerts_to_skip]
         alert_ids_chunks = self._split_list_to_chunks(alert_ids)
+        logger.info(f'Update skipped alerts at "{table_name}"')
         for alert_ids_chunk in alert_ids_chunks:
-            self.dbt_runner.run_operation(
-                macro_name="update_skipped_alerts",
-                macro_args={
+            self.dbt_runner.run(
+                select="update_alerts.update_skipped_alerts",
+                vars={
                     "alert_ids": alert_ids_chunk,
                     "table_name": table_name,
                 },
-                capture_output=False,
-                should_log=False,
+                quiet=True,
             )
 
     def query_pending_test_alerts(
@@ -138,16 +138,16 @@ class AlertsFetcher(FetcherClient):
 
     def update_sent_alerts(self, alert_ids: List[str], table_name: str) -> None:
         alert_ids_chunks = self._split_list_to_chunks(alert_ids)
+        logger.info(f'Update sent alerts at "{table_name}"')
         for alert_ids_chunk in alert_ids_chunks:
-            self.dbt_runner.run_operation(
-                macro_name="update_sent_alerts",
-                macro_args={
+            self.dbt_runner.run(
+                select="update_alerts.update_sent_alerts",
+                vars={
                     "alert_ids": alert_ids_chunk,
                     "sent_at": get_now_utc_str(),
                     "table_name": table_name,
                 },
-                capture_output=False,
-                should_log=False,
+                quiet=True,
             )
 
     @staticmethod

--- a/tests/unit/monitor/fetchers/test_alerts_fetcher.py
+++ b/tests/unit/monitor/fetchers/test_alerts_fetcher.py
@@ -35,9 +35,10 @@ def test_update_sent_alerts(
     calls_args = mock_subprocess_run.call_args_list
     for call_args in calls_args:
         # Test that update_sent_alerts has been called with alert_ids as arguments.
-        assert call_args[0][0][1] == "run-operation"
-        assert call_args[0][0][2] == "update_sent_alerts"
-        assert "alert_ids" in json.loads(call_args[0][0][4])
+        assert call_args[0][0][1] == "run"
+        assert call_args[0][0][2] == "-s"
+        assert call_args[0][0][3] == "update_alerts.update_sent_alerts"
+        assert "alert_ids" in json.loads(call_args[0][0][9])
 
 
 @mock.patch("subprocess.run")
@@ -56,9 +57,10 @@ def test_skip_alerts(mock_subprocess_run, alerts_fetcher_mock: MockAlertsFetcher
     calls_args = mock_subprocess_run.call_args_list
     for call_args in calls_args:
         # Test that update_skipped_alerts has been called with alert_ids as arguments.
-        assert call_args[0][0][1] == "run-operation"
-        assert call_args[0][0][2] == "update_skipped_alerts"
-        assert "alert_ids" in json.loads(call_args[0][0][4])
+        assert call_args[0][0][1] == "run"
+        assert call_args[0][0][2] == "-s"
+        assert call_args[0][0][3] == "update_alerts.update_skipped_alerts"
+        assert "alert_ids" in json.loads(call_args[0][0][9])
 
 
 @pytest.fixture

--- a/tests/unit/monitor/fetchers/test_alerts_fetcher.py
+++ b/tests/unit/monitor/fetchers/test_alerts_fetcher.py
@@ -38,7 +38,10 @@ def test_update_sent_alerts(
         assert call_args[0][0][1] == "run"
         assert call_args[0][0][2] == "-s"
         assert call_args[0][0][3] == "update_alerts.update_sent_alerts"
-        assert "alert_ids" in json.loads(call_args[0][0][9])
+        dbt_run_params = json.loads(call_args[0][0][9])
+        assert "alert_ids" in dbt_run_params
+        assert "table_name" in dbt_run_params
+        assert "sent_at" in dbt_run_params
 
 
 @mock.patch("subprocess.run")
@@ -60,7 +63,9 @@ def test_skip_alerts(mock_subprocess_run, alerts_fetcher_mock: MockAlertsFetcher
         assert call_args[0][0][1] == "run"
         assert call_args[0][0][2] == "-s"
         assert call_args[0][0][3] == "update_alerts.update_skipped_alerts"
-        assert "alert_ids" in json.loads(call_args[0][0][9])
+        dbt_run_params = json.loads(call_args[0][0][9])
+        assert "alert_ids" in dbt_run_params
+        assert "table_name" in dbt_run_params
 
 
 @pytest.fixture


### PR DESCRIPTION
Due to a bug with dbt-redshift 1.5.0 and above, we can't update tables using dbt run-operation.
In this PR I am replacing the use of dbt run-operation to update our alerts status, with dbt run (models).