### PR TITLE
Loosen the version of Packaging library for elementary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ pytest-parametrization = ">=2022.2.1"
 
 pydantic = "<3.0"
 networkx = ">=2.3,<3"
-packaging = ">=20.9,<=23.1"
+packaging = ">=20.9,<=24.0"
 azure-storage-blob = ">=12.11.0"
 pymsteams = ">=0.2.2,<1.0.0"
 pandas = ">=2.0.0"


### PR DESCRIPTION
## Purpose

When installing elementary on Amazon MWAA v2.7.2, I get the version incompatibility issue because the constraint file requires `packaging==23.2` and the current packing version in elementary is `>=20.9,<=23.1`.

Also, starting from MWAA 2.8 and above, the packaging library uses `24.0` version. So, it's future proof to loosen the dependency to `24.0` in elementary.

Ref:
https://raw.githubusercontent.com/apache/airflow/constraints-2.7.2/constraints-3.10.txt