### PR TITLE
Add Elementary 0.18.0

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -491,6 +491,7 @@
         {
           "group": "Releases",
           "pages": [
+            "oss/release-notes/releases/0.18.0",
             "oss/release-notes/releases/0.17.0",
             "oss/release-notes/releases/0.16.2",
             "oss/release-notes/releases/0.11.2",

--- a/docs/oss/release-notes/releases/0.18.0.mdx
+++ b/docs/oss/release-notes/releases/0.18.0.mdx
@@ -1,0 +1,14 @@
+---
+title: "Python v0.18.0"
+sidebarTitle: "0.18.0"
+---
+
+## What's Changed
+
+- Invocation Filter Fix: Invocation filters now apply to both reports and their summaries, ensuring consistent filtering.​
+- Python Version Support: Official support for Python 3.8 has been discontinued to align with dbt's supported versions.​
+- Test Description Bug: Fixed an issue where test descriptions were missing in alerts when using dbt version 1.9.
+
+Note: We've bumped the minor version to align with the recent minor version update in the dbt package.
+
+Full Changelog: [v0.17.0...v0.18.0](https://github.com/elementary-data/elementary/compare/v0.17.0...v0.18.0)


### PR DESCRIPTION
Add Elementary 0.18.0 to releases with the following notes:
https://github.com/elementary-data/elementary/releases/tag/v0.18.0