### PR TITLE
docs: add Cloud schema tests pages and update schema validation overview

### DIFF
--- a/docs/cloud/features/data-tests/schema-tests/exposure-tests.mdx
+++ b/docs/cloud/features/data-tests/schema-tests/exposure-tests.mdx
@@ -1,0 +1,6 @@
+---
+title: Exposure tests
+sidebarTitle: Exposure tests
+---
+
+## Exposure tests

--- a/docs/cloud/features/data-tests/schema-tests/json-schema.mdx
+++ b/docs/cloud/features/data-tests/schema-tests/json-schema.mdx
@@ -1,0 +1,6 @@
+---
+title: JSON schema
+sidebarTitle: JSON schema
+---
+
+## JSON Schema

--- a/docs/cloud/features/data-tests/schema-tests/schema-changes-from-baseline.mdx
+++ b/docs/cloud/features/data-tests/schema-tests/schema-changes-from-baseline.mdx
@@ -1,0 +1,6 @@
+---
+title: Schema change from baseline
+sidebarTitle: Schema change - baseline
+---
+
+## Schema Changes from Baseline

--- a/docs/cloud/features/data-tests/schema-tests/schema-changes.mdx
+++ b/docs/cloud/features/data-tests/schema-tests/schema-changes.mdx
@@ -1,0 +1,6 @@
+---
+title: Schema change
+sidebarTitle: Schema change
+---
+
+## Schema Changes 

--- a/docs/cloud/features/data-tests/schema-validation-test.mdx
+++ b/docs/cloud/features/data-tests/schema-validation-test.mdx
@@ -5,25 +5,25 @@ sidebarTitle: Schema validation
 
 The Elementary dbt package includes the following schema validation tests:
 
-<Card title="Schema changes" href="data-tests/schema-tests/schema-changes">
+<Card title="Schema changes" href="schema-tests/schema-changes">
   Fails on changes in schema: deleted or added columns, or change of data type
   of a column.
 </Card>
 
 <Card
 title="Schema changes from baseline"
-href="data-tests/schema-tests/schema-changes-from-baseline"
+href="schema-tests/schema-changes-from-baseline"
 >
 Fails if the table schema is different in columns names or column types than a
 configured baseline (can be generated with a macro).
 </Card>
 
-<Card title="JSON schema" href="data-tests/schema-tests/json-schema">
+<Card title="JSON schema" href="schema-tests/json-schema">
   Monitors a JSON type column and fails if there are JSON events that don't
   match a configured JSON schema (can be generated with a macro).
 </Card>
 
-<Card title="Exposure schema" href="data-tests/schema-tests/exposure-tests">
+<Card title="Exposure schema" href="schema-tests/exposure-tests">
   Monitors changes in your models' columns that break schema for downstream
   exposures, such as BI dashboards.
 </Card>


### PR DESCRIPTION
Fix: #2175

We still need to complete the documentation for the missing pages. I've created the folders and files to fix the `404` errors, but the actual content is yet to be added.
<!-- pylon-ticket-id: 7cacc9f0-9150-41a0-97df-031a33cb673e -->