### PR TITLE
docs: add --slack-full-width documentation

### DIFF
--- a/docs/oss/deployment-and-configuration/slack.mdx
+++ b/docs/oss/deployment-and-configuration/slack.mdx
@@ -57,3 +57,15 @@ The alert format is:
 ```
 
 ---
+
+## Full-width alerts
+
+By default, Slack alerts use a narrower layout with some content in attachments. To use the full message width and show test results as a Markdown table in the main message body, pass the flag when running the monitor:
+
+```shell
+edr monitor --slack-token <your_slack_token> --slack-channel-name <channel> --slack-full-width
+```
+
+With `--slack-full-width`, alerts are sent using Slack Block Kit in the main message body instead of attachments, so the full channel width is used and test result samples appear as formatted Markdown tables.
+
+---

--- a/docs/oss/guides/alerts/send-slack-alerts.mdx
+++ b/docs/oss/guides/alerts/send-slack-alerts.mdx
@@ -28,6 +28,8 @@ Make sure to run the following command after your dbt runs and tests:
 edr monitor --slack-token <your_slack_token> --slack-channel-name <slack_channel_to_post_at> --group-by [table | alert]
 ```
 
+Add `--slack-full-width` to use the full message width and show test results as Markdown tables. See [Slack setup - Full-width alerts](/oss/deployment-and-configuration/slack#full-width-alerts).
+
 Or just `edr monitor` if you used `config.yml`. Please note that when you specify the --slack-channel-name, it's the
 default channel name to which all the alerts will be sent that are not attributed to any custom channel. Therefore,
 if you execute several `edr monitor` commands at the same time with different `slack-channel-name` arguments, they can


### PR DESCRIPTION
## Summary

Adds documentation for the new `--slack-full-width` CLI flag (from #2107) to the docs branch:

- **`docs/oss/deployment-and-configuration/slack.mdx`** — New "Full-width alerts" section explaining the flag and its behavior
- **`docs/oss/guides/alerts/send-slack-alerts.mdx`** — Reference to the new flag in the CLI execution section

Split out from #2107 since the docs branch has diverged from master.<!-- pylon-ticket-id: 484a3ed3-07ec-48aa-a5f2-2df3f10255f7 -->