### PR TITLE
fix: Truncate large table samples in Teams alerts to prevent payload size issues

### DIFF
--- a/elementary/config/config.py
+++ b/elementary/config/config.py
@@ -72,6 +72,7 @@ class Config:
         report_url: Optional[str] = None,
         teams_webhook: Optional[str] = None,
         maximum_columns_in_alert_samples: Optional[int] = None,
+        maximum_rows_in_alert_samples_table: Optional[int] = None,
         env: str = DEFAULT_ENV,
         run_dbt_deps_if_needed: Optional[bool] = None,
         project_name: Optional[str] = None,
@@ -110,6 +111,12 @@ class Config:
             maximum_columns_in_alert_samples,
             config.get("maximum_columns_in_alert_samples"),
             4,
+        )
+
+        self.maximum_rows_in_alert_samples_table = self._first_not_none(
+            maximum_rows_in_alert_samples_table,
+            config.get("maximum_rows_in_alert_samples_table"),
+            25,
         )
 
         self.timezone = self._first_not_none(

--- a/elementary/monitor/cli.py
+++ b/elementary/monitor/cli.py
@@ -298,6 +298,13 @@ def get_cli_properties() -> dict:
     default=4,
     help="Maximum number of columns to display as a table in alert samples. Above this, the output is shown as raw JSON.",
 )
+@click.option(
+    "--maximum-rows-in-alert-samples-table",
+    "-mr",
+    type=int,
+    default=25,
+    help="Maximum number of rows to display in a table in alert samples. Above this, the table will be truncated to prevent Teams payload size issues.",
+)
 @click.pass_context
 def monitor(
     ctx,
@@ -330,6 +337,7 @@ def monitor(
     excludes,
     teams_webhook,
     maximum_columns_in_alert_samples,
+    maximum_rows_in_alert_samples_table,
     quiet_logs,
 ):
     """
@@ -364,6 +372,7 @@ def monitor(
         report_url=report_url,
         teams_webhook=teams_webhook,
         maximum_columns_in_alert_samples=maximum_columns_in_alert_samples,
+        maximum_rows_in_alert_samples_table=maximum_rows_in_alert_samples_table,
         quiet_logs=quiet_logs,
     )
     anonymous_tracking = AnonymousCommandLineTracking(config)

--- a/elementary/monitor/data_monitoring/alerts/data_monitoring_alerts.py
+++ b/elementary/monitor/data_monitoring/alerts/data_monitoring_alerts.py
@@ -129,7 +129,8 @@ class DataMonitoringAlerts(DataMonitoring):
         self.alerts_integration = self._get_integration_client()
         self.alert_message_builder = AlertMessageBuilder(
             MessageBuilderConfig(
-                maximum_columns_in_alert_samples=self.config.maximum_columns_in_alert_samples
+                maximum_columns_in_alert_samples=self.config.maximum_columns_in_alert_samples,
+                maximum_rows_in_alert_samples_table=self.config.maximum_rows_in_alert_samples_table,
             )
         )
 


### PR DESCRIPTION
## Description

This PR fixes issue #2044 where Teams alerts fail when the payload is too large (typically when there are >25 rows with multiple columns in test result samples).

## Changes

- Added new `maximum_rows_in_alert_samples_table` config parameter (default: 25)
- Added table truncation logic in `_get_result_blocks()` that:
  - Limits table rows to the configured maximum
  - Adds a message indicating how many rows were omitted
- Added CLI option `--maximum-rows-in-alert-samples-table` (`-mr`) to customize the limit
- Updated `Config` class to handle the new parameter
- Updated `DataMonitoringAlerts` to pass the config to `AlertMessageBuilder`

## How it works

When test result samples exceed the row limit:
1. The table is truncated to the first N rows (default 25)
2. A message is added below the table: "... and X more rows (truncated to prevent payload size issues)"
3. The alert is sent successfully without hitting Teams' payload limits

## Testing

Added tests for:
- Large tables (>25 rows) being truncated
- Small tables (<25 rows) not being affected
- Edge case of exactly 25 rows (no truncation message)
- Config and MessageBuilderConfig integration

Fixes #2044<!-- pylon-ticket-id: 7a990041-1669-46d0-94ca-d3811f67f070 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added ability to limit the number of rows displayed in alert sample tables to prevent excessively large payloads. Configurable via new CLI option with a default limit of 25 rows. When the limit is exceeded, tables are truncated with a note indicating additional row count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->