### PR TITLE
ignore monitor failure on clickhouse

### DIFF
--- a/.github/workflows/test-all-warehouses.yml
+++ b/.github/workflows/test-all-warehouses.yml
@@ -27,15 +27,7 @@ jobs:
       matrix:
         dbt-version: ${{ inputs.dbt-version && fromJSON(format('["{0}"]', inputs.dbt-version)) || fromJSON('["1.8.0", null]') }}
         warehouse-type:
-          [
-            postgres,
-            snowflake,
-            bigquery,
-            redshift,
-            databricks_catalog,
-            athena,
-            clickhouse,
-          ]
+          [postgres, snowflake, bigquery, redshift, databricks_catalog, athena]
     uses: ./.github/workflows/test-warehouse.yml
     with:
       warehouse-type: ${{ matrix.warehouse-type }}

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -47,15 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         warehouse-type:
-          [
-            postgres,
-            snowflake,
-            bigquery,
-            redshift,
-            databricks_catalog,
-            athena,
-            clickhouse,
-          ]
+          [postgres, snowflake, bigquery, redshift, databricks_catalog, athena]
     needs: get-latest-release-tags
     uses: ./.github/workflows/test-warehouse.yml
     with:

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -186,6 +186,8 @@ jobs:
           dbt run-operation validate_alert_statuses_are_updated -t "${{ inputs.warehouse-type }}"
 
       - name: Run report
+        # remove this once clickhouse supports anomaly detection
+        continue-on-error: ${{ inputs.warehouse-type == 'clickhouse' }}
         run: >
           edr monitor report
           -t "${{ inputs.warehouse-type }}"

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -240,4 +240,6 @@ jobs:
 
       - name: Run Python package e2e tests
         if: github.event_name != 'workflow_dispatch' || inputs.should-run-tests
+        # remove this once clickhouse supports anomaly detection
+        continue-on-error: ${{ inputs.warehouse-type == 'clickhouse' }}
         run: pytest -vv tests/e2e --warehouse-type ${{ inputs.warehouse-type }}

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -169,6 +169,8 @@ jobs:
       - name: Run monitor
         env:
           SLACK_WEBHOOK: ${{ secrets.CI_SLACK_WEBHOOK }}
+        # remove this once clickhouse supports anomaly detection
+        continue-on-error: ${{ inputs.warehouse-type == 'clickhouse' }}
         run: >
           edr monitor 
           -t "${{ inputs.warehouse-type }}"

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -206,6 +206,8 @@ jobs:
         run: echo "$GCS_KEYFILE" | base64 -d > /tmp/gcs_keyfile.json
 
       - name: Run send report
+        # remove this once clickhouse supports anomaly detection
+        continue-on-error: ${{ inputs.warehouse-type == 'clickhouse' }}
         env:
           SLACK_TOKEN: ${{ secrets.CI_SLACK_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -14,7 +14,6 @@ on:
           - databricks_catalog
           - spark
           - athena
-          - clickhouse
       elementary-ref:
         type: string
         required: false
@@ -105,10 +104,10 @@ jobs:
         working-directory: ${{ env.DBT_PKG_INTEG_TESTS_DIR }}
         run: docker compose up -d postgres
 
-      - name: Start Clickhouse
-        if: inputs.warehouse-type == 'clickhouse'
-        working-directory: ${{ env.DBT_PKG_INTEG_TESTS_DIR }}
-        run: docker compose up -d clickhouse
+      # - name: Start Clickhouse
+      #   if: inputs.warehouse-type == 'clickhouse'
+      #   working-directory: ${{ env.DBT_PKG_INTEG_TESTS_DIR }}
+      #   run: docker compose up -d clickhouse
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -156,8 +155,6 @@ jobs:
 
       - name: Run dbt package integration tests
         if: github.event_name != 'workflow_dispatch' || inputs.should-run-tests
-        # remove this once clickhouse supports anomaly detection
-        continue-on-error: ${{ inputs.warehouse-type == 'clickhouse' }}
         working-directory: ${{ env.DBT_PKG_INTEG_TESTS_DIR }}
         run: |
           dbt deps
@@ -169,8 +166,6 @@ jobs:
       - name: Run monitor
         env:
           SLACK_WEBHOOK: ${{ secrets.CI_SLACK_WEBHOOK }}
-        # remove this once clickhouse supports anomaly detection
-        continue-on-error: ${{ inputs.warehouse-type == 'clickhouse' }}
         run: >
           edr monitor 
           -t "${{ inputs.warehouse-type }}"
@@ -186,8 +181,6 @@ jobs:
           dbt run-operation validate_alert_statuses_are_updated -t "${{ inputs.warehouse-type }}"
 
       - name: Run report
-        # remove this once clickhouse supports anomaly detection
-        continue-on-error: ${{ inputs.warehouse-type == 'clickhouse' }}
         run: >
           edr monitor report
           -t "${{ inputs.warehouse-type }}"
@@ -206,8 +199,6 @@ jobs:
         run: echo "$GCS_KEYFILE" | base64 -d > /tmp/gcs_keyfile.json
 
       - name: Run send report
-        # remove this once clickhouse supports anomaly detection
-        continue-on-error: ${{ inputs.warehouse-type == 'clickhouse' }}
         env:
           SLACK_TOKEN: ${{ secrets.CI_SLACK_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -240,6 +231,4 @@ jobs:
 
       - name: Run Python package e2e tests
         if: github.event_name != 'workflow_dispatch' || inputs.should-run-tests
-        # remove this once clickhouse supports anomaly detection
-        continue-on-error: ${{ inputs.warehouse-type == 'clickhouse' }}
         run: pytest -vv tests/e2e --warehouse-type ${{ inputs.warehouse-type }}


### PR DESCRIPTION
null<!-- pylon-ticket-id: e3859ce6-6fc4-43a0-b790-33e6743610de -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed Clickhouse option from warehouse type selection and disabled related services in the workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->