### PR TITLE
explicit exec info

### DIFF
--- a/elementary/monitor/data_monitoring/report/data_monitoring_report.py
+++ b/elementary/monitor/data_monitoring/report/data_monitoring_report.py
@@ -127,7 +127,7 @@ class DataMonitoringReport(DataMonitoring):
         if error:
             logger.exception(
                 f"Could not generate the report - Error: {error}\nPlease reach out to our community for help with this issue.",
-                exc_info=(type(error), error, error.__traceback__),
+                exc_info=error,
             )
             self.success = False
 

--- a/elementary/monitor/data_monitoring/report/data_monitoring_report.py
+++ b/elementary/monitor/data_monitoring/report/data_monitoring_report.py
@@ -126,7 +126,8 @@ class DataMonitoringReport(DataMonitoring):
         self._add_report_tracking(report_data, error)
         if error:
             logger.exception(
-                f"Could not generate the report - Error: {error}\nPlease reach out to our community for help with this issue."
+                f"Could not generate the report - Error: {error}\nPlease reach out to our community for help with this issue.",
+                exc_info=(type(error), error, error.__traceback__),
             )
             self.success = False
 


### PR DESCRIPTION
Sometimes we do not get the exc info in the logs (seen it in the community a lot lately, [example](https://elementary-community.slack.com/archives/C02CTC89LAX/p1704206725106879)), this should resolve this