### PR TITLE
Ele 5089 use row number instead of rank

### DIFF
--- a/elementary/monitor/dbt_project/macros/get_models_runs.sql
+++ b/elementary/monitor/dbt_project/macros/get_models_runs.sql
@@ -1,14 +1,14 @@
 {%- macro get_models_runs(days_back = 7, exclude_elementary=false) -%}
     {% set models_runs_query %}
         with model_runs as (
-            select 
+            select
                 *,
-                rank() over (partition by unique_id order by generated_at desc) as invocations_rank_index
+                row_number() over (partition by unique_id order by generated_at desc) as invocations_rank_index
             from {{ ref('elementary', 'model_run_results') }}
         )
 
         select
-            unique_id, 
+            unique_id,
             invocation_id,
             name,
             schema_name as schema,

--- a/elementary/monitor/dbt_project/macros/get_source_freshness_results.sql
+++ b/elementary/monitor/dbt_project/macros/get_source_freshness_results.sql
@@ -11,7 +11,7 @@
             select
                 *,
                 {{ elementary_cli.normalized_source_freshness_status()}},
-                rank() over (partition by unique_id order by generated_at desc) as invocations_rank_index
+                row_number() over (partition by unique_id order by generated_at desc) as invocations_rank_index
             from {{ ref('elementary', 'dbt_source_freshness_results') }}
             {% if days_back %}
                 where {{ elementary.edr_datediff(elementary.edr_cast_as_timestamp('generated_at'), elementary.edr_current_timestamp(), 'day') }} < {{ days_back }}

--- a/elementary/monitor/dbt_project/macros/get_test_results.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_results.sql
@@ -14,7 +14,7 @@
                 *,
                 {{ elementary.edr_datediff(elementary.edr_cast_as_timestamp('detected_at'), elementary.edr_current_timestamp(), 'day') }} as days_diff,
                 {# When we split test into multiple test results, we want to have the same invocation order for the test results from the same run so we use rank. #}
-                rank() over (partition by elementary_unique_id order by {{elementary.edr_cast_as_timestamp('detected_at')}} desc) as invocations_rank_index
+                row_number() over (partition by elementary_unique_id order by {{elementary.edr_cast_as_timestamp('detected_at')}} desc) as invocations_rank_index
             from test_results
         )
 
@@ -193,7 +193,7 @@
         etr.status,
         drr.execution_time,
         {{ elementary.edr_datediff(elementary.edr_cast_as_timestamp('etr.detected_at'), elementary.edr_current_timestamp(), 'day') }} AS days_diff,
-        RANK() OVER (PARTITION BY elementary_unique_id ORDER BY etr.detected_at DESC) AS invocations_rank_index,
+        ROW_NUMBER() OVER (PARTITION BY elementary_unique_id ORDER BY etr.detected_at DESC) AS invocations_rank_index,
         etr.failures,
         etr.result_rows
     FROM {{ ref('elementary', 'elementary_test_results') }} etr


### PR DESCRIPTION
null<!-- pylon-ticket-id: 6dd98198-d89b-473b-ae48-64111b0f89b7 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Made recent-invocation selection deterministic across tests, models, and sources, eliminating tie-related inconsistencies.
  - Ensures unique, sequential invocation indices per resource, preventing gaps and duplicate rankings.
  - Improves reliability of filters based on invocations-per-test and stabilizes result ordering across environments.
  - Reduces flakiness in dashboards, comparisons, and alerts caused by non-deterministic ordering in tied timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->