### PR TITLE
Added more detailed exception for teams webhook failure

### DIFF
--- a/elementary/messages/messaging_integrations/teams_webhook.py
+++ b/elementary/messages/messaging_integrations/teams_webhook.py
@@ -27,6 +27,15 @@ Channel: TypeAlias = Optional[str]
 ONE_SECOND = 1
 
 
+class TeamsWebhookHttpError(MessagingIntegrationError):
+    def __init__(self, response: requests.Response):
+        self.status_code = response.status_code
+        self.response = response
+        super().__init__(
+            f"Failed to send message to Teams webhook: {response.status_code}"
+        )
+
+
 def send_adaptive_card(webhook_url: str, card: dict) -> requests.Response:
     payload = {
         "type": "message",
@@ -88,6 +97,8 @@ class TeamsWebhookMessagingIntegration(
                 timestamp=datetime.utcnow(),
                 message_format="adaptive_cards",
             )
+        except requests.HTTPError as e:
+            raise TeamsWebhookHttpError(e.response) from e
         except requests.RequestException as e:
             raise MessagingIntegrationError(
                 f"An error occurred while posting message to Teams webhook: {str(e)}"


### PR DESCRIPTION
null<!-- pylon-ticket-id: 1a03b0e4-a445-40ab-aefe-50f1b2078c59 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for Microsoft Teams webhook notifications. When a message fails to send, the app now surfaces clearer error messages with HTTP status codes.
  - Underlying HTTP errors are unified into a single, user-facing error while preserving response details for easier troubleshooting.
  - Reduces ambiguity around delivery failures, making it simpler to diagnose misconfiguration or endpoint issues. No impact on successful message delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->