### PR TITLE
unfurl_links=False for avoiding preview in slack messages

### DIFF
--- a/elementary/messages/messaging_integrations/slack_web.py
+++ b/elementary/messages/messaging_integrations/slack_web.py
@@ -104,6 +104,7 @@ class SlackWebMessagingIntegration(
                 blocks=json.dumps(formatted_message.blocks),
                 attachments=json.dumps(formatted_message.attachments),
                 thread_ts=thread_ts,
+                unfurl_links=False,
                 reply_broadcast=reply_broadcast,
             )
         except SlackApiError as e:


### PR DESCRIPTION
Before the change:
<img width="1266" height="611" alt="image" src="https://github.com/user-attachments/assets/4527faa9-a7d6-4781-9d9c-281e2741778a" />

After the change:
<img width="1266" height="480" alt="image" src="https://github.com/user-attachments/assets/df2909e8-1a7d-465c-9411-0ebc0506fc90" />


null<!-- pylon-ticket-id: bd9713a8-dd8a-45a1-ae62-fd391ca6b220 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Slack message handling to prevent automatic link unfurling, ensuring links display as plain text rather than expanded previews in messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->