### PR TITLE
security: pin lxml >=6.1.0 to fix CVE-2026-41066

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ google-cloud-storage = ">=2.4,<3.2"
 alive-progress = "<=2.3.1"
 slack-sdk = ">=3.20.1,<4.0.0"
 
+lxml = ">=6.1.0"
+
 pydantic = "<3.0"
 networkx = ">=2.3,<3"
 packaging = ">=20.9"


### PR DESCRIPTION
## Summary
- Pin `lxml >= 6.1.0` to resolve the last remaining high-severity Dependabot alert (CVE-2026-41066 — XXE via default `iterparse()` / `ETCompatXMLParser()` config)
- Follow-up to #2216 which cleared 6 of 7 alerts by removing dbt-fabricspark/dbt-vertica; this one needed an explicit pin since Dependabot still resolved lxml to a vulnerable version

## Test plan
- [ ] Verify Dependabot alert #15 clears after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `lxml` as a project dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->