### PR TITLE
Add attribution block to alert messages in data monitoring

### DIFF
--- a/elementary/monitor/data_monitoring/alerts/data_monitoring_alerts.py
+++ b/elementary/monitor/data_monitoring/alerts/data_monitoring_alerts.py
@@ -7,8 +7,14 @@ from alive_progress import alive_bar
 
 from elementary.config.config import Config
 from elementary.messages.block_builders import TextLineBlock
-from elementary.messages.blocks import HeaderBlock, LinesBlock
-from elementary.messages.message_body import MessageBody
+from elementary.messages.blocks import (
+    HeaderBlock,
+    LineBlock,
+    LinesBlock,
+    LinkBlock,
+    TextBlock,
+)
+from elementary.messages.message_body import MessageBlock, MessageBody
 from elementary.messages.messaging_integrations.base_messaging_integration import (
     BaseMessagingIntegration,
     MessageSendResult,
@@ -55,6 +61,37 @@ def get_health_check_message() -> MessageBody:
             ),
         ]
     )
+
+
+def _add_elementary_attribution(body: MessageBody) -> MessageBody:
+    lines = [
+        LineBlock(
+            inlines=[
+                TextBlock(text="Powered by"),
+                LinkBlock(
+                    text="Elementary",
+                    url="https://www.elementary-data.com/",
+                ),
+            ]
+        )
+    ]
+    attribution_block = LinesBlock(
+        lines=lines,
+    )
+
+    new_blocks: List[MessageBlock] = []
+    first_block_is_header = body.blocks and isinstance(body.blocks[0], HeaderBlock)
+    if first_block_is_header:
+        new_blocks = [body.blocks[0], attribution_block, *body.blocks[1:]]
+    else:
+        new_blocks = [*body.blocks, attribution_block]
+
+    body_with_attribution = MessageBody(
+        blocks=new_blocks,
+        color=body.color,
+        id=body.id,
+    )
+    return body_with_attribution
 
 
 class DataMonitoringAlerts(DataMonitoring):
@@ -313,6 +350,7 @@ class DataMonitoringAlerts(DataMonitoring):
         alert_message_body = alert_message_builder.build(
             alert=alert,
         )
+        alert_message_body = _add_elementary_attribution(alert_message_body)
         try:
             self._send_message(
                 integration=self.alerts_integration,


### PR DESCRIPTION
- Introduced a new function  to append an attribution block to alert messages.
- Updated the alert message construction to include the attribution block, enhancing message content with a link to Elementary.
- Refactored imports for better organization and clarity.<!-- pylon-ticket-id: d410c59a-89d8-4e8f-85e9-a354745f92b8 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alert messages now include a subtle “Powered by Elementary” attribution with a hyperlink to learn more. It appears right after the alert title when available, or at the end of the message otherwise. This is purely visual and does not affect alert delivery or settings. Existing integrations and formatting remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->