### PR TITLE
Fixed `Example configurations` in the 'Anomaly Tests Params' docs.

### DIFF
--- a/docs/data-tests/anomaly-detection-configuration/anomaly-params.mdx
+++ b/docs/data-tests/anomaly-detection-configuration/anomaly-params.mdx
@@ -60,7 +60,7 @@ sidebarTitle: "All configuration params"
 
 <CodeGroup>
 
-```yml properties.yml
+```yml Models
 version: 2
 
 models:
@@ -75,7 +75,7 @@ models:
     tests: <here you will add elementary monitors as tests>
 ```
 
-```yml Example
+```yml Models example
 version: 2
 
 models:
@@ -96,7 +96,9 @@ models:
           tags: ["elementary"]
 ```
 
-```yml sources_properties.yml
+```yml Sources
+version: 2
+
 sources:
   - name: < some name >
     database: < database >
@@ -110,7 +112,9 @@ sources:
         tests: <here you will add elementary monitors as tests>
 ```
 
-```yml Example
+```yml Sources example
+version: 2
+
 sources:
   - name: "my_non_dbt_table"
     database: "raw_events"


### PR DESCRIPTION
Hello! The behavior of the `Example` tab in the `Example configurations` section of the "[Anomaly Tests configuration params](https://docs.elementary-data.com/data-tests/anomaly-detection-configuration/anomaly-params)" documentation was incorrect, so we've fixed it.


When you try to open the second `Example` tab as shown in the video below, the first `Example` tab opens instead, and the second one doesn't open.

The cause is probably that the tab names are duplicated.



https://github.com/user-attachments/assets/a589a0a8-798a-4740-9c28-c0733eaf7664



I modified the tab names as follows, referring to the “[Schema changes from baseline](https://docs.elementary-data.com/data-tests/schema-tests/schema-changes-from-baseline)” page.

• Models
• Models example
• Sources
• Sources example

Now that the tab names are not duplicated, I think this should solve the problem of the tabs not opening.
Also, I added the `version: 2` code, which was missing.