### PR TITLE
security: fix 7 high/critical Dependabot alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,7 @@ dbt-clickhouse = {version = ">=1.8,<2.0.0", optional = true}
 dbt-duckdb = {version = ">=1.8,<2.0.0", optional = true}
 dbt-dremio = {version = ">=1.8,<2.0.0", optional = true}
 dbt-fabric = {version = ">=1.8,<2.0.0", optional = true}
-dbt-fabricspark = {version = ">=1.8,<2.0.0", optional = true}
 dbt-sqlserver = {version = ">=1.8,<2.0.0", optional = true}
-dbt-vertica = {version = ">=1.8,<2.0.0", optional = true}
 [tool.poetry.extras]
 snowflake = ["dbt-snowflake"]
 bigquery = ["dbt-bigquery"]
@@ -73,12 +71,11 @@ trino = ["dbt-trino"]
 duckdb = ["dbt-duckdb"]
 dremio = ["dbt-dremio"]
 fabric = ["dbt-fabric"]
-fabricspark = ["dbt-fabricspark"]
 sqlserver = ["dbt-sqlserver"]
-vertica = ["dbt-vertica"]
-# dbt-fabricspark is excluded due to broken upstream dependencies (azure-cli pre-release pins).
-# dbt-vertica is excluded because it pins dbt-core==1.8.5, forcing the entire resolution to dbt 1.8.
-# Both are still available as individual extras (e.g. pip install elementary-data[vertica]).
+# dbt-fabricspark and dbt-vertica are removed from the lockfile resolution because they pin
+# outdated transitive dependencies (dbt-core==1.8.5, azure-cli pre-release) that block
+# security patches for deepdiff, protobuf, and pyopenssl. Users who need these adapters
+# can still install them directly (e.g. pip install dbt-fabricspark dbt-vertica).
 all = ["dbt-snowflake", "dbt-bigquery", "dbt-redshift", "dbt-postgres", "dbt-databricks", "dbt-spark", "dbt-athena-community", "dbt-trino", "dbt-clickhouse", "dbt-duckdb", "dbt-dremio", "dbt-fabric", "dbt-sqlserver"]
 
 [build-system]


### PR DESCRIPTION
## Summary
- Remove `dbt-fabricspark` and `dbt-vertica` from optional deps — both were already excluded from the `all` extra, and their outdated upstream pins (`dbt-core==1.8.5`, azure-cli pre-release) forced vulnerable transitive dependency versions to be resolved
- Without them, poetry resolves all 7 high/critical Dependabot alerts to patched versions naturally:
  - `deepdiff` 8.6.1 → 8.6.2 (CVE-2025-58367 critical RCE + CVE-2026-33155 high DoS)
  - `lxml` 5.3.1 → 6.1.0 (CVE-2026-41066 XXE)
  - `pyopenssl` 24.3.0 → 26.1.0 (CVE-2026-27459 buffer overflow)
  - `cryptography` 46.0.3 → 47.0.0 (CVE-2026-26007 subgroup attack)
  - `protobuf` 4.25.6 → 6.33.6 (CVE-2026-0994 recursion bypass)
  - `azure-core` 1.36.0 → 1.39.0 (CVE-2026-21226 deserialization)
- Users who need these adapters can still install them directly (e.g. `pip install dbt-fabricspark dbt-vertica`)

## Test plan
- [ ] Verify Dependabot alerts clear after merge
- [ ] If alerts persist, add explicit minimum version pins as a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added core runtime dependencies with minimum versions for deepdiff, lxml, pyopenssl, cryptography, protobuf, and azure-core.
  * Removed optional adapter support for Fabric Spark and Vertica platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->