### PR TITLE
Add GitHub Actions workflow for building Docker image

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,46 @@
+name: Build Docker image
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-docker-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Elementary
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU for multi-platform support
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx for multi-platform support
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Configure a workflow to build a multi-platform Docker image for the repository, supporting both amd64 and arm64 architectures. The workflow includes steps for:
- Checking out the repository
- Setting up QEMU and Docker Buildx
- Logging into the GitHub Container Registry
- Extracting Docker metadata
- Building (but not pushing) the Docker image<!-- pylon-ticket-id: bc124aa1-d30e-4022-aa31-f50651f54706 -->