### PR TITLE
GH-1699 Setup multi-platform Docker images to support both x86 and arm architectures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,12 @@ jobs:
       - name: Checkout Elementary
         uses: actions/checkout@v3
 
+      - name: Set up QEMU for multi-platform support
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx for multi-platform support
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the container registry
         uses: docker/login-action@v2
         with:
@@ -66,6 +72,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
**Introduction**

Support multiple platforms (architectures) for the Docker container in the Github Action release.

In this way open-source users can run the Docker image on both `x86` and `arm` architectures. Rational behind this is because more cloud providers are supporting `arm` architectures with provide a better price-performance.

Closed GH-1699

**Supporting documentation**

- https://github.com/marketplace/actions/build-and-push-docker-images
- https://docs.docker.com/build/ci/github-actions/multi-platform/