### PR TITLE
send alert to default channel as fallback

### DIFF
--- a/elementary/monitor/data_monitoring/alerts/integrations/slack/slack.py
+++ b/elementary/monitor/data_monitoring/alerts/integrations/slack/slack.py
@@ -1124,6 +1124,25 @@ class SlackIntegration(BaseIntegration):
             )
             sent_successfully = False
 
+        if (
+            not sent_successfully
+            and self.config.slack_channel_name
+            and channel_name != self.config.slack_channel_name
+        ):
+            try:
+                logger.debug(
+                    f"Sending alert to default Slack channel: {self.config.slack_channel_name}"
+                )
+                channel_name = self.config.slack_channel_name
+                sent_successfully = self.client.send_message(
+                    channel_name=channel_name, message=template
+                )
+            except Exception as err:
+                logger.error(
+                    f"Unable to send alert via Slack to default channel: {err}"
+                )
+                sent_successfully = False
+
         if not sent_successfully:
             try:
                 fallback_template = self._get_fallback_template(alert)


### PR DESCRIPTION
If an alert was sent to a Slack channel other than the default channel and the channel was not found, we'll try to send it to the default channel. <!-- pylon-ticket-id: e2e26216-7b4e-48c9-b2ba-3305788acb2b -->