### PR TITLE
Docs Home: Large space fix for headings

### DIFF
--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -11,8 +11,8 @@ icon: "house"
         <div className="home__hero-content">
           <div className="home__hero-text-block">
             <h1 className="home__hero-title">
-              Dev-First <br />
-              AI-Powered <br />
+              Dev-First
+              AI-Powered
               Data Observability
             </h1>
             <p className="home__hero-subtitle">
@@ -53,7 +53,7 @@ icon: "house"
     <div className="home__jump-navigation">
       <div className="home__jump-navigation-content">
         <h2 className="home__jump-navigation-heading">
-          Discover what you can do <br />
+          Discover what you can do
           with Elementary
         </h2>
         <div className="home__jump-navigation-links">


### PR DESCRIPTION
This pull request makes small formatting changes to the homepage content in `docs/home.mdx` to fix large spaces between the headings.

* Removed `<br />` line breaks in the main hero title and section heading to display text on a single line. [[1]](diffhunk://#diff-436e5786873236631d8993b37ad6c80af9de17dab8f58ed123cff3da5ac06814L14-R15) [[2]](diffhunk://#diff-436e5786873236631d8993b37ad6c80af9de17dab8f58ed123cff3da5ac06814L56-R56)