### PR TITLE
Add orchestrator jobs data to alerts

### DIFF
--- a/elementary/messages/blocks.py
+++ b/elementary/messages/blocks.py
@@ -20,6 +20,7 @@ class Icon(Enum):
     BELL = "bell"
     GEM = "gem"
     SPARKLES = "sparkles"
+    LINK = "link"
 
 
 class TextStyle(Enum):

--- a/elementary/messages/formats/unicode.py
+++ b/elementary/messages/formats/unicode.py
@@ -15,6 +15,7 @@ ICON_TO_UNICODE = {
     Icon.BELL: "🔔",
     Icon.GEM: "💎",
     Icon.SPARKLES: "✨",
+    Icon.LINK: "🔗",
 }
 
 for icon in Icon:

--- a/elementary/monitor/alerts/alert.py
+++ b/elementary/monitor/alerts/alert.py
@@ -32,6 +32,12 @@ class AlertModel:
         alert_fields: Optional[List[str]] = None,
         elementary_database_and_schema: Optional[str] = None,
         env: Optional[str] = None,
+        job_id: Optional[str] = None,
+        job_name: Optional[str] = None,
+        job_run_id: Optional[str] = None,
+        job_url: Optional[str] = None,
+        job_run_url: Optional[str] = None,
+        orchestrator: Optional[str] = None,
         **kwargs,
     ):
         self.id = id
@@ -65,6 +71,12 @@ class AlertModel:
         self.alert_fields = alert_fields
         self.elementary_database_and_schema = elementary_database_and_schema
         self.env = env
+        self.job_id = job_id
+        self.job_name = job_name
+        self.job_run_id = job_run_id
+        self.job_url = job_url
+        self.job_run_url = job_run_url
+        self.orchestrator = orchestrator
 
     @property
     def unified_meta(self) -> Dict:
@@ -84,3 +96,23 @@ class AlertModel:
 
     def get_report_link(self) -> Optional[ReportLinkData]:
         raise NotImplementedError
+
+    @property
+    def orchestrator_info(self) -> Optional[Dict[str, str]]:
+        """Returns structured orchestrator metadata if available."""
+        if not any([self.job_name, self.job_run_id, self.orchestrator]):
+            return None
+
+        info = {}
+        if self.job_name:
+            info["job_name"] = self.job_name
+        if self.job_run_id:
+            info["run_id"] = self.job_run_id
+        if self.orchestrator:
+            info["orchestrator"] = self.orchestrator
+        if self.job_url:
+            info["job_url"] = self.job_url
+        if self.job_run_url:
+            info["run_url"] = self.job_run_url
+
+        return info

--- a/elementary/monitor/alerts/model_alert.py
+++ b/elementary/monitor/alerts/model_alert.py
@@ -37,6 +37,12 @@ class ModelAlertModel(AlertModel):
         alert_fields: Optional[List[str]] = None,
         elementary_database_and_schema: Optional[str] = None,
         env: Optional[str] = None,
+        job_id: Optional[str] = None,
+        job_name: Optional[str] = None,
+        job_run_id: Optional[str] = None,
+        job_url: Optional[str] = None,
+        job_run_url: Optional[str] = None,
+        orchestrator: Optional[str] = None,
         **kwargs,
     ):
         super().__init__(
@@ -57,6 +63,13 @@ class ModelAlertModel(AlertModel):
             alert_fields,
             elementary_database_and_schema,
             env=env,
+            job_id=job_id,
+            job_name=job_name,
+            job_run_id=job_run_id,
+            job_url=job_url,
+            job_run_url=job_run_url,
+            orchestrator=orchestrator,
+            **kwargs,
         )
         self.alias = alias
         self.path = path

--- a/elementary/monitor/alerts/source_freshness_alert.py
+++ b/elementary/monitor/alerts/source_freshness_alert.py
@@ -46,6 +46,12 @@ class SourceFreshnessAlertModel(AlertModel):
         alert_fields: Optional[List[str]] = None,
         elementary_database_and_schema: Optional[str] = None,
         env: Optional[str] = None,
