### PR TITLE
Configure stale workflow: mark stale after 60 days, close after 30 da…

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,9 +11,10 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v10
         with:
-          days-before-stale: 180
+          days-before-stale: 60
+          days-before-close: 30
           stale-issue-message: |
             This issue is stale because it has been open for too long with no activity.
             If you would like the issue to remain open, please remove the stale label or leave a comment.


### PR DESCRIPTION
…ys, upgrade to v10<!-- pylon-ticket-id: eaf5fc75-6799-4abc-93ab-8d491f2de1d7 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow for improved repository maintenance, including upgraded stale action version and adjusted staleness parameters to streamline issue and PR management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->