### PR TITLE
Updated gcs client to use `client.bucket` instead of `client.get_bucket` method

### DIFF
--- a/elementary/clients/gcs/client.py
+++ b/elementary/clients/gcs/client.py
@@ -41,7 +41,7 @@ class GCSClient:
         bucket_website_url = None
         bucket_report_path = remote_bucket_file_path or report_filename
         logger.info(f'Uploading to GCS bucket "{self.config.gcs_bucket_name}"')
-        bucket = self.client.get_bucket(self.config.gcs_bucket_name)
+        bucket = self.client.bucket(self.config.gcs_bucket_name)
         blob = bucket.blob(bucket_report_path)
         blob.upload_from_filename(
             local_html_file_path,


### PR DESCRIPTION
This pull request has been added to update the client to use `bucket` method instead of the `get_bucket` method. 

If the `get_bucket` method is used the account that makes the request must have `storage.buckets.get` access on the project itself which means that the account must have two roles applied to it in order for the IAM to work. This also means that the account must have more access than it technically needs to the project.

This stack overflow [post](https://stackoverflow.com/a/78782777/7478234) outlines the issue

This was spotted when building and pushing elementary files through a CI pipeline. The `get_bucket` method can be used to check a bucket exists but as this is not something that is done within the elementary code, it doesn't make sense to use it. It should be on the user to make sure the bucket is available.

More details on this [here](https://stackoverflow.com/questions/65310422/difference-between-bucket-and-get-bucket-on-google-storage)

Switching to this method the account will only need `storage.objectAdmin` role on the bucket to write the files. Rather than having to use `storage.objectAdmin` and another role that has the `storage.bucket.get` permission.

I have not raised a bug for this as it is a one line change but happy to if required