+        job_id: Optional[str] = None,
+        job_name: Optional[str] = None,
+        job_run_id: Optional[str] = None,
+        job_url: Optional[str] = None,
+        job_run_url: Optional[str] = None,
+        orchestrator: Optional[str] = None,
         **kwargs,
     ):
         super().__init__(
@@ -66,6 +72,13 @@ class SourceFreshnessAlertModel(AlertModel):
             alert_fields,
             elementary_database_and_schema,
             env=env,
+            job_id=job_id,
+            job_name=job_name,
+            job_run_id=job_run_id,
+            job_url=job_url,
+            job_run_url=job_run_url,
+            orchestrator=orchestrator,
+            **kwargs,
         )
         self.snapshotted_at_str = (
             convert_datetime_utc_str_to_timezone_str(

--- a/elementary/monitor/alerts/test_alert.py
+++ b/elementary/monitor/alerts/test_alert.py
@@ -48,6 +48,12 @@ class TestAlertModel(AlertModel):
         alert_fields: Optional[List[str]] = None,
         elementary_database_and_schema: Optional[str] = None,
         env: Optional[str] = None,
+        job_id: Optional[str] = None,
+        job_name: Optional[str] = None,
+        job_run_id: Optional[str] = None,
+        job_url: Optional[str] = None,
+        job_run_url: Optional[str] = None,
+        orchestrator: Optional[str] = None,
         **kwargs,
     ):
         super().__init__(
@@ -68,6 +74,13 @@ class TestAlertModel(AlertModel):
             alert_fields,
             elementary_database_and_schema,
             env=env,
+            job_id=job_id,
+            job_name=job_name,
+            job_run_id=job_run_id,
+            job_url=job_url,
+            job_run_url=job_run_url,
+            orchestrator=orchestrator,
+            **kwargs,
         )
         self.table_name = table_name
         self.test_type = test_type

--- a/elementary/monitor/data_monitoring/alerts/integrations/utils/orchestrator_link.py
+++ b/elementary/monitor/data_monitoring/alerts/integrations/utils/orchestrator_link.py
@@ -20,14 +20,11 @@ def create_orchestrator_link(
 
     orchestrator = orchestrator_info.get("orchestrator", "orchestrator")
 
-    # Capitalize orchestrator name for display
-    display_name = orchestrator.replace("_", " ").title()
-
     return OrchestratorLinkData(
         url=orchestrator_info["run_url"],
-        text=f"View in {display_name}",
+        text=f"View in {orchestrator}",
         orchestrator=orchestrator,
-        icon=Icon.INFO,
+        icon=Icon.LINK,
     )
 
 

--- a/elementary/monitor/data_monitoring/alerts/integrations/utils/orchestrator_link.py
+++ b/elementary/monitor/data_monitoring/alerts/integrations/utils/orchestrator_link.py
@@ -1,0 +1,52 @@
+from typing import Dict, Optional
+
+from elementary.messages.blocks import Icon
+from elementary.utils.pydantic_shim import BaseModel
+
+
+class OrchestratorLinkData(BaseModel):
+    url: str
+    text: str
+    orchestrator: str
+    icon: Optional[Icon] = None
+
+
+def create_orchestrator_link(
+    orchestrator_info: Dict[str, str]
+) -> Optional[OrchestratorLinkData]:
+    """Create an orchestrator link from orchestrator info if URL is available."""
+    if not orchestrator_info or not orchestrator_info.get("run_url"):
+        return None
+
+    orchestrator = orchestrator_info.get("orchestrator", "orchestrator")
+
+    # Capitalize orchestrator name for display
+    display_name = orchestrator.replace("_", " ").title()
+
+    return OrchestratorLinkData(
+        url=orchestrator_info["run_url"],
+        text=f"View in {display_name}",
+        orchestrator=orchestrator,
+        icon=Icon.INFO,
+    )
+
+
+def create_job_link(
+    orchestrator_info: Dict[str, str]
+) -> Optional[OrchestratorLinkData]:
+    """Create a job-level orchestrator link if job URL is available."""
+    if not orchestrator_info or not orchestrator_info.get("job_url"):
+        return None
+
+    orchestrator = orchestrator_info.get("orchestrator", "orchestrator")
+    job_name = orchestrator_info.get("job_name", "Job")
+
+    # Capitalize orchestrator name for display
+    display_name = orchestrator.replace("_", " ").title()
+
+    return OrchestratorLinkData(
+        url=orchestrator_info["job_url"],
+        text=f"{job_name} in {display_name}",
+        orchestrator=orchestrator,
+        icon=Icon.GEAR,
+    )

--- a/elementary/monitor/dbt_project/macros/get_source_freshness_results.sql
+++ b/elementary/monitor/dbt_project/macros/get_source_freshness_results.sql
@@ -10,7 +10,7 @@
         with dbt_source_freshness_results as (
             select
                 *,
-                {{ elementary_cli.normalized_source_freshness_status()}},
+                {{ elementary_cli.normalized_source_freshness_status('status')}},
                 rank() over (partition by unique_id order by generated_at desc) as invocations_rank_index
             from {{ ref('elementary', 'dbt_source_freshness_results') }}
             {% if days_back %}

--- a/elementary/monitor/dbt_project/macros/utils/normalized_source_freshness_status.sql
+++ b/elementary/monitor/dbt_project/macros/utils/normalized_source_freshness_status.sql
@@ -1,7 +1,7 @@
-{% macro normalized_source_freshness_status() %}
+{% macro normalized_source_freshness_status(status_column='status') %}
     case
-        when status = 'error' then 'fail'
-        when status = 'runtime error' then 'error'
-        else status
+        when {{ status_column }} = 'error' then 'fail'
+        when {{ status_column }} = 'runtime error' then 'error'
+        else {{ status_column }}
     end as normalized_status
 {% endmacro %}

--- a/elementary/monitor/dbt_project/models/alerts/alerts_v2.sql
+++ b/elementary/monitor/dbt_project/models/alerts/alerts_v2.sql
@@ -24,6 +24,9 @@
 
 -- depends_on: {{ ref('dbt_seeds') }}
 
+-- depends_on: {{ ref('elementary', 'dbt_invocations') }}
+-- depends_on: {{ ref('elementary', 'dbt_run_results') }}
+
 -- backwards compatibility
 -- depends_on: {{ ref('elementary_cli', 'alerts') }}
 -- depends_on: {{ ref('elementary_cli', 'alerts_models') }}

--- a/elementary/monitor/fetchers/alerts/schema/alert_data.py
+++ b/elementary/monitor/fetchers/alerts/schema/alert_data.py
@@ -34,6 +34,13 @@ class BaseAlertDataSchema(BaseModel):
     owners: Optional[List[str]] = None
     model_meta: Optional[Dict] = None
     status: str
+    # Orchestrator fields
+    job_id: Optional[str] = None
+    job_name: Optional[str] = None
+    job_run_id: Optional[str] = None
+    job_url: Optional[str] = None
+    job_run_url: Optional[str] = None
+    orchestrator: Optional[str] = None
 
     @property
     def unified_meta(self) -> Dict:
@@ -228,6 +235,13 @@ class TestAlertDataSchema(BaseAlertDataSchema):
             alert_fields=self.alert_fields,
             elementary_database_and_schema=elementary_database_and_schema,
             env=env,
+            # Orchestrator fields
+            job_id=self.job_id,
+            job_name=self.job_name,
+            job_run_id=self.job_run_id,
+            job_url=self.job_url,
+            job_run_url=self.job_run_url,
+            orchestrator=self.orchestrator,
         )
 
 
@@ -277,6 +291,13 @@ class ModelAlertDataSchema(BaseAlertDataSchema):
             alert_fields=self.alert_fields,
             elementary_database_and_schema=elementary_database_and_schema,
             env=env,
+            # Orchestrator fields
+            job_id=self.job_id,
+            job_name=self.job_name,
+            job_run_id=self.job_run_id,
+            job_url=self.job_url,
+            job_run_url=self.job_run_url,
+            orchestrator=self.orchestrator,
         )
 
     @validator("full_refresh", pre=True, always=True)
@@ -346,4 +367,11 @@ class SourceFreshnessAlertDataSchema(BaseAlertDataSchema):
             alert_fields=self.alert_fields,
             elementary_database_and_schema=elementary_database_and_schema,
             env=env,
+            # Orchestrator fields
+            job_id=self.job_id,
+            job_name=self.job_name,
+            job_run_id=self.job_run_id,
+            job_url=self.job_url,
+            job_run_url=self.job_run_url,
+            orchestrator=self.orchestrator,
         )

