### PR TITLE
Include Seeds and Snapshots w/o Tests in Dashboard

### DIFF
--- a/elementary/monitor/api/filters/filters.py
+++ b/elementary/monitor/api/filters/filters.py
@@ -6,6 +6,7 @@ from elementary.monitor.api.models.schema import (
     ModelRunsSchema,
     NormalizedModelSchema,
     NormalizedSeedSchema,
+    NormalizedSnapshotSchema,
     NormalizedSourceSchema,
 )
 from elementary.monitor.api.totals_schema import TotalsSchema
@@ -27,12 +28,13 @@ class FiltersAPI(APIClient):
         sources: Dict[str, NormalizedSourceSchema],
         models_runs: List[ModelRunsSchema],
         seeds: Dict[str, NormalizedSeedSchema],
+        snapshots: Dict[str, NormalizedSnapshotSchema],
     ) -> FiltersSchema:
         test_results_filters = self._get_test_filters(
-            test_results_totals, models, sources, seeds
+            test_results_totals, models, sources, seeds, snapshots
         )
         test_runs_filters = self._get_test_filters(
-            test_runs_totals, models, sources, seeds
+            test_runs_totals, models, sources, seeds, snapshots
         )
         model_runs_filters = self._get_model_runs_filters(models_runs)
         return FiltersSchema(
@@ -47,6 +49,7 @@ class FiltersAPI(APIClient):
         models: Dict[str, NormalizedModelSchema],
         sources: Dict[str, NormalizedSourceSchema],
         seeds: Dict[str, NormalizedSeedSchema],
+        snapshots: Dict[str, NormalizedSnapshotSchema],
     ) -> List[FilterSchema]:
         failures_filter = FilterSchema(name="failures", display_name="Failures")
         warnings_filter = FilterSchema(name="warnings", display_name="Warnings")
@@ -59,6 +62,7 @@ class FiltersAPI(APIClient):
             *models.values(),
             *sources.values(),
             *seeds.values(),
+            *snapshots.values(),
         ]
         for artifact in artifacts:
             if artifact.unique_id and artifact.unique_id not in totals_models_ids:

--- a/elementary/monitor/api/report/report.py
+++ b/elementary/monitor/api/report/report.py
@@ -167,6 +167,7 @@ class ReportAPI(APIClient):
                 sources,
                 models_runs.runs,
                 seeds,
+                snapshots,
             )
 
             serializable_groups = groups.dict()


### PR DESCRIPTION
## Description

Seeds and Snapshots without tests weren't part of the report `filters`, causing them to not appear in the Dashboard panels.

## Tests

### Before the change

Only models and sources were part of the "No Tests" filter.
```
            {
                "name": "no_test",
                "display_name": "No Tests",
                "model_unique_ids": [
                    "model.elementary_tutorial.stg_orders",
                    "model.elementary_tutorial.stg_customers",
                    "model.elementary_tutorial.stg_payments",
                    "source.elementary_tutorial.customers_traning_v2.CUSTOMERS_TRAINING_V2",
                    "model.elementary_tutorial.stg_signups"
                ]
            }
```

And 5 tables in the "Not monitored" in the dashboard:
<img width="391" height="256" alt="image" src="https://github.com/user-attachments/assets/eb95628f-909b-4cdb-9b69-12c44de3b5c0" />


### After the change
Seeds and snapshots without tests appear in the filter:
```
            {
                "name": "no_test",
                "display_name": "No Tests",
                "model_unique_ids": [
                    "model.elementary_tutorial.stg_customers",
                    "model.elementary_tutorial.stg_signups",
                    "seed.elementary_tutorial.payments_training",
                    "seed.elementary_tutorial.signups_validation",
                    "seed.elementary_tutorial.customers_validation",
                    "seed.elementary_tutorial.signups_training",
                    "model.elementary_tutorial.stg_payments",
                    "seed.elementary_tutorial.orders_validation",
                    "seed.elementary_tutorial.orders_training",
                    "source.elementary_tutorial.customers_traning_v2.CUSTOMERS_TRAINING_V2",
                    "model.elementary_tutorial.stg_orders",
                    "seed.elementary_tutorial.payments_validation",
                    "snapshot.elementary_tutorial.orders_snapshot"
                ]
            }
```

And 13 tables in the "Not monitored" in the dashboard (old 5 + 7 seeds + 1 snapshot)
<img width="359" height="240" alt="image" src="https://github.com/user-attachments/assets/29ace022-9f27-4231-9dc4-4ec1f7a72246" />


<!-- pylon-ticket-id: null -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Seeds and snapshots are now included in the filtering system, improving filter coverage when generating reports and viewing test/run results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->