### PR TITLE
Add elementary data link to cli alerts

### DIFF
--- a/elementary/monitor/data_monitoring/alerts/data_monitoring_alerts.py
+++ b/elementary/monitor/data_monitoring/alerts/data_monitoring_alerts.py
@@ -284,7 +284,28 @@ class DataMonitoringAlerts(DataMonitoring):
             metadata=metadata,
             override_config_defaults=self.override_config_defaults,
         )
-        return integration.send_message(destination=destination, body=body)
+        # Append footer link as the last line in the alert
+        try:
+            from elementary.messages.block_builders import LinkLineBlock
+
+            footer_block = LinesBlock(
+                lines=[
+                    LinkLineBlock(
+                        text="powered by elementary",
+                        url="https://www.elementary-data.com/",
+                    )
+                ]
+            )
+            body_with_footer = MessageBody(
+                blocks=[*body.blocks, footer_block],
+                color=body.color,
+                id=body.id,
+            )
+        except Exception:
+            # If any unexpected issue occurs while adding the footer, fallback to original body
+            body_with_footer = body
+
+        return integration.send_message(destination=destination, body=body_with_footer)
 
     def _send_test_message(self) -> MessageSendResult:
         if isinstance(self.alerts_integration, BaseIntegration):


### PR DESCRIPTION
Add a "powered by elementary" footer link to all EDR CLI alerts to include branding and a link to the elementary website.

---
<a href="https://cursor.com/background-agent?bcId=bc-16eab3ad-e803-42cd-97b3-26e11b99c23c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16eab3ad-e803-42cd-97b3-26e11b99c23c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a><!-- pylon-ticket-id: 9a5a9b3b-1f25-4002-b739-b50879b4bac3 -->