--- a/tests/unit/alerts/alert_messages/test_orchestrator_message_simple.py
+++ b/tests/unit/alerts/alert_messages/test_orchestrator_message_simple.py
@@ -1,0 +1,167 @@
+"""Simplified tests for orchestrator integration in alert messages."""
+
+from unittest.mock import Mock
+
+from elementary.messages.formats.block_kit import format_block_kit
+from elementary.monitor.alerts.model_alert import ModelAlertModel
+from elementary.monitor.alerts.test_alert import TestAlertModel
+from tests.unit.alerts.alert_messages.test_alert_utils import get_alert_message_body
+
+
+class TestOrchestratorMessageIntegration:
+    """Test orchestrator integration in alert messages using actual message rendering."""
+
+    def test_alert_message_includes_orchestrator_job_info(self):
+        """Test that alerts with orchestrator data include job information."""
+        alert = TestAlertModel(
+            id="test_id",
+            test_unique_id="test_unique_id",
+            elementary_unique_id="elementary_unique_id",
+            test_name="test_name",
+            severity="error",
+            test_type="dbt_test",
+            test_sub_type="generic",
+            test_short_name="test_short_name",
+            alert_class_id="test_alert_class_id",
+            status="fail",
+            job_name="nightly_load",
+            orchestrator="airflow",
+        )
+
+        # Mock get_report_link to avoid dependency
+        alert.get_report_link = Mock(return_value=None)
+
+        # Generate message and render to Slack format
+        message_body = get_alert_message_body(alert)
+        slack_message = format_block_kit(message_body)
+
+        # Convert to JSON string for easy text search
+        slack_json = str(slack_message)
+
+        # Should contain job information
+        assert "nightly_load" in slack_json
+        assert "airflow" in slack_json
+
+    def test_alert_message_includes_orchestrator_link(self):
+        """Test that alerts with run URL include orchestrator links."""
+        alert = TestAlertModel(
+            id="test_id",
+            test_unique_id="test_unique_id",
+            elementary_unique_id="elementary_unique_id",
+            test_name="test_name",
+            severity="error",
+            test_type="dbt_test",
+            test_sub_type="generic",
+            test_short_name="test_short_name",
+            alert_class_id="test_alert_class_id",
+            status="fail",
+            job_name="nightly_load",
+            orchestrator="dbt_cloud",
+            job_run_url="https://cloud.getdbt.com/run/12345",
+        )
+
+        alert.get_report_link = Mock(return_value=None)
+
+        message_body = get_alert_message_body(alert)
+        slack_message = format_block_kit(message_body)
+        slack_json = str(slack_message)
+
+        # Should contain orchestrator link
+        assert "View in Dbt Cloud" in slack_json
+        assert "cloud.getdbt.com/run/12345" in slack_json
+
+    def test_alert_without_orchestrator_data_works_normally(self):
+        """Test that alerts without orchestrator data work as before."""
+        alert = TestAlertModel(
+            id="test_id",
+            test_unique_id="test_unique_id",
+            elementary_unique_id="elementary_unique_id",
+            test_name="test_name",
+            severity="error",
+            test_type="dbt_test",
+            test_sub_type="generic",
+            test_short_name="test_short_name",
+            alert_class_id="test_alert_class_id",
+            status="fail"
+            # No orchestrator fields
+        )
+
+        alert.get_report_link = Mock(return_value=None)
+
+        # Should not fail and should generate a valid message
+        message_body = get_alert_message_body(alert)
+        slack_message = format_block_kit(message_body)
+
+        # Should be a valid Slack message structure (it's a Pydantic model, not a dict)
+        assert slack_message is not None
+        assert hasattr(slack_message, "attachments") or hasattr(slack_message, "blocks")
+
+    def test_model_alert_with_orchestrator_data(self):
+        """Test ModelAlertModel with orchestrator integration."""
+        alert = ModelAlertModel(
+            id="model_alert_id",
+            alias="test_model",
+            path="/models/test_model.sql",
+            original_path="models/test_model.sql",
+            materialization="table",
+            full_refresh=False,
+            alert_class_id="model_alert_class",
+            status="error",
+            job_name="nightly_build",
+            orchestrator="github_actions",
+            job_run_url="https://github.com/org/repo/actions/runs/123",
+        )
+
+        alert.get_report_link = Mock(return_value=None)
+
+        message_body = get_alert_message_body(alert)
+        slack_message = format_block_kit(message_body)
+        slack_json = str(slack_message)
+
+        # Should contain model orchestrator info
+        assert "nightly_build" in slack_json
+        assert "github_actions" in slack_json
+        assert "View in Github Actions" in slack_json
+
+    def test_orchestrator_info_property_integration(self):
+        """Test that the orchestrator_info property works correctly."""
+        alert = TestAlertModel(
+            id="test_id",
+            test_unique_id="test_unique_id",
+            elementary_unique_id="elementary_unique_id",
+            test_name="test_name",
+            severity="error",
+            test_type="dbt_test",
+            test_sub_type="generic",
+            test_short_name="test_short_name",
+            alert_class_id="test_alert_class_id",
+            job_name="integration_test",
+            job_run_id="run_123",
+            orchestrator="airflow",
+            job_url="https://airflow.example.com/job/integration_test",
+            job_run_url="https://airflow.example.com/run/123",
+        )
+
+        # Test orchestrator_info property
+        orchestrator_info = alert.orchestrator_info
+
+        assert orchestrator_info is not None
+        assert orchestrator_info["job_name"] == "integration_test"
+        assert orchestrator_info["run_id"] == "run_123"
+        assert orchestrator_info["orchestrator"] == "airflow"
+        assert (
+            orchestrator_info["job_url"]
+            == "https://airflow.example.com/job/integration_test"
+        )
+        assert orchestrator_info["run_url"] == "https://airflow.example.com/run/123"
+
+        # Test message includes this data
+        alert.get_report_link = Mock(return_value=None)
+
+        message_body = get_alert_message_body(alert)
+        slack_message = format_block_kit(message_body)
+        slack_json = str(slack_message)
+
+        assert "integration_test" in slack_json
+        assert "airflow" in slack_json
+        assert "airflow.example.com/run/123" in slack_json

