### PR TITLE
add setup for dbt supported testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+# **what?**
+# Run tests for <this package> against supported adapters
+
+# **why?**
+# To ensure that <this package> works as expected with all supported adapters
+
+# **when?**
+# On every PR, and every push to main and when manually triggered
+
+name: Package Integration Tests
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+    workflow_dispatch:
+
+jobs:
+  run-tests:
+      uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox.yml@v1
+      # this just tests with postgres so no variables need to be passed through.
+      # When it's time to add more adapters you will need to pass through inputs for
+      # the other adapters as shown in the below example for redshift
+    #   with:
+    #     # redshift
+    #     REDSHIFT_HOST: ${{ vars.REDSHIFT_HOST }}
+    #     REDSHIFT_USER: ${{ vars.REDSHIFT_USER }}
+    #     REDSHIFT_DATABASE: ${{ vars.REDSHIFT_DATABASE }}
+    #     REDSHIFT_SCHEMA: "integration_tests_redshift_${{ github.run_number }}"
+    #     REDSHIFT_PORT: ${{ vars.REDSHIFT_PORT }}
+    #   secrets:
+    #     DBT_ENV_SECRET_REDSHIFT_PASS: ${{ secrets.DBT_ENV_SECRET_REDSHIFT_PASS }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ pytest
 pytest-parametrization>=2022.2.1
 pre-commit
 mypy
+tox
 
 # MyPy stubs
 types-requests

--- a/elementary/monitor/dbt_project/dbt_project.yml
+++ b/elementary/monitor/dbt_project/dbt_project.yml
@@ -6,7 +6,7 @@ version: "1.0.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.
-profile: "elementary"
+profile: "integration_tests"
 
 # These configurations specify where dbt should look for different types of files.
 # The `model-paths` config, for example, states that models in this project can be

--- a/integration_tests/profiles.yml
+++ b/integration_tests/profiles.yml
@@ -1,0 +1,111 @@
+integration_tests:
+  target: postgres
+  outputs:
+    postgres:
+      type: "postgres"
+      host: "{{ env_var('POSTGRES_HOST') }}"
+      user: "{{ env_var('POSTGRES_USER') }}"
+      pass: "{{ env_var('DBT_ENV_SECRET_POSTGRES_PASS') }}"
+      port: "{{ env_var('POSTGRES_PORT') | as_number }}"
+      dbname: "{{ env_var('POSTGRES_DATABASE') }}"
+      schema: "{{ env_var('POSTGRES_SCHEMA') }}"
+      threads: 5
+
+    redshift:
+      type: "redshift"
+      host: "{{ env_var('REDSHIFT_HOST') }}"
+      user: "{{ env_var('REDSHIFT_USER') }}"
+      pass: "{{ env_var('DBT_ENV_SECRET_REDSHIFT_PASS') }}"
+      dbname: "{{ env_var('REDSHIFT_DATABASE') }}"
+      port: "{{ env_var('REDSHIFT_PORT') | as_number }}"
+      schema: "{{ env_var('REDSHIFT_SCHEMA') }}"
+      threads: 5
+
+    bigquery:
+      type: "bigquery"
+      method: "service-account-json"
+      project: "{{ env_var('BIGQUERY_PROJECT') }}"
+      dataset: "{{ env_var('BIGQUERY_SCHEMA') }}"
+      threads: 10
+      keyfile_json:
+        "{{ env_var('BIGQUERY_KEYFILE_JSON') | as_native}}"
+      job_retries: 3
+
+    snowflake:
+      type: "snowflake"
+      account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
+      user: "{{ env_var('SNOWFLAKE_USER') }}"
+      password: "{{ env_var('DBT_ENV_SECRET_SNOWFLAKE_PASS') }}"
+      role: "{{ env_var('SNOWFLAKE_ROLE') }}"
+      database: "{{ env_var('SNOWFLAKE_DATABASE') }}"
+      warehouse: "{{ env_var('SNOWFLAKE_WAREHOUSE') }}"
+      schema: "{{ env_var('SNOWFLAKE_SCHEMA') }}"
+      threads: 10
+
+    trino:
+      type: "trino"
+      method: "{{ env_var('TRINO_METHOD') }}"
+      user: "{{ env_var('TRINO_USER') }}"
+      password: "{{ env_var('DBT_ENV_SECRET_TRINO_PASS') }}"
+      host: "{{ env_var('TRINO_HOST') }}"
+      port: "{{ env_var('TRINO_PORT') | as_number}}"
+      catalog: "{{ env_var('TRINO_CATALOG') }}"
+      schema: "{{ env_var('TRINO_SCHEMA') }}"
+      timezone: "{{ env_var('TRINO_TIMEZONE') }}"
+      threads: 12
+
+    databricks:
+      type: "databricks"
+      schema: "{{ env_var('DATABRICKS_SCHEMA') }}"
+      host: "{{ env_var('DATABRICKS_HOST') }}"
+      http_path: "{{ env_var('DATABRICKS_HTTP_PATH') }}"
+      token: "{{ env_var('DBT_SECRET_ENV_DATABRICKS_TOKEN') }}"
+      threads: 8
+      connect_retries: 5
+      connect_timeout: 300
+
+    spark:
+      type: spark
+      host: "{{ env_var('SPARK_HOST') }}"
+      schema: "{{ env_var('SPARK_SCHEMA') }}"
+      user: "{{ env_var('SPARK_USER') }}"
+      method: "{{ env_var('SPARK_METHOD') }}"
+      port: "{{ env_var('SPARK_PORT') | as_number}}"
+      connect_retries: 3
+      connect_timeout: 5
+
+    fabric:
+      type: fabric
+      driver: "{{ env_var('FABRIC_DRIVER') }}"
+      server: "{{ env_var('FABRIC_HOST') }}"
+      port: "{{ env_var('FABRIC_PORT') | as_number}}"
+      database: "{{ env_var('FABRIC_DATABASE') }}"
+      schema: "{{ env_var('FABRIC_SCHEMA') }}"
+      authentication: "{{ env_var('FABRIC_AUTHENTICATION') }}"
+      tenant_id: "{{ env_var('FABRIC_TENANT') }}"
+      client_id: "{{ env_var('FABRIC_CLIENT') }}"
+      client_secret: "{{ env_var('DBT_ENV_SECRET_FABRIC_CLIENT_SECRET') }}"
+
+    synapse:
+      type: synapse
+      driver: "{{ env_var('SYNAPSE_DRIVER') }}"
+      server: "{{ env_var('SYNAPSE_HOST') }}"
+      port: "{{ env_var('SYNAPSE_PORT') | as_number}}"
+      database: "{{ env_var('SYNAPSE_DATABASE') }}"
+      schema: "{{ env_var('SYNAPSE_SCHEMA') }}"
+      authentication: "{{ env_var('SYNAPSE_AUTHENTICATION') }}"
+      tenant_id: "{{ env_var('SYNAPSE_TENANT_ID') }}"
+      client_id: "{{ env_var('SYNAPSE_CLIENT_ID') }}"
+      client_secret: "{{ env_var('DBT_ENV_SECRET_SYNAPSE_CLIENT_SECRET') }}"
+
+    athena:
+      type: athena
+      s3_staging_dir: "{{ env_var('ATHENA_S3_STAGING_DIR') }}"
+      s3_data_dir: "{{ env_var('ATHENA_S3_DATA_DIR') }}"
+      s3_data_naming: "{{ env_var('ATHENA_S3_DATA_NAMING') }}"
+      region_name: "{{ env_var('ATHENA_REGION_NAME') }}"
+      schema: "{{ env_var('ATHENA_SCHEMA') }}"
+      database: "{{ env_var('ATHENA_DATABASE') }}"
+      threads: 4
+      aws_access_key_id: "{{ env_var('DBT_ENV_SECRET_ATHENA_AWS_ACCESS_KEY_ID') }}"
+      aws_secret_access_key: "{{ env_var('DBT_ENV_SECRET_ATHENA_AWS_SECRET_ACCESS_KEY') }}"

