### PR TITLE
add package-lock needed for dbt 1.8 in read-only deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ var/
 logs/
 .venv
 poetry.lock
-package-lock.yml
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/elementary/monitor/dbt_project/package-lock.yml
+++ b/elementary/monitor/dbt_project/package-lock.yml
@@ -1,0 +1,6 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 0.8.6
+  - package: elementary-data/elementary
+    version: 0.16.0
+sha1_hash: 5b34f4e4c6c0165577a05f58c6dff27e4b42444e


### PR DESCRIPTION
When elementary is installed on a docker image in a read-only folder, dbt deps are run and that will generate a packages-lock file. The way to solve the packages issue is to include the lock file in the project.  This PR will address this issue. The [issue here](https://github.com/elementary-data/elementary/issues/1584) is similar as it is related to running `dbt deps` in a read-only folder. 

With this change, edr commands can be run as follows to address both issues.
```
               mkdir /tmp/elementary
                export DBT_TARGET_PATH=/tmp/elementary &&
                export DBT_PACKAGES_FOLDER=/tmp/elementary &&
                edr send-report --days-back 60
```

