### PR TITLE
Fix namespace of macro call

### DIFF
--- a/elementary/monitor/dbt_project/macros/get_result_rows_agate.sql
+++ b/elementary/monitor/dbt_project/macros/get_result_rows_agate.sql
@@ -1,5 +1,5 @@
 {% macro get_result_rows_agate(days_back, valid_ids_query = none) %}
-  {% do return(adapter.dispatch('get_result_rows_agate', 'elementary')(days_back, valid_ids_query)) %}
+  {% do return(adapter.dispatch('get_result_rows_agate', 'elementary_cli')(days_back, valid_ids_query)) %}
 {% endmacro %}
 
 {% macro default__get_result_rows_agate(days_back, valid_ids_query = none) %}


### PR DESCRIPTION
## Description

A [recent change](https://github.com/elementary-data/elementary/pull/1940) in the `get_result_rows_agate` macro added specific implementation for BigQuery.
The namespace of the dispatch call was `elementary` instead of `elementary_cli`, causing the error:
```
No macro named 'get_result_rows_agate' found within namespace: 'elementary'
```

<!-- pylon-ticket-id: 51cdf2d0-d9e5-4ae4-810e-4aebebf31903 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal adapter dispatch mechanism to optimize system operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->