### PR TITLE
when one of the dependancies appears, the exposure should be included

### DIFF
--- a/elementary/monitor/api/models/models.py
+++ b/elementary/monitor/api/models/models.py
@@ -229,7 +229,7 @@ class ModelsAPI(APIClient):
         if not visited:
             visited = set()
 
-        return all(
+        return any(
             dep not in visited
             and (
                 dep in upstream_node_ids


### PR DESCRIPTION
null<!-- pylon-ticket-id: 0074af86-8533-4eeb-bc7c-71f404c8c57c -->