--- a/tests/unit/alerts/test_orchestrator_integration.py
+++ b/tests/unit/alerts/test_orchestrator_integration.py
@@ -1,0 +1,319 @@
+import pytest
+
+from elementary.messages.blocks import Icon
+from elementary.monitor.alerts.model_alert import ModelAlertModel
+from elementary.monitor.alerts.source_freshness_alert import SourceFreshnessAlertModel
+from elementary.monitor.alerts.test_alert import TestAlertModel
+from elementary.monitor.data_monitoring.alerts.integrations.utils.orchestrator_link import (
+    OrchestratorLinkData,
+    create_job_link,
+    create_orchestrator_link,
+)
+
+
+class TestOrchestratorLinkCreation:
+    """Test orchestrator link creation functionality."""
+
+    def test_create_orchestrator_link_with_valid_data(self):
+        orchestrator_info = {
+            "job_name": "nightly_load",
+            "run_id": "12345",
+            "orchestrator": "airflow",
+            "run_url": "https://airflow.example.com/run/12345",
+        }
+
+        link = create_orchestrator_link(orchestrator_info)
+
+        assert link is not None
+        assert link.text == "View in Airflow"
+        assert link.url == "https://airflow.example.com/run/12345"
+        assert link.orchestrator == "airflow"
+        assert link.icon == Icon.INFO
+
+    def test_create_orchestrator_link_formats_orchestrator_names(self):
+        test_cases = [
+            ("airflow", "View in Airflow"),
+            ("dbt_cloud", "View in Dbt Cloud"),
+            ("github_actions", "View in Github Actions"),
+            ("custom_orchestrator", "View in Custom Orchestrator"),
+        ]
+
+        for orchestrator, expected_text in test_cases:
+            orchestrator_info = {
+                "orchestrator": orchestrator,
+                "run_url": "https://example.com/run/123",  # noqa: E231
+            }
+
+            link = create_orchestrator_link(orchestrator_info)
+
+            assert link is not None
+            assert link.text == expected_text
+            assert link.orchestrator == orchestrator
+
+    def test_create_orchestrator_link_without_url_returns_none(self):
+        orchestrator_info = {
+            "job_name": "nightly_load",
+            "orchestrator": "airflow"
+            # No run_url
+        }
+
+        link = create_orchestrator_link(orchestrator_info)
+        assert link is None
+
+    def test_create_orchestrator_link_with_empty_info_returns_none(self):
+        link = create_orchestrator_link({})
+        assert link is None
+
+    def test_create_job_link_with_valid_data(self):
+        orchestrator_info = {
+            "job_name": "nightly_load",
+            "orchestrator": "airflow",
+            "job_url": "https://airflow.example.com/job/nightly_load",
+        }
+
+        link = create_job_link(orchestrator_info)
+
+        assert link is not None
+        assert link.text == "nightly_load in Airflow"
+        assert link.url == "https://airflow.example.com/job/nightly_load"
+        assert link.orchestrator == "airflow"
+        assert link.icon == Icon.GEAR
+
+    def test_create_job_link_without_url_returns_none(self):
+        orchestrator_info = {
+            "job_name": "nightly_load",
+            "orchestrator": "airflow"
+            # No job_url
+        }
+
+        link = create_job_link(orchestrator_info)
+        assert link is None
+
+
+class TestAlertModelOrchestratorInfo:
+    """Test AlertModel orchestrator_info property across all alert types."""
+
+    def test_test_alert_orchestrator_info_with_complete_data(self):
+        alert = TestAlertModel(
+            id="test_id",
+            test_unique_id="test_unique_id",
+            elementary_unique_id="elementary_unique_id",
+            test_name="test_name",
+            severity="error",
+            test_type="dbt_test",
+            test_sub_type="generic",
+            test_short_name="test_short_name",
+            alert_class_id="test_alert_class_id",
+            job_name="nightly_load",
+            job_run_id="12345",
+            orchestrator="airflow",
+            job_url="https://airflow.example.com/job/nightly_load",
+            job_run_url="https://airflow.example.com/run/12345",
+        )
+
+        info = alert.orchestrator_info
+        assert info is not None
+        assert info["job_name"] == "nightly_load"
+        assert info["run_id"] == "12345"
+        assert info["orchestrator"] == "airflow"
+        assert info["job_url"] == "https://airflow.example.com/job/nightly_load"
+        assert info["run_url"] == "https://airflow.example.com/run/12345"
+
+    def test_test_alert_orchestrator_info_with_minimal_data(self):
+        alert = TestAlertModel(
+            id="test_id",
+            test_unique_id="test_unique_id",
+            elementary_unique_id="elementary_unique_id",
+            test_name="test_name",
+            severity="error",
+            test_type="dbt_test",
+            test_sub_type="generic",
+            test_short_name="test_short_name",
+            alert_class_id="test_alert_class_id",
+            job_name="test_job"
+            # Only job_name provided
+        )
+
+        info = alert.orchestrator_info
+        assert info is not None
+        assert info["job_name"] == "test_job"
+        assert len(info) == 1
+
+    def test_test_alert_orchestrator_info_with_no_data_returns_none(self):
+        alert = TestAlertModel(
+            id="test_id",
+            test_unique_id="test_unique_id",
+            elementary_unique_id="elementary_unique_id",
+            test_name="test_name",
+            severity="error",
+            test_type="dbt_test",
+            test_sub_type="generic",
+            test_short_name="test_short_name",
+            alert_class_id="test_alert_class_id"
+            # No orchestrator fields
+        )
+
+        info = alert.orchestrator_info
+        assert info is None
+
+    def test_model_alert_orchestrator_info(self):
+        alert = ModelAlertModel(
+            id="model_alert_id",
+            alias="test_model",
+            path="/models/test_model.sql",
+            original_path="models/test_model.sql",
+            materialization="table",
+            full_refresh=False,
+            alert_class_id="model_alert_class",
+            job_name="nightly_build",
+            job_run_id="67890",
+            orchestrator="dbt_cloud",
+            job_run_url="https://cloud.getdbt.com/run/67890",
+        )
+
+        info = alert.orchestrator_info
+        assert info is not None
+        assert info["job_name"] == "nightly_build"
+        assert info["run_id"] == "67890"
+        assert info["orchestrator"] == "dbt_cloud"
+        assert info["run_url"] == "https://cloud.getdbt.com/run/67890"
+
+    def test_source_freshness_alert_orchestrator_info(self):
+        alert = SourceFreshnessAlertModel(
+            id="source_alert_id",
+            source_name="test_source",
+            identifier="test_table",
+            original_status="error",
+            path="sources.yml",
+            error="Freshness check failed",
+            alert_class_id="source_alert_class",
+            source_freshness_execution_id="exec_123",
+            job_name="freshness_check",
+            orchestrator="airflow",
+            job_run_url="https://airflow.example.com/run/111",
+        )
+
+        info = alert.orchestrator_info
+        assert info is not None
+        assert info["job_name"] == "freshness_check"
+        assert info["orchestrator"] == "airflow"
+        assert info["run_url"] == "https://airflow.example.com/run/111"
+
+
+class TestOrchestratorInfoEdgeCases:
+    """Test edge cases and error handling for orchestrator integration."""
+
+    def test_orchestrator_info_with_empty_strings(self):
+        alert = TestAlertModel(
+            id="test_id",
+            test_unique_id="test_unique_id",
+            elementary_unique_id="elementary_unique_id",
+            test_name="test_name",
+            severity="error",
+            test_type="dbt_test",
+            test_sub_type="generic",
+            test_short_name="test_short_name",
+            alert_class_id="test_alert_class_id",
+            job_name="",  # Empty string
+            orchestrator="",  # Empty string
+            job_run_url="",  # Empty string
+        )
+
+        info = alert.orchestrator_info
+        assert info is None
+
+    def test_orchestrator_info_filters_none_values(self):
+        alert = TestAlertModel(
+            id="test_id",
+            test_unique_id="test_unique_id",
+            elementary_unique_id="elementary_unique_id",
+            test_name="test_name",
+            severity="error",
+            test_type="dbt_test",
+            test_sub_type="generic",
+            test_short_name="test_short_name",
+            alert_class_id="test_alert_class_id",
+            job_name="valid_job",
+            orchestrator=None,  # None value
+            job_run_url=None,  # None value
+        )
+
+        info = alert.orchestrator_info
+        assert info is not None
+        assert "job_name" in info
+        assert "orchestrator" not in info
+        assert "run_url" not in info
+        assert len(info) == 1
+
+    def test_orchestrator_info_with_only_run_id(self):
+        alert = TestAlertModel(
+            id="test_id",
+            test_unique_id="test_unique_id",
+            elementary_unique_id="elementary_unique_id",
+            test_name="test_name",
+            severity="error",
+            test_type="dbt_test",
+            test_sub_type="generic",
+            test_short_name="test_short_name",
+            alert_class_id="test_alert_class_id",
+            job_run_id="12345",  # Only run_id provided
+        )
+
+        info = alert.orchestrator_info
+        assert info is not None
+        assert info["run_id"] == "12345"
+        assert len(info) == 1
+
+    def test_orchestrator_info_with_only_orchestrator(self):
+        alert = TestAlertModel(
+            id="test_id",
+            test_unique_id="test_unique_id",
+            elementary_unique_id="elementary_unique_id",
+            test_name="test_name",
+            severity="error",
+            test_type="dbt_test",
+            test_sub_type="generic",
+            test_short_name="test_short_name",
+            alert_class_id="test_alert_class_id",
+            orchestrator="dbt_cloud",  # Only orchestrator provided
+        )
+
+        info = alert.orchestrator_info
+        assert info is not None
+        assert info["orchestrator"] == "dbt_cloud"
+        assert len(info) == 1
+
+
+class TestOrchestratorLinkDataModel:
+    """Test OrchestratorLinkData model validation."""
+
+    def test_orchestrator_link_data_creation(self):
+        link = OrchestratorLinkData(
+            url="https://airflow.example.com/run/123",
+            text="View in Airflow",
+            orchestrator="airflow",
+            icon=Icon.INFO,
+        )
+
+        assert link.url == "https://airflow.example.com/run/123"
+        assert link.text == "View in Airflow"
+        assert link.orchestrator == "airflow"
+        assert link.icon == Icon.INFO
+
+    def test_orchestrator_link_data_without_icon(self):
+        link = OrchestratorLinkData(
+            url="https://airflow.example.com/run/123",
+            text="View in Airflow",
+            orchestrator="airflow"
+            # icon is optional
+        )
+
+        assert link.icon is None
+
+    def test_orchestrator_link_data_required_fields(self):
+        # Should raise validation error if required fields are missing
+        with pytest.raises((TypeError, ValueError)):
+            OrchestratorLinkData(
+                # Missing required fields
+                icon=Icon.INFO
+            )


### PR DESCRIPTION
This is a first attempt for https://github.com/elementary-data/elementary/issues/1944.  
I tested it locally with a failed model and a failed test:  
<img width="670" height="186" alt="image" src="https://github.com/user-attachments/assets/1c9b5755-13cb-485a-a460-ea8c7cf83cba" />
<img width="658" height="112" alt="image" src="https://github.com/user-attachments/assets/4ae2038f-df97-4523-b12a-ee54c1236a09" />

I'm not quite sure if the tests that Claude Code created make that much sense - looking forward to some feedback here.
