### PR TITLE
fix indentation in dbt tests alerts code examples

### DIFF
--- a/docs/_snippets/guides/alerts-code-configuration.mdx
+++ b/docs/_snippets/guides/alerts-code-configuration.mdx
@@ -62,8 +62,8 @@ models:
 ```yml test
 tests:
   - not_null:
-    meta:
-      owner: ["@jessica.jones", "@joe.joseph"]
+      meta:
+        owner: ["@jessica.jones", "@joe.joseph"]
 ```
 
 ```yml test/model config block
@@ -111,8 +111,8 @@ models:
 ```yml test
 tests:
   - not_null:
-    meta:
-      subscribers: ["@jessica.jones", "@joe.joseph"]
+      meta:
+        subscribers: ["@jessica.jones", "@joe.joseph"]
 ```
 
 ```yml test/model config block
@@ -149,8 +149,8 @@ It's recommended to add an explanation of what does it mean if this test fails, 
 ```yml test
 tests:
   - not_null:
-    meta:
-      description: "This is the test description"
+      meta:
+        description: "This is the test description"
 ```
 
 ```yml test config block
@@ -190,7 +190,7 @@ models:
 ```yml test
 tests:
   - not_null:
-    tags: ["#marketing", "#data_ops"]
+      tags: ["#marketing", "#data_ops"]
 ```
 
 ```yml test/model config block
@@ -238,8 +238,8 @@ models:
 ```yml test
 tests:
   - not_null:
-    meta:
-      channel: data_ops
+      meta:
+        channel: data_ops
 ```
 
 ```yml test/model config block
@@ -288,8 +288,8 @@ models:
 ```yml test
 tests:
   - not_null:
-    meta:
-      alert_suppression_interval: 12
+      meta:
+        alert_suppression_interval: 12
 ```
 
 ```yml test/model config block
@@ -338,8 +338,8 @@ models:
 ```yml test
 tests:
   - not_null:
-    meta:
-      slack_group_alerts_by: table
+      meta:
+        slack_group_alerts_by: table
 ```
 
 ```yml test/model config block
@@ -398,8 +398,8 @@ models:
 ```yml test
 tests:
   - not_null:
-    meta:
-      alert_fields: ["description", "owners", "tags", "subscribers"]
+      meta:
+        alert_fields: ["description", "owners", "tags", "subscribers"]
 ```
 
 ```yml test/model config block


### PR DESCRIPTION
Hello team,

I was receiving the follow error with current indentation examples:

```
Parsing Error
  Invalid test config given in models/staging/airbyte_salesforce/stg__airbyte_salesforce_account.yml:
        test definition dictionary must have exactly one key, got [('not_null', None), ('meta', {'description': 'Not NULL test for Fax.'})] instead (2 keys)
        @: UnparsedModelUpdate(original_file_path='mode...ne)
```

I have updated the applicable spots.

Also, when should `tests` be updated to `data_tests` in docs? I know we use `data_tests` now with  1.8.x dbt core.

Thank you 🚀 