### PR TITLE
Fix docs CI: remove deprecated types-pkg-resources

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,6 @@ pre-commit
 mypy
 
 # MyPy stubs
-types-pkg-resources
 types-requests
 networkx-stubs
 types-python-dateutil


### PR DESCRIPTION
## Summary
- Remove `types-pkg-resources` from `dev-requirements.txt` — it has been yanked from PyPI and is now part of `types-setuptools` (already listed)
- This was breaking the `code-quality` CI check on all docs branch PRs (e.g. #2115, #2117)
- Already fixed on `master`, this just syncs the docs branch

## Test plan
- [ ] Verify `code-quality` CI check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)<!-- pylon-ticket-id: c58489ae-7a54-4077-9ee6-c70a257dde42 -->