### PR TITLE
only check fork on PR events

### DIFF
--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Set requires approval output
         id: set-output
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request_target" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+          if [[ "${{ github.event_name }}" =~ ^pull_request && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
             echo "requires_approval=true" >> $GITHUB_OUTPUT
           else
             echo "requires_approval=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
null<!-- pylon-ticket-id: 7c44591f-013e-4822-9091-f574bbbae069 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow triggers to match all pull_request events (e.g., pull_request and pull_request_target) instead of a single event, ensuring the approval check runs more consistently across scenarios.
  * Maintains existing fork-detection logic and approval flag behavior; only the activation condition is broadened.
  * Improves reliability of contributor workflow by applying the same checks regardless of which pull request event initiates the run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->