### PR TITLE
Add optional primary flag to FactBlock

### DIFF
--- a/elementary/messages/blocks.py
+++ b/elementary/messages/blocks.py
@@ -86,6 +86,7 @@ class FactBlock(BaseBlock):
     type: Literal["fact"] = "fact"
     title: LineBlock
     value: LineBlock
+    primary: bool = False
 
 
 class FactListBlock(BaseBlock):


### PR DESCRIPTION
- Introduced a new optional `primary` boolean attribute to the `FactBlock` class
- Defaults to `False` when not specified
- Allows for distinguishing primary facts in message blocks