### PR TITLE
for clickhouse, continue even if e2e are failing

### DIFF
--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Run dbt package integration tests
         if: github.event_name != 'workflow_dispatch' || inputs.should-run-tests
         # remove this once clickhouse supports anomaly detection
-        continue-on-error: ${{ inputs.warehouse-type == 'clickhouse' }} 
+        continue-on-error: ${{ inputs.warehouse-type == 'clickhouse' }}
         working-directory: ${{ env.DBT_PKG_INTEG_TESTS_DIR }}
         run: |
           dbt deps


### PR DESCRIPTION
null<!-- pylon-ticket-id: 72e41527-8900-4740-95c5-f3a6bf647bea -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Adjusted workflow to allow integration tests to continue on error for Clickhouse warehouses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->