### PR TITLE
Fix docker build pip version (causing package installation issues)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
     /var/tmp/*
 
 COPY . /app
+RUN pip install --upgrade pip
 RUN pip install --no-cache-dir "/app[all]"
 
 ENTRYPOINT ["edr"]


### PR DESCRIPTION
I can just run `--upgrade pip` but I feel like setting it to a specific version is a better practice 