### PR TITLE
Handle missing asset name in test alert message generation

### DIFF
--- a/elementary/monitor/alerts/test_alert.py
+++ b/elementary/monitor/alerts/test_alert.py
@@ -173,8 +173,16 @@ class TestAlertModel(AlertModel):
         )
 
         if self.test_type == "schema_change":
-            return f"{self.test_sub_type_display_name} on {asset_name}"
-        return f'"{self.concise_name}" test failed on {asset_name}'
+            return (
+                f"{self.test_sub_type_display_name} on {asset_name}"
+                if asset_name
+                else self.test_sub_type_display_name
+            )
+        return (
+            f'"{self.concise_name}" test failed on {asset_name}'
+            if asset_name
+            else f'"{self.concise_name}" test failed'
+        )
 
     def get_report_link(self) -> Optional[ReportLinkData]:
         return get_test_runs_link(self.report_url, self.elementary_unique_id)

--- a/tests/unit/alerts/alert_messages/fixtures/adaptive_card_dbt_test_alert_status-None_link-False_description-False_tags-False_owners-False_table-False_error-False_sample-False_env-False.json
+++ b/tests/unit/alerts/alert_messages/fixtures/adaptive_card_dbt_test_alert_status-None_link-False_description-False_tags-False_owners-False_table-False_error-False_sample-False_env-False.json
@@ -10,7 +10,7 @@
           "items": [
             {
               "type": "TextBlock",
-              "text": "\"test_short_name\" test failed on ",
+              "text": "\"test_short_name\" test failed",
               "weight": "bolder",
               "size": "large",
               "wrap": true

--- a/tests/unit/alerts/alert_messages/fixtures/adaptive_card_dbt_test_alert_status-error_link-False_description-True_tags-False_owners-True_table-False_error-True_sample-False_env-True.json
+++ b/tests/unit/alerts/alert_messages/fixtures/adaptive_card_dbt_test_alert_status-error_link-False_description-True_tags-False_owners-True_table-False_error-True_sample-False_env-True.json
@@ -10,7 +10,7 @@
           "items": [
             {
               "type": "TextBlock",
-              "text": "Error: \"test_short_name\" test failed on ",
+              "text": "Error: \"test_short_name\" test failed",
               "weight": "bolder",
               "size": "large",
               "wrap": true

--- a/tests/unit/alerts/alert_messages/fixtures/adaptive_card_dbt_test_alert_status-fail_link-False_description-False_tags-False_owners-False_table-False_error-False_sample-False_env-False.json
+++ b/tests/unit/alerts/alert_messages/fixtures/adaptive_card_dbt_test_alert_status-fail_link-False_description-False_tags-False_owners-False_table-False_error-False_sample-False_env-False.json
@@ -10,7 +10,7 @@
           "items": [
             {
               "type": "TextBlock",
-              "text": "Failure: \"test_short_name\" test failed on ",
+              "text": "Failure: \"test_short_name\" test failed",
               "weight": "bolder",
               "size": "large",
               "wrap": true

--- a/tests/unit/alerts/alert_messages/fixtures/adaptive_card_elementary_test_alert_status-None_link-False_description-False_tags-False_owners-False_table-False_error-False_sample-False_anomaly-False_env-False.json
+++ b/tests/unit/alerts/alert_messages/fixtures/adaptive_card_elementary_test_alert_status-None_link-False_description-False_tags-False_owners-False_table-False_error-False_sample-False_anomaly-False_env-False.json
@@ -10,7 +10,7 @@
           "items": [
             {
               "type": "TextBlock",
-              "text": "Generic on ",
+              "text": "Generic",
               "weight": "bolder",
               "size": "large",
               "wrap": true

--- a/tests/unit/alerts/alert_messages/fixtures/adaptive_card_elementary_test_alert_status-None_link-False_description-True_tags-False_owners-True_table-False_error-True_sample-False_anomaly-True_env-True.json
+++ b/tests/unit/alerts/alert_messages/fixtures/adaptive_card_elementary_test_alert_status-None_link-False_description-True_tags-False_owners-True_table-False_error-True_sample-False_anomaly-True_env-True.json
@@ -10,7 +10,7 @@
           "items": [
             {
               "type": "TextBlock",
-              "text": "\"test_short_name\" test failed on ",
+              "text": "\"test_short_name\" test failed",
               "weight": "bolder",
               "size": "large",
               "wrap": true

--- a/tests/unit/alerts/alert_messages/fixtures/adaptive_card_elementary_test_alert_status-error_link-True_description-True_tags-False_owners-False_table-False_error-True_sample-False_anomaly-True_env-True.json
+++ b/tests/unit/alerts/alert_messages/fixtures/adaptive_card_elementary_test_alert_status-error_link-True_description-True_tags-False_owners-False_table-False_error-True_sample-False_anomaly-True_env-True.json
@@ -10,7 +10,7 @@
           "items": [
             {
               "type": "TextBlock",
-              "text": "Error: \"test_short_name\" test failed on ",
+              "text": "Error: \"test_short_name\" test failed",
               "weight": "bolder",
               "size": "large",
               "wrap": true

--- a/tests/unit/alerts/alert_messages/fixtures/adaptive_card_elementary_test_alert_status-fail_link-False_description-False_tags-False_owners-False_table-False_error-False_sample-False_anomaly-False_env-False.json
+++ b/tests/unit/alerts/alert_messages/fixtures/adaptive_card_elementary_test_alert_status-fail_link-False_description-False_tags-False_owners-False_table-False_error-False_sample-False_anomaly-False_env-False.json
@@ -10,7 +10,7 @@
           "items": [
             {
               "type": "TextBlock",
-              "text": "Generic on ",
+              "text": "Generic",
               "weight": "bolder",
               "size": "large",
               "wrap": true

--- a/tests/unit/alerts/alert_messages/fixtures/adaptive_card_elementary_test_alert_status-warn_link-False_description-True_tags-False_owners-True_table-False_error-True_sample-False_anomaly-True_env-False.json
+++ b/tests/unit/alerts/alert_messages/fixtures/adaptive_card_elementary_test_alert_status-warn_link-False_description-True_tags-False_owners-True_table-False_error-True_sample-False_anomaly-True_env-False.json
@@ -10,7 +10,7 @@
           "items": [
             {
               "type": "TextBlock",
-              "text": "Warning: \"test_short_name\" test failed on ",
+              "text": "Warning: \"test_short_name\" test failed",
               "weight": "bolder",
               "size": "large",
               "wrap": true


### PR DESCRIPTION
- Updated `get_alert_title()` method to generate concise alert messages when asset name is not available<!-- pylon-ticket-id: ec8e3c4a-d024-4668-999d-643e50dcc5d6 -->