### PR TITLE
fix file path when uploading to Azure Blob Storage

### DIFF
--- a/elementary/clients/azure/client.py
+++ b/elementary/clients/azure/client.py
@@ -29,7 +29,7 @@ class AzureClient:
         self, local_html_file_path: str, remote_bucket_file_path: Optional[str] = None
     ) -> Tuple[bool, Optional[str]]:
         report_filename = (
-            bucket_path.basename(remote_bucket_file_path)
+            remote_bucket_file_path
             if remote_bucket_file_path
             else path.basename(local_html_file_path)
         )


### PR DESCRIPTION
Hello Elementary team,

I encountered an issue while sending my report to Azure Blob Storage. I noticed that when providing the argument '--bucket-file-path' Elementary only keeps the filename and gets rid of the folders. For example: `test/elementary/elementary_report.html` becomes `elementary_report.html`.

I found out that we were using the `basename` method to only keep the base name.
I propose this simple modification to keep the full path provided by the user when sending the report to Azure. This issue might also be happening on GCS or S3, I haven't tested it on these platforms.

Thanks

Samir