### PR TITLE
dbt-databricks must be <1.10.2

### DIFF
--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -122,7 +122,8 @@ jobs:
         run: >
           pip install
           "dbt-core${{ inputs.dbt-version && format('=={0}', inputs.dbt-version) }}"
-          "dbt-${{ (inputs.warehouse-type == 'databricks_catalog' && 'databricks') || inputs.warehouse-type }}${{ inputs.dbt-version && format('<={0}', inputs.dbt-version) }}"
+          # TODO: remove the <1.10.2 once we have a fix for https://github.com/elementary-data/elementary/issues/1931
+          "dbt-${{ (inputs.warehouse-type == 'databricks_catalog' && 'databricks<1.10.2,') || inputs.warehouse-type }}${{ inputs.dbt-version && format('~={0}', inputs.dbt-version) }}"
 
       - name: Install Elementary
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dbt-snowflake = {version = ">=0.20,<2.0.0", optional = true}
 dbt-bigquery = {version = ">=0.20,<2.0.0", optional = true}
 dbt-redshift = {version = ">=0.20,<2.0.0", optional = true}
 dbt-postgres = {version = ">=0.20,<2.0.0", optional = true}
-dbt-databricks = {version = ">=0.20,<2.0.0", optional = true}
+# TODO: change back to <2.0.0 once we have a fix for https://github.com/elementary-data/elementary/issues/1931
+dbt-databricks = {version = ">=0.20,<1.10.2", optional = true}
 dbt-spark = {version = ">=0.20,<2.0.0", optional = true}
 dbt-athena-community = {version = ">=1.6.3,<2.0.0", optional = true}
 dbt-trino = {version = ">=1.5.0,<2.0.0", optional = true}


### PR DESCRIPTION
null<!-- pylon-ticket-id: 3fa73a22-d16c-483b-a035-cfab05c43aef -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the way dbt package versions are installed in the GitHub Actions workflow, including a temporary upper version limit for the `databricks_catalog` warehouse type to address a known issue.
  - Applied a temporary version restriction on the `dbt-databricks` dependency to maintain compatibility until the related issue is resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->