### PR TITLE
Depends on macro: use enriched_exposures if needed

### DIFF
--- a/elementary/monitor/dbt_project/macros/get_nodes_depends_on_nodes.sql
+++ b/elementary/monitor/dbt_project/macros/get_nodes_depends_on_nodes.sql
@@ -1,4 +1,8 @@
 {% macro get_nodes_depends_on_nodes(exclude_elementary=false) %}
+    {% set exposures_relation = ref('elementary_cli', 'enriched_exposures') %}
+    {% if not elementary.relation_exists(exposures_relation) %}
+        {% set exposures_relation = ref('elementary', 'dbt_exposures') %}
+    {% endif %}
     {% set models_depends_on_nodes_query %}
         with dbt_models as (
             select * from {{ ref('elementary', 'dbt_models') }}
@@ -12,14 +16,14 @@
         ),
 
         dbt_exposures as (
-            select * from {{ ref('elementary', 'dbt_exposures') }}
+            select * from {{ exposures_relation }}
         )
 
         select
             unique_id,
             depends_on_nodes,
             'model' as type
-        from dbt_models 
+        from dbt_models
         union all
         select
             unique_id,
@@ -31,7 +35,7 @@
             unique_id,
             depends_on_nodes,
             'exposure' as type
-        from dbt_exposures   
+        from dbt_exposures
     {% endset %}
     {% set models_depends_on_agate = run_query(models_depends_on_nodes_query) %}
     {% do return(elementary.agate_to_dicts(models_depends_on_agate)) %}


### PR DESCRIPTION
Ensure that exposures from `elementary_exposures` are included in node dependencies when possible
