### PR TITLE
switched back to use the update_forward_refs function as we need to support pydantic1

### DIFF
--- a/elementary/messages/blocks.py
+++ b/elementary/messages/blocks.py
@@ -113,7 +113,7 @@ InlineBlock = Union[
     "LineBlock",
 ]
 
-LineBlock.model_rebuild()
+LineBlock.update_forward_refs()
 
 
 class HeaderBlock(BaseBlock):
@@ -184,4 +184,4 @@ InExpandableBlock = Union[
 ]
 
 # Update forward references for recursive types
-ExpandableBlock.model_rebuild()
+ExpandableBlock.update_forward_refs()

--- a/elementary/messages/message_body.py
+++ b/elementary/messages/message_body.py
@@ -39,4 +39,4 @@ class MessageBody(BaseModel):
     id: Optional[str] = None
 
 
-MessageBody.model_rebuild()
+MessageBody.update_forward_refs()


### PR DESCRIPTION
switched back to use the update_forward_refs function as we need to support pydantic1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of type references to enhance model reliability and maintainability. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->