### PR TITLE
ci: switch test-warehouse AWS auth to OIDC role (CORE-687)

### DIFF
--- a/.github/workflows/cleanup-stale-schemas.yml
+++ b/.github/workflows/cleanup-stale-schemas.yml
@@ -20,6 +20,9 @@ env:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -30,6 +33,13 @@ jobs:
           - databricks_catalog
           - athena
     steps:
+      - name: Configure AWS credentials
+        if: matrix.warehouse-type == 'athena'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: eu-west-1
+
       - name: Checkout dbt package
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/test-all-warehouses.yml
+++ b/.github/workflows/test-all-warehouses.yml
@@ -78,6 +78,12 @@ jobs:
 
   test:
     needs: [check-fork-status, approve-fork]
+    permissions:
+      contents: read
+      # Required so the called test-warehouse.yml can mint an OIDC token to
+      # assume the AWS role; per GitHub, id-token: write must be granted by
+      # the calling workflow.
+      id-token: write
     if: |
       ! cancelled() &&
       needs.check-fork-status.result == 'success' &&

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -43,6 +43,12 @@ jobs:
           echo "dbt bumped: ${{ steps.bump-tag.outputs.dbt-bumped }}"
 
   validate-upgrade-cli:
+    permissions:
+      contents: read
+      # Required so the called test-warehouse.yml can mint an OIDC token to
+      # assume the AWS role; per GitHub, id-token: write must be granted by
+      # the calling workflow.
+      id-token: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -70,6 +70,9 @@ jobs:
     defaults:
       run:
         working-directory: elementary
+    permissions:
+      contents: read
+      id-token: write
     concurrency:
       # Serialises runs for the same warehouse × dbt-version × branch.
       # The schema name is derived from a hash of this group (see "Write dbt profiles").
@@ -81,6 +84,12 @@ jobs:
         with:
           path: elementary
           ref: ${{ inputs.elementary-ref }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: eu-west-1
 
       - name: Checkout dbt package
         uses: actions/checkout@v6
@@ -382,8 +391,6 @@ jobs:
       - name: Run send report
         env:
           SLACK_TOKEN: ${{ secrets.CI_SLACK_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AZURE_CONNECTION_STRING: ${{ secrets.AZURE_CONNECTION_STRING }}
         run: >
           edr monitor send-report
@@ -394,8 +401,6 @@ jobs:
           --slack-token "$SLACK_TOKEN"
           --slack-channel-name data-ops
           --bucket-file-path "ci_reports/report_${{ inputs.warehouse-type }}_${{ env.BRANCH_NAME }}.html"
-          --aws-access-key-id "$AWS_ACCESS_KEY_ID"
-          --aws-secret-access-key "$AWS_SECRET_ACCESS_KEY"
           --s3-bucket-name elementary-ci-artifacts
           --azure-connection-string "$AZURE_CONNECTION_STRING"
           --azure-container-name reports

--- a/tests/e2e_dbt_project/snapshots/failed_snapshot.sql
+++ b/tests/e2e_dbt_project/snapshots/failed_snapshot.sql
@@ -1,8 +1,9 @@
 {% snapshot failed_snapshot() %}
 
+{# target_schema is required by dbt; reuse target.schema so this lands in the per-run CI schema. #}
 {{
     config(
-      target_schema='snapshots',
+      target_schema=target.schema,
       unique_key='unique_id',
       strategy='timestamp',
       updated_at='generated_at',

--- a/tests/profiles/profiles.yml.j2
+++ b/tests/profiles/profiles.yml.j2
@@ -149,8 +149,7 @@ elementary_tests:
       region_name: {{ athena_region | toyaml }}
       database: awsdatacatalog
       schema: {{ schema_name }}
-      aws_access_key_id: {{ athena_aws_access_key_id | toyaml }}
-      aws_secret_access_key: {{ athena_aws_secret_access_key | toyaml }}
+      work_group: oss_tests
       threads: 4
 
 # The internal CLI dbt_project uses profile "elementary", so we alias the


### PR DESCRIPTION
## Summary

Replaces the static AWS access keys used by `test-warehouse.yml` with short-lived credentials assumed via GitHub OIDC. Mirrors the prior GCP WIF migration (CORE-244).

- Add job-level `permissions: { contents: read, id-token: write }`.
- Add `aws-actions/configure-aws-credentials@v4` step that assumes the role from `secrets.AWS_OIDC_ROLE_ARN` in `eu-west-1`.
- Drop the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars and the `--aws-access-key-id` / `--aws-secret-access-key` flags from the send-report step (boto3 picks up role creds from the env vars exported by `configure-aws-credentials`).
- Drop `aws_access_key_id` / `aws_secret_access_key` from the `dbt-athena` profile (boto3 default credential chain handles it) and pin `work_group: oss_tests`.

## Linked

- Linear: https://linear.app/elementary/issue/CORE-687
- IaC change (must be applied first): https://github.com/elementary-data/elementary-internal/pull/new/core-687-aws-oidc-auth

## Pre-merge checklist (manual)

- [ ] `terraform apply` the matching `elementary-internal` PR.
- [ ] Add the role ARN as a repo secret named `AWS_OIDC_ROLE_ARN`.
- [ ] Re-encode `CI_WAREHOUSE_SECRETS` without `ATHENA_AWS_ACCESS_KEY_ID` / `ATHENA_AWS_SECRET_ACCESS_KEY` (keep `ATHENA_S3_*` and `ATHENA_REGION`).

## Test plan

- [ ] Trigger `Test warehouse platform` workflow with `warehouse-type=athena` — should succeed via OIDC.
- [ ] Trigger with `warehouse-type=postgres` (or any non-athena) — confirm send-report S3 upload still works.
- [ ] After a green run, deactivate the old IAM access keys (keep ~24h before deletion as a rollback path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows now use OIDC-based AWS credentialing with tightened job token permissions; AWS credentials are configured only where required.
  * Report publishing now uploads to S3 and can update the S3 website configuration.

* **Tests**
  * Test profile for Athena no longer contains explicit AWS credentials and sets a work group for test runs.
  * A dbt snapshot now writes to the active target schema instead of a fixed schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->