### PR TITLE
move cloud and test dependencies to "extras"

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-parametrization>=2022.2.1
 pre-commit
 mypy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,16 +21,15 @@ requests = ">=2.28.1,<3.0.0"
 beautifulsoup4 = "<5.0.0"
 ratelimit = "*"
 posthog = "<3.0.0"
-boto3 = "<2.0.0"
-google-cloud-storage = "<3.0.0"
+boto3 = {version = "<2.0.0", optional = true}
+google-cloud-storage = {version = "<3.0.0", optional = true}
 "ruamel.yaml" = "<1.0.0"
 alive-progress = "<=2.3.1"
 slack-sdk = ">=3.20.1,<4.0.0"
-pytest-parametrization = ">=2022.2.1"
 pydantic = "<2.0"
 networkx = ">=2.3,<3"
 packaging = ">=20.9,<=23.1"
-azure-storage-blob = ">=12.11.0"
+azure-storage-blob = {version = ">=12.11.0", optional = true}
 
 dbt-snowflake = {version = ">=0.20,<2.0.0", optional = true}
 dbt-bigquery = {version = ">=0.20,<2.0.0", optional = true}
@@ -48,7 +47,10 @@ postgres = ["dbt-postgres"]
 databricks = ["dbt-databricks"]
 spark = ["dbt-spark"]
 athena = ["dbt-athena-community"]
-all = ["dbt-snowflake", "dbt-bigquery", "dbt-redshift", "dbt-postgres", "dbt-databricks", "dbt-spark"]
+aws = ["boto3"]
+azure = ["azure-storage-blob"]
+gcs = ["google-cloud-storage"]
+all = ["aws", "azure", "gcs", "dbt-snowflake", "dbt-bigquery", "dbt-redshift", "dbt-postgres", "dbt-databricks", "dbt-spark"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Most downstream users are not on multiple cloud providers, nor do they need to run the tests.  Allowing the option to select only what they need simplifies downstream dependency resolutions and prevents conflicts.

(I went with the dev- pattern tests instead of poetry groups, as the CONTRIBUTING instructions pointed towards using pip/requirements and not mandating poetry directly.)