### PR TITLE
changed dbt package version to a commit with dremio types mapping. ne…

### DIFF
--- a/elementary/monitor/dbt_project/package-lock.yml
+++ b/elementary/monitor/dbt_project/package-lock.yml
@@ -2,5 +2,5 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 0.8.6
   - git: https://github.com/elementary-data/dbt-data-reliability.git
-    revision: 178e57ca8296def184fc70aa0a8ee51d01db2bba
-sha1_hash: e653d0a6e0944314a1efede5ac7629068f9c8731
+    revision: 257974756e195140204ac4a76278a26acf78a27f
+sha1_hash: 0bac331a6cf2d739e67a64cf27532d9502175e37

--- a/elementary/monitor/dbt_project/package-lock.yml
+++ b/elementary/monitor/dbt_project/package-lock.yml
@@ -1,6 +1,6 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: 0.8.6
-  - package: elementary-data/elementary
-    version: 0.19.2
-sha1_hash: fb182360b3c74342aba55c5046a4139e2f1a6f2f
+  - git: https://github.com/elementary-data/dbt-data-reliability.git
+    revision: 178e57ca8296def184fc70aa0a8ee51d01db2bba
+sha1_hash: e653d0a6e0944314a1efede5ac7629068f9c8731

--- a/elementary/monitor/dbt_project/packages.yml
+++ b/elementary/monitor/dbt_project/packages.yml
@@ -1,8 +1,8 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: [">=0.8.0", "<0.9.0"]
-  - package: elementary-data/elementary
-    version: 0.19.2
+  - git: https://github.com/elementary-data/dbt-data-reliability.git
+    revision: 178e57ca8296def184fc70aa0a8ee51d01db2bba
 
   #  NOTE - for unreleased CLI versions we often need to update the package version to a commit hash (please leave this
   #  commented, so it will be easy to access)

--- a/elementary/monitor/dbt_project/packages.yml
+++ b/elementary/monitor/dbt_project/packages.yml
@@ -2,7 +2,7 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=0.8.0", "<0.9.0"]
   - git: https://github.com/elementary-data/dbt-data-reliability.git
-    revision: 178e57ca8296def184fc70aa0a8ee51d01db2bba
+    revision: 257974756e195140204ac4a76278a26acf78a27f
 
   #  NOTE - for unreleased CLI versions we often need to update the package version to a commit hash (please leave this
   #  commented, so it will be easy to access)

--- a/tests/tests_with_db/dbt_project/package-lock.yml
+++ b/tests/tests_with_db/dbt_project/package-lock.yml
@@ -1,0 +1,7 @@
+packages:
+  - local: ../../../elementary/monitor/dbt_project
+  - package: dbt-labs/dbt_utils
+    version: 0.8.6
+  - package: elementary-data/elementary
+    version: 0.19.1
+sha1_hash: 9d71a1a328acdc2d583ae6180e9f5304ae79acc2

--- a/tests/tests_with_db/dbt_project/package-lock.yml
+++ b/tests/tests_with_db/dbt_project/package-lock.yml
@@ -1,7 +1,0 @@
-packages:
-  - local: ../../../elementary/monitor/dbt_project
-  - package: dbt-labs/dbt_utils
-    version: 0.8.6
-  - package: elementary-data/elementary
-    version: 0.19.1
-sha1_hash: 9d71a1a328acdc2d583ae6180e9f5304ae79acc2


### PR DESCRIPTION
…eded for dremio cll in elementary cloud<!-- pylon-ticket-id: f1d79d34-cf5b-4d95-a8f9-03d2905a3761 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the data reliability package dependency to use a pinned Git revision instead of a packaged release, aligning versions across environments.
  * Dependency catalog refreshed; no other dependencies changed.

* **Impact**
  * No user-facing changes or behavior differences expected.
  * Improves build consistency and predictability.

* **Action Required**
  * None for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->