### PR TITLE
Handle empty result in clickhouse

### DIFF
--- a/elementary/monitor/dbt_project/macros/get_result_rows_agate.sql
+++ b/elementary/monitor/dbt_project/macros/get_result_rows_agate.sql
@@ -9,5 +9,9 @@
     and elementary_test_results_id in ({{ valid_ids_query }})
   {% endif %}
   {% endset %}
-  {% do return(elementary.run_query(query).group_by("elementary_test_results_id")) %}
+  {% set res = elementary.run_query(query) %}
+  {% if not res %}
+    {% do return({}) %}
+  {% endif %}
+  {% do return(res.group_by("elementary_test_results_id")) %}
 {% endmacro %}


### PR DESCRIPTION
In most warehouses, when running a query with no results, we get an empty table that contains the queried columns in return
In clickhouse, we get an empty table without any columns...

<!-- pylon-ticket-id: 913ffbf9-3866-4654-9031-1f6f0a95430c -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty query results to prevent errors during result grouping.
  * Ensures a consistent empty response when no data is returned, improving stability in edge cases.

* **Chores**
  * Minor internal adjustments to result processing logic for safer execution paths with no data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->