### PR TITLE
Ensure backwards compatability for depends_on_columns

### DIFF
--- a/elementary/monitor/dbt_project/macros/get_exposures.sql
+++ b/elementary/monitor/dbt_project/macros/get_exposures.sql
@@ -5,6 +5,7 @@
     {% endif %}
     {% set label_column_exists = elementary.column_exists_in_relation(exposures_relation, 'label') %}
     {% set raw_queries_column_exists = elementary.column_exists_in_relation(exposures_relation, 'raw_queries') %}
+    {% set depends_on_columns_column_exists = elementary.column_exists_in_relation(exposures_relation, 'depends_on_columns') %}
     {%- if elementary.relation_exists(exposures_relation) -%}
         --{# TODO: should we group by #}
         {% set get_exposures_query %}
@@ -26,10 +27,16 @@
                   meta,
                   original_path as full_path,
                   {% if raw_queries_column_exists %}
-                    raw_queries
+                    raw_queries,
                   {% else %}
-                    NULL as raw_queries
+                    NULL as raw_queries,
                   {% endif %}
+                  {% if depends_on_columns_column_exists %}
+                    depends_on_columns
+                  {% else %}
+                    NULL as depends_on_columns
+                  {% endif %}
+
                 from {{ exposures_relation }}
               )
 

--- a/elementary/monitor/dbt_project/macros/get_nodes_depends_on_nodes.sql
+++ b/elementary/monitor/dbt_project/macros/get_nodes_depends_on_nodes.sql
@@ -5,18 +5,18 @@
     {% endif %}
     {% set models_depends_on_nodes_query %}
         with dbt_models as (
-            select * from {{ ref('elementary', 'dbt_models') }}
+            select unique_id, depends_on_nodes from {{ ref('elementary', 'dbt_models') }}
             {% if exclude_elementary %}
               where package_name != 'elementary'
             {% endif %}
         ),
 
         dbt_sources as (
-            select * from {{ ref('elementary', 'dbt_sources') }}
+            select unique_id from {{ ref('elementary', 'dbt_sources') }}
         ),
 
         dbt_exposures as (
-            select * from {{ exposures_relation }}
+            select unique_id, depends_on_nodes from {{ exposures_relation }}
         )
 
         select

--- a/elementary/monitor/dbt_project/models/enriched_exposures/enriched_exposures.sql
+++ b/elementary/monitor/dbt_project/models/enriched_exposures/enriched_exposures.sql
@@ -6,6 +6,9 @@ config(
 )
 }}
 
+{% set dbt_exposures_relation = ref('dbt_exposures') %}
+{% set depends_on_columns_column_exists = elementary.column_exists_in_relation(dbt_exposures_relation, 'depends_on_columns') %}
+
 select
     COALESCE(ee.unique_id, de.unique_id) as unique_id,
     COALESCE(ee.name, de.name) as name,
@@ -26,6 +29,10 @@ select
     COALESCE(ee.metadata_hash, de.metadata_hash) as metadata_hash,
     COALESCE(ee.label, de.label) as label,
     COALESCE(ee.raw_queries, de.raw_queries) as raw_queries,
+{% if depends_on_columns_column_exists %}
     COALESCE(ee.depends_on_columns, de.depends_on_columns) as depends_on_columns
+{% else %}
+    ee.depends_on_columns as depends_on_columns
+{% endif %}
 from
-    {{ ref('dbt_exposures') }} de full join {{ ref('elementary_cli', 'elementary_exposures') }} ee on ee.unique_id = de.unique_id
+    {{ dbt_exposures_relation }} de full join {{ ref('elementary_cli', 'elementary_exposures') }} ee on ee.unique_id = de.unique_id

--- a/elementary/monitor/dbt_project/packages.yml
+++ b/elementary/monitor/dbt_project/packages.yml
@@ -1,10 +1,10 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: [">=0.8.0", "<0.9.0"]
-  - package: elementary-data/elementary
-    version: 0.13.0
+  # - package: elementary-data/elementary
+  #   version: 0.13.0
 
   #  NOTE - for unreleased CLI versions we often need to update the package version to a commit hash (please leave this
   #  commented, so it will be easy to access)
-#   - git: https://github.com/elementary-data/dbt-data-reliability.git
-#     revision: 017066cd2f150670ea33fd3ef348740e3a2a4e8d
+  - git: https://github.com/elementary-data/dbt-data-reliability.git
+    revision: 18091636a65790217714833963cd612dfc1a3d1c


### PR DESCRIPTION
Ensure that `edr` doesn't fail with older versions without `depends_on_columns`
