### PR TITLE
change to use pinned version for trusted actions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -58,8 +58,7 @@ jobs:
           echo "dbt package version: $DBT_PACKAGE_VERSION"
       - name: fail on invalid input
         if: ${{ steps.validate-cli-input.outputs.cli-validation == '' || (inputs.dbt-package-version != '' && steps.validate-dbt-package-input.outputs.dbt-package-validation == '') }}
-        # actions/github-script v8, checked 2026-04-26.
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: actions/github-script@v8
         with:
           script: |
             core.setFailed("Invalid version inputs")
@@ -75,8 +74,7 @@ jobs:
       RELEASE_BRANCH: release/v${{ needs.validate-version.outputs.validated-cli-version }}
     steps:
       - name: Checkout code
-        # actions/checkout v6, checked 2026-04-26.
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
       - name: Create release branch
         run: git checkout -b "$RELEASE_BRANCH"
       - name: Initial config
@@ -110,8 +108,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      # actions/checkout v6, checked 2026-04-26.
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v6
       - name: create pull request
         # repo-sync/pull-request v2.12.1, checked 2026-04-26.
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,14 +45,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout Elementary
-        # actions/checkout v6, checked 2026-04-26.
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate-release-ref.outputs.release-ref }}
 
       - name: Setup Python
-        # actions/setup-python v6, checked 2026-04-26.
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -104,14 +102,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout Elementary
-        # actions/checkout v6, checked 2026-04-26.
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate-release-ref.outputs.release-ref }}
 
       - name: Setup Python
-        # actions/setup-python v6, checked 2026-04-26.
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -122,8 +118,7 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist .
 
       - name: Upload build artifact
-        # actions/upload-artifact v6, checked 2026-04-26.
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        uses: actions/upload-artifact@v6
         with:
           name: build
           path: dist
@@ -144,22 +139,18 @@ jobs:
 
     steps:
       - name: Checkout Elementary
-        # actions/checkout v6, checked 2026-04-26.
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate-release-ref.outputs.release-ref }}
 
       - name: Set up QEMU for multi-platform support
-        # docker/setup-qemu-action v4, checked 2026-04-26.
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx for multi-platform support
-        # docker/setup-buildx-action v4, checked 2026-04-26.
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to the container registry
-        # docker/login-action v4, checked 2026-04-26.
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -167,8 +158,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        # docker/metadata-action v6, checked 2026-04-26.
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -176,8 +166,7 @@ jobs:
             type=ref,event=tag
 
       - name: Build and push Docker image
-        # docker/build-push-action v7, checked 2026-04-26.
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -194,8 +183,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      # actions/checkout v6, checked 2026-04-26.
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate-release-ref.outputs.release-ref }}
       - name: PR master to docs

--- a/.github/workflows/triage-labels.yml
+++ b/.github/workflows/triage-labels.yml
@@ -11,8 +11,7 @@ jobs:
       issues: write
     steps:
       - name: Update label
-        # actions/github-script v8, checked 2026-04-26.
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo } = context.repo;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to use major-version tags instead of pinned commit SHAs for improved consistency and maintainability in CI/CD pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->