### PR TITLE
Add job_run_id and job_run_url fields into DbtInvocationSchema

### DIFF
--- a/elementary/monitor/dbt_project/macros/get_models_latest_invocations_data.sql
+++ b/elementary/monitor/dbt_project/macros/get_models_latest_invocations_data.sql
@@ -1,5 +1,8 @@
 {% macro get_models_latest_invocations_data() %}
   {% set invocations_relation = ref("dbt_invocations", package="elementary") %}
+  {% set job_url_exists = elementary.column_exists_in_relation(invocations_relation, 'job_url') %}
+  {% set job_run_id_exists = elementary.column_exists_in_relation(invocations_relation, 'job_run_id') %}
+  {% set job_run_url_exists = elementary.column_exists_in_relation(invocations_relation, 'job_run_url') %}
 
   {% set query %}
     with ordered_run_results as (
@@ -21,11 +24,11 @@
       invocations.command,
       invocations.selected,
       invocations.full_refresh,
-      invocations.job_url,
+      {% if job_url_exists %}invocations.job_url,{% endif %}
       invocations.job_name,
       invocations.job_id,
-      invocations.job_run_id,
-      invocations.job_run_url,
+      {% if job_run_id_exists %}invocations.job_run_id,{% endif %}
+      {% if job_run_url_exists %}invocations.job_run_url,{% endif %}
       invocations.orchestrator
     from {{ invocations_relation }} invocations
     join latest_models_invocations on invocations.invocation_id = latest_models_invocations.invocation_id

--- a/elementary/monitor/dbt_project/macros/get_models_latest_invocations_data.sql
+++ b/elementary/monitor/dbt_project/macros/get_models_latest_invocations_data.sql
@@ -1,6 +1,5 @@
 {% macro get_models_latest_invocations_data() %}
   {% set invocations_relation = ref("dbt_invocations", package="elementary") %}
-  {% set column_exists = elementary.column_exists_in_relation(invocations_relation, 'job_url') %}
 
   {% set query %}
     with ordered_run_results as (
@@ -22,11 +21,11 @@
       invocations.command,
       invocations.selected,
       invocations.full_refresh,
-      {% if column_exists %}
-        invocations.job_url,
-      {% endif %}
+      invocations.job_url,
       invocations.job_name,
       invocations.job_id,
+      invocations.job_run_id,
+      invocations.job_run_url,
       invocations.orchestrator
     from {{ invocations_relation }} invocations
     join latest_models_invocations on invocations.invocation_id = latest_models_invocations.invocation_id

--- a/elementary/monitor/dbt_project/macros/get_test_last_invocation.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_last_invocation.sql
@@ -20,14 +20,16 @@
         )
 
         {% if invocations_relation %}
+            {% set job_run_id_exists = elementary.column_exists_in_relation(invocations_relation, 'job_run_id') %}
+            {% set job_run_url_exists = elementary.column_exists_in_relation(invocations_relation, 'job_run_url') %}
             select
                 test_invocation.invocation_id,
                 test_invocation.detected_at,
                 invocations.command,
                 invocations.selected,
                 invocations.full_refresh,
-                invocations.job_run_id,
-                invocations.job_run_url
+                {% if job_run_id_exists %}invocations.job_run_id{% else %}NULL as job_run_id{% endif %},
+                {% if job_run_url_exists %}invocations.job_run_url{% else %}NULL as job_run_url{% endif %}
             from test_invocation left join {{ ref('elementary', 'dbt_invocations') }} as invocations
             on test_invocation.invocation_id = invocations.invocation_id
         {% else %}

--- a/elementary/monitor/dbt_project/macros/get_test_last_invocation.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_last_invocation.sql
@@ -20,21 +20,25 @@
         )
 
         {% if invocations_relation %}
-            select 
-                test_invocation.invocation_id, 
+            select
+                test_invocation.invocation_id,
                 test_invocation.detected_at,
                 invocations.command,
                 invocations.selected,
-                invocations.full_refresh
+                invocations.full_refresh,
+                invocations.job_run_id,
+                invocations.job_run_url
             from test_invocation left join {{ ref('elementary', 'dbt_invocations') }} as invocations
             on test_invocation.invocation_id = invocations.invocation_id
         {% else %}
-            select 
+            select
                 invocation_id,
                 detected_at,
                 NULL as command,
                 NULL as selected,
-                NULL as full_refresh
+                NULL as full_refresh,
+                NULL as job_run_id,
+                NULL as job_run_url
             from test_invocation
         {% endif %}
     {% endset %}

--- a/elementary/monitor/fetchers/invocations/schema.py
+++ b/elementary/monitor/fetchers/invocations/schema.py
@@ -14,6 +14,8 @@ class DbtInvocationSchema(BaseModel):
     job_url: Optional[str] = None
     job_name: Optional[str] = None
     job_id: Optional[str] = None
+    job_run_id: Optional[str] = None
+    job_run_url: Optional[str] = None
     orchestrator: Optional[str] = None
 
     @validator("detected_at", pre=True)


### PR DESCRIPTION
I needed those values in `NODE INFO` tab. We have them in UI and in Database, but don't have in the schema.

I have tested the solution locally.<!-- pylon-ticket-id: b3dc95a2-ada1-4d0b-aaa7-2aa32daa7f5b -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invocation records now include optional job run metadata: job run ID and job run URL.
  * Job-related URL/ID fields are returned when available, improving visibility into dbt job executions without affecting records that lack those fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->