### PR TITLE
Corrected the JOIN condition in 'enriched_exposures' model.

### DIFF
--- a/elementary/monitor/dbt_project/models/enriched_exposures/enriched_exposures.sql
+++ b/elementary/monitor/dbt_project/models/enriched_exposures/enriched_exposures.sql
@@ -35,4 +35,4 @@ select
     ee.depends_on_columns as depends_on_columns
 {% endif %}
 from
-    {{ dbt_exposures_relation }} de full join {{ ref('elementary_cli', 'elementary_exposures') }} ee on ee.unique_id = de.unique_id
+    {{ dbt_exposures_relation }} de full join {{ ref('elementary_cli', 'elementary_exposures') }} ee on ee.name = de.name


### PR DESCRIPTION
The 'unique_id' is generated differently in 'dbt_exposures' (by dbt), and in 'elementary_exposures' (by us). Therefore, we cannot rely on it as the ID. Instead, we use the exposures' names which is consistent.