### PR TITLE
Fix #2084: Handle 'none' severity value in TestResultDBRowSchema

### DIFF
--- a/elementary/monitor/fetchers/tests/schema.py
+++ b/elementary/monitor/fetchers/tests/schema.py
@@ -101,6 +101,16 @@ class TestResultDBRowSchema(ExtendedBaseModel):
         # Elementary's tests doesn't return correct failures.
         return failures or None if test_type == "dbt_test" else None
 
+    @validator("severity", pre=True)
+    def normalize_severity(cls, severity):
+        # Handle dbt-fusion and other adapters that may return "none" as a string
+        # instead of null/None. See issue #2084.
+        if severity is None:
+            return None
+        if isinstance(severity, str) and severity.lower() == "none":
+            return None
+        return severity
+
 
 class TestDBRowSchema(ExtendedBaseModel):
     unique_id: str

--- a/tests/unit/monitor/fetchers/tests/test_schema.py
+++ b/tests/unit/monitor/fetchers/tests/test_schema.py
@@ -1,0 +1,86 @@
+import pytest
+
+from elementary.monitor.fetchers.tests.schema import TestResultDBRowSchema
+
+
+@pytest.fixture
+def base_test_result():
+    """Base test result data for TestResultDBRowSchema tests."""
+    return {
+        "id": "test_id_1",
+        "test_unique_id": "unique_id_1",
+        "elementary_unique_id": "elem_id_1",
+        "detected_at": "2023-01-01 10:00:00",
+        "schema_name": "test_schema",
+        "column_name": None,
+        "test_type": "dbt_test",
+        "test_sub_type": "generic",
+        "test_results_description": "Test description",
+        "original_path": "path/to/test",
+        "other": None,
+        "test_name": "test_name",
+        "test_params": {},
+        "status": "pass",
+        "days_diff": 1,
+        "invocations_rank_index": 1,
+        "meta": {},
+        "model_meta": {},
+    }
+
+
+class TestTestResultDBRowSchema:
+    """Tests for TestResultDBRowSchema validation."""
+
+    def test_severity_error(self, base_test_result):
+        """Test that 'ERROR' severity is handled correctly."""
+        data = {**base_test_result, "severity": "ERROR"}
+        result = TestResultDBRowSchema(**data)
+        assert result.severity == "ERROR"
+
+    def test_severity_warn(self, base_test_result):
+        """Test that 'WARN' severity is handled correctly."""
+        data = {**base_test_result, "severity": "WARN"}
+        result = TestResultDBRowSchema(**data)
+        assert result.severity == "WARN"
+
+    def test_severity_none_string_lowercase(self, base_test_result):
+        """Test that lowercase 'none' string is normalized to None.
+        
+        This addresses issue #2084 where dbt-fusion returns "none" as a string
+        instead of null/None, causing validation errors.
+        """
+        data = {**base_test_result, "severity": "none"}
+        result = TestResultDBRowSchema(**data)
+        assert result.severity is None
+
+    def test_severity_none_string_uppercase(self, base_test_result):
+        """Test that uppercase 'NONE' string is normalized to None."""
+        data = {**base_test_result, "severity": "NONE"}
+        result = TestResultDBRowSchema(**data)
+        assert result.severity is None
+
+    def test_severity_none_string_mixed_case(self, base_test_result):
+        """Test that mixed case 'None' string is normalized to None."""
+        data = {**base_test_result, "severity": "None"}
+        result = TestResultDBRowSchema(**data)
+        assert result.severity is None
+
+    def test_severity_python_none(self, base_test_result):
+        """Test that Python None is handled correctly."""
+        data = {**base_test_result, "severity": None}
+        result = TestResultDBRowSchema(**data)
+        assert result.severity is None
+
+    def test_severity_missing_field(self, base_test_result):
+        """Test that missing severity field defaults to None."""
+        # Remove severity from base_test_result to simulate it not being provided
+        data = {k: v for k, v in base_test_result.items() if k != "severity"}
+        result = TestResultDBRowSchema(**data)
+        assert result.severity is None
+
+    def test_severity_empty_string(self, base_test_result):
+        """Test that empty string severity is preserved (not normalized to None)."""
+        data = {**base_test_result, "severity": ""}
+        result = TestResultDBRowSchema(**data)
+        # Empty string should be preserved as-is
+        assert result.severity == ""


### PR DESCRIPTION
## Summary

This PR fixes issue #2084 where the "none" severity value causes a validation error in `TestResultDBRowSchema` when using dbt-fusion.

## Problem

dbt-fusion returns severity as the string "none" (lowercase) instead of `null`/`None`. This caused a validation error:
```
ERROR — Could not generate the report - Error: 1 validation error for TestResultDBRowSchema
severity
 none is not an allowed value (type=type_error.none.not_allowed)
```

## Solution

Added a Pydantic validator `normalize_severity` to `TestResultDBRowSchema` that:
1. Converts the string "none" (case-insensitive) to Python `None`
2. Preserves other severity values as-is
3. Handles `None` values correctly

## Changes

- Modified `elementary/monitor/fetchers/tests/schema.py` - Added `normalize_severity` validator
- Added `tests/unit/monitor/fetchers/tests/test_schema.py` - Comprehensive tests for severity validation

## Testing

All 8 new tests pass:
- test_severity_error
- test_severity_warn
- test_severity_none_string_lowercase
- test_severity_none_string_uppercase
- test_severity_none_string_mixed_case
- test_severity_python_none
- test_severity_missing_field
- test_severity_empty_string

Fixes #2084<!-- pylon-ticket-id: c739a397-ce59-4a62-9880-0813f853949a -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed severity field normalization to consistently handle different representations of null values across data adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->