### PR TITLE
Set `--project-dir` as working directory.

### DIFF
--- a/elementary/clients/dbt/dbt_runner.py
+++ b/elementary/clients/dbt/dbt_runner.py
@@ -90,6 +90,7 @@ class DbtRunner(BaseDbtRunner):
                 check=self.raise_on_failure,
                 capture_output=(capture_output or quiet),
                 env=self._get_command_env(),
+                cwd=self.project_dir,
             )
         except subprocess.CalledProcessError as err:
             logs = list(parse_dbt_output(err.output.decode())) if err.output else []


### PR DESCRIPTION
dbt creates `dbt_packages` in the working directory rather than in `--project-dir`. This ensure that it creates it in the right place.