### PR TITLE
Backward compatibility for missing `raw_queries`

### DIFF
--- a/elementary/monitor/dbt_project/models/enriched_exposures/enriched_exposures.sql
+++ b/elementary/monitor/dbt_project/models/enriched_exposures/enriched_exposures.sql
@@ -6,14 +6,25 @@ config(
 )
 }}
 
-with dbt_exposures as (
-select * from {{ ref('dbt_exposures') }}
-),
-
-elementary_exposures as (
-select * from {{ ref('elementary_cli', 'elementary_exposures') }}
-)
-
-{# Union without duplicates where elementary_exposures has prio #}
-select * from dbt_exposures where dbt_exposures.unique_id not in (select elementary_exposures.unique_id from elementary_exposures)
-{{ elementary.sql_union_distinct() }} select * from elementary_exposures
+select
+    COALESCE(ee.unique_id, de.unique_id) as unique_id,
+    COALESCE(ee.name, de.name) as name,
+    COALESCE(ee.maturity, de.maturity) as maturity,
+    COALESCE(ee.type, de.type) as type,
+    COALESCE(ee.owner_email, de.owner_email) as owner_email,
+    COALESCE(ee.owner_name, de.owner_name) as owner_name,
+    COALESCE(ee.url, de.url) as url,
+    COALESCE(ee.depends_on_macros, de.depends_on_macros) as depends_on_macros,
+    COALESCE(ee.depends_on_nodes, de.depends_on_nodes) as depends_on_nodes,
+    COALESCE(ee.description, de.description) as description,
+    COALESCE(ee.tags, de.tags) as tags,
+    COALESCE(ee.meta, de.meta) as meta,
+    COALESCE(ee.package_name, de.package_name) as package_name,
+    COALESCE(ee.original_path, de.original_path) as original_path,
+    COALESCE(ee.path, de.path) as path,
+    COALESCE(ee.generated_at, de.generated_at) as generated_at,
+    COALESCE(ee.metadata_hash, de.metadata_hash) as metadata_hash,
+    COALESCE(ee.label, de.label) as label,
+    ee.raw_queries as raw_queries
+from
+    {{ ref('dbt_exposures') }} de full join {{ ref('elementary_cli', 'elementary_exposures') }} ee on ee.unique_id = de.unique_id


### PR DESCRIPTION
Ensure that `enriched_exposures` work even with older `dbt_exposures`
