### PR TITLE
Add project-name and env to slack notification

### DIFF
--- a/elementary/config/config.py
+++ b/elementary/config/config.py
@@ -67,6 +67,7 @@ class Config:
         teams_webhook: Optional[str] = None,
         env: str = "dev",
         run_dbt_deps_if_needed: Optional[bool] = None,
+        project_name: Optional[str] = None,
     ):
         self.config_dir = config_dir
         self.profiles_dir = profiles_dir
@@ -74,6 +75,7 @@ class Config:
         self.profile_target = profile_target
         self.project_profile_target = project_profile_target
         self.env = env
+        self.project_name = project_name
 
         # Additional env vars supplied to dbt invocations
         self.env_vars = dict()

--- a/elementary/monitor/cli.py
+++ b/elementary/monitor/cli.py
@@ -684,6 +684,7 @@ def send_report(
         gcs_timeout_limit=gcs_timeout_limit,
         report_url=report_url,
         env=env,
+        project_name=project_name,
     )
     anonymous_tracking = AnonymousCommandLineTracking(config)
     anonymous_tracking.set_env("use_select", bool(select))

--- a/elementary/monitor/data_monitoring/report/data_monitoring_report.py
+++ b/elementary/monitor/data_monitoring/report/data_monitoring_report.py
@@ -299,6 +299,8 @@ class DataMonitoringReport(DataMonitoring):
                     include_description=include_description,
                     filter=self.selector_filter.to_selector_filter_schema(),
                     days_back=days_back,
+                    env=self.config.env,
+                    project_name=self.config.project_name,
                 ),
             )
         else:

--- a/elementary/monitor/data_monitoring/report/slack_report_summary_message_builder.py
+++ b/elementary/monitor/data_monitoring/report/slack_report_summary_message_builder.py
@@ -16,11 +16,13 @@ class SlackReportSummaryMessageBuilder(SlackMessageBuilder):
         self,
         test_results: List[TestResultSummarySchema],
         days_back: int,
+        env: str,
         bucket_website_url: Optional[str] = None,
         filter: SelectorFilterSchema = SelectorFilterSchema(),
         include_description: bool = False,
+        project_name: Optional[str] = None,
     ) -> SlackMessageSchema:
-        self.add_title_to_slack_alert()
+        self.add_title_to_slack_alert(env, project_name)
         self.add_preview_to_slack_alert(
             test_results,
             days_back=days_back,
@@ -34,9 +36,12 @@ class SlackReportSummaryMessageBuilder(SlackMessageBuilder):
         )
         return super().get_slack_message()
 
-    def add_title_to_slack_alert(self):
+    def add_title_to_slack_alert(self, env: str, project_name: Optional[str] = None):
+        _project_name = f"for the {project_name} " if project_name else ""
         title_blocks = [
-            self.create_header_block(":mag: Monitoring summary"),
+            self.create_header_block(
+                f":mag: Monitoring summary {_project_name}({env})"
+            ),
             self.create_divider_block(),
         ]
         self._add_always_displayed_blocks(title_blocks)

--- a/elementary/monitor/data_monitoring/report/slack_report_summary_message_builder.py
+++ b/elementary/monitor/data_monitoring/report/slack_report_summary_message_builder.py
@@ -37,10 +37,10 @@ class SlackReportSummaryMessageBuilder(SlackMessageBuilder):
         return super().get_slack_message()
 
     def add_title_to_slack_alert(self, env: str, project_name: Optional[str] = None):
-        _project_name = f"for the {project_name} " if project_name else ""
+        context = f"- {project_name} ({env})" if project_name else f"({env})"
         title_blocks = [
             self.create_header_block(
-                f":mag: Monitoring summary {_project_name}({env})"
+                f":mag: Monitoring summary {context}"
             ),
             self.create_divider_block(),
         ]


### PR DESCRIPTION
For consistency with a report and for better visibility in slack notification, header is now extended by environment and project name(if provided via --project-name argument) like so:

- without --project-name
   ![image](https://github.com/elementary-data/elementary/assets/67253952/2c5e2380-695d-4ca0-b440-b98adedf8080)

- with --project-name
   ![image](https://github.com/elementary-data/elementary/assets/67253952/a90e214f-40a3-41ed-a80e-91f28e1da0b3)


Closes #1496 