### PR TITLE
removed usage of deprecated `-m` flag in dbt

### DIFF
--- a/elementary/clients/dbt/command_line_dbt_runner.py
+++ b/elementary/clients/dbt/command_line_dbt_runner.py
@@ -205,7 +205,6 @@ class CommandLineDbtRunner(BaseDbtRunner):
 
     def run(
         self,
-        models: Optional[str] = None,
         select: Optional[str] = None,
         selector: Optional[str] = None,
         full_refresh: bool = False,
@@ -216,8 +215,6 @@ class CommandLineDbtRunner(BaseDbtRunner):
         command_args = ["run"]
         if full_refresh:
             command_args.append("--full-refresh")
-        if models:
-            command_args.extend(["-m", models])
         if select:
             command_args.extend(["-s", select])
         if selector:

--- a/elementary/monitor/data_monitoring/alerts/data_monitoring_alerts.py
+++ b/elementary/monitor/data_monitoring/alerts/data_monitoring_alerts.py
@@ -107,7 +107,7 @@ class DataMonitoringAlerts(DataMonitoring):
         if days_back:
             vars.update(days_back=days_back)
         success = self.internal_dbt_runner.run(
-            models="elementary_cli.alerts.alerts_v2",
+            select="elementary_cli.alerts.alerts_v2",
             full_refresh=dbt_full_refresh,
             vars=vars,
         )


### PR DESCRIPTION
the `-m` flag was deprecated in favor of `-s` in 2021
https://docs.getdbt.com/reference/deprecations#modelparamusagedeprecation
removed its usage in the project<!-- pylon-ticket-id: 464ef088-b291-49e6-964e-13c3f5dd64e0 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized dbt run filtering to use select/selector; removed models-based filtering.
  * Updated alerting workflows to use select while maintaining existing behavior.
  * Breaking change: scripts or integrations passing models must switch to select or selector.
  * Other options (full_refresh, vars, quiet, capture_output) remain unchanged.
  * Improves consistency with dbt conventions and simplifies the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->