### PR TITLE
numpy restriction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ packaging = ">=20.9,<=24.0"
 azure-storage-blob = ">=12.11.0"
 pymsteams = ">=0.2.2,<1.0.0"
 pandas = ">=2.0.0"
+numpy = "<2.0.0"
 tabulate = ">= 0.9.0"
 
 dbt-snowflake = {version = ">=0.20,<2.0.0", optional = true}


### PR DESCRIPTION
updated `numpy` requirement version to support Python>=3.10<!-- pylon-ticket-id: 1f2038c6-5011-4c37-9926-12db76969340 -->