### PR TITLE
Chunk calls to DBT based on string length

### DIFF
--- a/elementary/operations/upload_source_freshness.py
+++ b/elementary/operations/upload_source_freshness.py
@@ -12,8 +12,8 @@ from elementary.config.config import Config
 from elementary.monitor import dbt_project_utils
 from elementary.utils.ordered_yaml import OrderedYaml
 
-
 MAX_SERIALISED_CHARACTER_LENGTH = 90_000
+
 
 class UploadSourceFreshnessOperation:
     def __init__(self, config: Config):


### PR DESCRIPTION
Fixes issue https://github.com/elementary-data/elementary/issues/1353

## Bug

In some scenarios the argument list Elementary calls DBT with when uploading source freshness exceeds the limit of the operating system. 

This is because the chunking of calls to DBT is currently based on the number of sources and not the length of the arguments. So some combination of sources results in longer argument lists than others.

This PR changes the chunking to use the character length and adds a buffer to allow for a bit of variation. 

## Testing

I've tested this locally by patching elementary in our deployment and confirming the results are uploaded.