--- a/supported_adapters.env
+++ b/supported_adapters.env
@@ -1,0 +1,1 @@
+SUPPORTED_ADAPTERS=postgres

--- a/tests/tests_with_db/dbt_project/dbt_project.yml
+++ b/tests/tests_with_db/dbt_project/dbt_project.yml
@@ -1,7 +1,7 @@
 name: "elementary_tests"
 version: "1.0.0"
 config-version: 2
-profile: "elementary_tests"
+profile: "integration_tests"
 
 model-paths: ["models"]
 analysis-paths: ["analyses"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,44 @@
+[tox]
+skipsdist = True
+envlist = lint_all, testenv, copyfile
+
+[testenv]
+passenv =
+    # postgres env vars
+    POSTGRES_HOST
+    POSTGRES_USER
+    DBT_ENV_SECRET_POSTGRES_PASS
+    POSTGRES_PORT
+    POSTGRES_DATABASE
+    POSTGRES_SCHEMA
+allowlist_externals =
+    edr
+    cp
+    pip
+deps = 
+  -rdev-requirements.txt
+  -e .
+commands =
+    edr
+    # Create the destination folder if it doesn't exist
+    mkdir -p ~/.dbt
+    # Copy the file to the home directory
+    cp integration_tests/profiles.yml ~/.dbt/profiles.yml
+
+# Postgres integration tests for centralized dbt testing
+# run pytest but skips e2e tests with reports
+[testenv:dbt_integration_postgres]
+changedir = tests
+allowlist_externals = 
+    pytest
+    cp
+    edr
+    mkdir
+skip_install = true
+commands =
+    edr
+    # Create the destination folder if it doesn't exist
+    mkdir -p ~/.dbt
+    # Copy the file to the home directory
+    cp ../integration_tests/profiles.yml ~/.dbt/profiles.yml
+    pytest -v --target postgres --ignore e2e


### PR DESCRIPTION
Resolves: #1700 

This only adds support for testing with postgres.  Postgres is run inside the GitHub runner and I do not need to worry about getting credentials for the various warehouses set up this way.

To add additional adapter testing support in the future, you will just need to modify 
- .github/workflows/ci.yml to pass through the env vars
- supported_adapters.env to list the adapters you want to test
- tox.ini to add the commands for the adapter tests
