### PR TITLE
Use native Slack Table Block for test results sample rendering

### DIFF
--- a/elementary/messages/formats/block_kit.py
+++ b/elementary/messages/formats/block_kit.py
@@ -265,7 +265,8 @@ class BlockKitBuilder:
         }
 
     def _make_data_cell(self, value: Any) -> dict:
-        return {"type": "raw_text", "text": str(value) if value is not None else ""}
+        text = str(value) if value is not None else "NULL"
+        return {"type": "raw_text", "text": text or " "}
 
     def _add_table_block(self, block: TableBlock) -> None:
         column_count = len(block.headers)

--- a/elementary/messages/formats/block_kit.py
+++ b/elementary/messages/formats/block_kit.py
@@ -2,7 +2,6 @@ import json
 from typing import Any, Callable, List, Optional, Tuple
 
 from slack_sdk.models import blocks as slack_blocks
-from tabulate import tabulate
 
 from elementary.messages.blocks import (
     ActionBlock,
@@ -50,7 +49,8 @@ ResolveMentionCallback = Callable[[str], Optional[str]]
 class BlockKitBuilder:
     _SECONDARY_FACT_CHUNK_SIZE = 2
     _LONGEST_MARKDOWN_SUFFIX_LEN = 3  # length of markdown's code suffix (```)
-    _MAX_CELL_LENGTH_BY_COLUMN_COUNT = {4: 11, 3: 14, 2: 22, 1: 40, 0: 40}
+    _MAX_SLACK_TABLE_COLUMNS = 20
+    _MAX_SLACK_TABLE_ROWS = 100
 
     def __init__(
         self, resolve_mention: Optional[ResolveMentionCallback] = None
@@ -58,6 +58,7 @@ class BlockKitBuilder:
         self._blocks: List[dict] = []
         self._attachment_blocks: List[dict] = []
         self._is_divided = False
+        self._has_table_block = False
         self._resolve_mention = resolve_mention or (lambda x: None)
 
     def _format_icon(self, icon: Icon) -> str:
@@ -97,13 +98,6 @@ class BlockKitBuilder:
         return block.sep.join(
             [self._format_inline_block(inline) for inline in block.inlines]
         )
-
-    def _format_table_cell(self, cell_value: Any, column_count: int) -> str:
-        value = str(cell_value)
-        max_cell_length = self._MAX_CELL_LENGTH_BY_COLUMN_COUNT[column_count]
-        if len(value) > max_cell_length:
-            return value[: max_cell_length - 2] + ".."
-        return value
 
     def _format_markdown_section_text(self, text: str) -> dict:
         if len(text) > slack_blocks.SectionBlock.text_max_length:
@@ -257,24 +251,49 @@ class BlockKitBuilder:
         self._add_block({"type": "divider"})
         self._is_divided = True
 
+    def _make_header_cell(self, text: str) -> dict:
+        return {
+            "type": "rich_text",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {"type": "text", "text": str(text), "style": {"bold": True}}
+                    ],
+                }
+            ],
+        }
+
+    def _make_data_cell(self, value: Any) -> dict:
+        return {"type": "raw_text", "text": str(value) if value is not None else ""}
+
     def _add_table_block(self, block: TableBlock) -> None:
         column_count = len(block.headers)
-        if column_count not in self._MAX_CELL_LENGTH_BY_COLUMN_COUNT:
+
+        if column_count > self._MAX_SLACK_TABLE_COLUMNS or self._has_table_block:
             dicts = [
                 {header: cell for header, cell in zip(block.headers, row)}
                 for row in block.rows
             ]
-            table_text = json.dumps(dicts, indent=2)
-        else:
-            new_rows = [
-                [self._format_table_cell(cell, column_count) for cell in row]
-                for row in block.rows
-            ]
-            new_headers = [
-                self._format_table_cell(cell, column_count) for cell in block.headers
-            ]
-            table_text = tabulate(new_rows, headers=new_headers, tablefmt="simple")
-        self._add_block(self._format_markdown_section(f"```{table_text}```"))
+            self._add_block(
+                self._format_markdown_section(f"```{json.dumps(dicts, indent=2)}```")
+            )
+            return
+
+        rows: List[List[dict]] = [[self._make_header_cell(h) for h in block.headers]]
+        for row in block.rows[: self._MAX_SLACK_TABLE_ROWS - 1]:
+            rows.append([self._make_data_cell(v) for v in row])
+
+        self._add_block(
+            {
+                "type": "table",
+                "rows": rows,
+                "column_settings": [
+                    {"align": "left", "is_wrapped": False} for _ in block.headers
+                ],
+            }
+        )
+        self._has_table_block = True
 
     def _add_actions_block(self, block: ActionsBlock) -> None:
         self._add_block(
@@ -337,6 +356,7 @@ class BlockKitBuilder:
     def build(self, message: MessageBody) -> FormattedBlockKitMessage:
         self._blocks = []
         self._attachment_blocks = []
+        self._has_table_block = False
         self._add_message_blocks(message.blocks)
         color_code = COLOR_MAP.get(message.color) if message.color else None
         blocks, attachment_blocks = self._get_final_blocks(message.color)

--- a/tests/unit/alerts/alert_messages/fixtures/block_kit/dbt_test_alert_status-error_link-True_description-True_tags-True_owners-True_table-True_error-True_sample-True_env-True.json
+++ b/tests/unit/alerts/alert_messages/fixtures/block_kit/dbt_test_alert_status-error_link-True_description-True_tags-True_owners-True_table-True_error-True_sample-True_env-True.json
@@ -89,11 +89,65 @@
           }
         },
         {
-          "type": "section",
-          "text": {
-            "type": "mrkdwn",
-            "text": "```column1    column2\n---------  ---------\nvalue1     value2```"
-          }
+          "type": "table",
+          "rows": [
+            [
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "column1",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "column2",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "raw_text",
+                "text": "value1"
+              },
+              {
+                "type": "raw_text",
+                "text": "value2"
+              }
+            ]
+          ],
+          "column_settings": [
+            {
+              "align": "left",
+              "is_wrapped": false
+            },
+            {
+              "align": "left",
+              "is_wrapped": false
+            }
+          ]
         }
       ],
       "color": "#ff0000"

--- a/tests/unit/alerts/alert_messages/fixtures/block_kit/dbt_test_alert_status-fail_link-True_description-True_tags-True_owners-True_table-True_error-True_sample-True_env-False.json
+++ b/tests/unit/alerts/alert_messages/fixtures/block_kit/dbt_test_alert_status-fail_link-True_description-True_tags-True_owners-True_table-True_error-True_sample-True_env-False.json
@@ -89,11 +89,65 @@
           }
         },
         {
-          "type": "section",
-          "text": {
-            "type": "mrkdwn",
-            "text": "```column1    column2\n---------  ---------\nvalue1     value2```"
-          }
+          "type": "table",
+          "rows": [
+            [
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "column1",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "column2",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "raw_text",
+                "text": "value1"
+              },
+              {
+                "type": "raw_text",
+                "text": "value2"
+              }
+            ]
+          ],
+          "column_settings": [
+            {
+              "align": "left",
+              "is_wrapped": false
+            },
+            {
+              "align": "left",
+              "is_wrapped": false
+            }
+          ]
         }
       ],
       "color": "#ff0000"

--- a/tests/unit/alerts/alert_messages/fixtures/block_kit/dbt_test_alert_status-warn_link-True_description-False_tags-True_owners-False_table-True_error-False_sample-True_env-False.json
+++ b/tests/unit/alerts/alert_messages/fixtures/block_kit/dbt_test_alert_status-warn_link-True_description-False_tags-True_owners-False_table-True_error-False_sample-True_env-False.json
@@ -68,11 +68,65 @@
           }
         },
         {
-          "type": "section",
-          "text": {
-            "type": "mrkdwn",
-            "text": "```column1    column2\n---------  ---------\nvalue1     value2```"
-          }
+          "type": "table",
+          "rows": [
+            [
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "column1",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "column2",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "raw_text",
+                "text": "value1"
+              },
+              {
+                "type": "raw_text",
+                "text": "value2"
+              }
+            ]
+          ],
+          "column_settings": [
+            {
+              "align": "left",
+              "is_wrapped": false
+            },
+            {
+              "align": "left",
+              "is_wrapped": false
+            }
+          ]
         }
       ],
       "color": "#ffcc00"

--- a/tests/unit/alerts/alert_messages/fixtures/block_kit/dbt_test_alert_status-warn_link-True_description-True_tags-True_owners-True_table-True_error-True_sample-True_env-True.json
+++ b/tests/unit/alerts/alert_messages/fixtures/block_kit/dbt_test_alert_status-warn_link-True_description-True_tags-True_owners-True_table-True_error-True_sample-True_env-True.json
@@ -89,11 +89,65 @@
           }
         },
         {
-          "type": "section",
-          "text": {
-            "type": "mrkdwn",
-            "text": "```column1    column2\n---------  ---------\nvalue1     value2```"
-          }
+          "type": "table",
+          "rows": [
+            [
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "column1",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "column2",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "raw_text",
+                "text": "value1"
+              },
+              {
+                "type": "raw_text",
+                "text": "value2"
+              }
+            ]
+          ],
+          "column_settings": [
+            {
+              "align": "left",
+              "is_wrapped": false
+            },
+            {
+              "align": "left",
+              "is_wrapped": false
+            }
+          ]
         }
       ],
       "color": "#ffcc00"

--- a/tests/unit/messages/formats/block_kit/fixtures/all_blocks_green.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/all_blocks_green.json
@@ -56,11 +56,104 @@
           ]
         },
         {
-          "type": "section",
-          "text": {
-            "type": "mrkdwn",
-            "text": "```Column 1     Column 2     Column 3\n-----------  -----------  -----------\nRow 1 Col 1  Row 1 Col 2  Row 1 Col 3\nRow 2 Col 1  Row 2 Col 2  Row 2 Col 3```"
-          }
+          "type": "table",
+          "rows": [
+            [
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "Column 1",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "Column 2",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "Column 3",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "raw_text",
+                "text": "Row 1 Col 1"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 1 Col 2"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 1 Col 3"
+              }
+            ],
+            [
+              {
+                "type": "raw_text",
+                "text": "Row 2 Col 1"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 2 Col 2"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 2 Col 3"
+              }
+            ]
+          ],
+          "column_settings": [
+            {
+              "align": "left",
+              "is_wrapped": false
+            },
+            {
+              "align": "left",
+              "is_wrapped": false
+            },
+            {
+              "align": "left",
+              "is_wrapped": false
+            }
+          ]
         },
         {
           "type": "section",

--- a/tests/unit/messages/formats/block_kit/fixtures/all_blocks_no_color.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/all_blocks_no_color.json
@@ -56,11 +56,104 @@
           ]
         },
         {
-          "type": "section",
-          "text": {
-            "type": "mrkdwn",
-            "text": "```Column 1     Column 2     Column 3\n-----------  -----------  -----------\nRow 1 Col 1  Row 1 Col 2  Row 1 Col 3\nRow 2 Col 1  Row 2 Col 2  Row 2 Col 3```"
-          }
+          "type": "table",
+          "rows": [
+            [
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "Column 1",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "Column 2",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "Column 3",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "raw_text",
+                "text": "Row 1 Col 1"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 1 Col 2"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 1 Col 3"
+              }
+            ],
+            [
+              {
+                "type": "raw_text",
+                "text": "Row 2 Col 1"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 2 Col 2"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 2 Col 3"
+              }
+            ]
+          ],
+          "column_settings": [
+            {
+              "align": "left",
+              "is_wrapped": false
+            },
+            {
+              "align": "left",
+              "is_wrapped": false
+            },
+            {
+              "align": "left",
+              "is_wrapped": false
+            }
+          ]
         },
         {
           "type": "section",

--- a/tests/unit/messages/formats/block_kit/fixtures/all_blocks_red.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/all_blocks_red.json
@@ -56,11 +56,104 @@
           ]
         },
         {
-          "type": "section",
-          "text": {
-            "type": "mrkdwn",
-            "text": "```Column 1     Column 2     Column 3\n-----------  -----------  -----------\nRow 1 Col 1  Row 1 Col 2  Row 1 Col 3\nRow 2 Col 1  Row 2 Col 2  Row 2 Col 3```"
-          }
+          "type": "table",
+          "rows": [
+            [
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "Column 1",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "Column 2",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "Column 3",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "raw_text",
+                "text": "Row 1 Col 1"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 1 Col 2"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 1 Col 3"
+              }
+            ],
+            [
+              {
+                "type": "raw_text",
+                "text": "Row 2 Col 1"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 2 Col 2"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 2 Col 3"
+              }
+            ]
+          ],
+          "column_settings": [
+            {
+              "align": "left",
+              "is_wrapped": false
+            },
+            {
+              "align": "left",
+              "is_wrapped": false
+            },
+            {
+              "align": "left",
+              "is_wrapped": false
+            }
+          ]
         },
         {
           "type": "section",

--- a/tests/unit/messages/formats/block_kit/fixtures/all_blocks_yellow.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/all_blocks_yellow.json
@@ -56,11 +56,104 @@
           ]
         },
         {
-          "type": "section",
-          "text": {
-            "type": "mrkdwn",
-            "text": "```Column 1     Column 2     Column 3\n-----------  -----------  -----------\nRow 1 Col 1  Row 1 Col 2  Row 1 Col 3\nRow 2 Col 1  Row 2 Col 2  Row 2 Col 3```"
-          }
+          "type": "table",
+          "rows": [
+            [
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "Column 1",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "Column 2",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "Column 3",
+                        "style": {
+                          "bold": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "raw_text",
+                "text": "Row 1 Col 1"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 1 Col 2"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 1 Col 3"
+              }
+            ],
+            [
+              {
+                "type": "raw_text",
+                "text": "Row 2 Col 1"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 2 Col 2"
+              },
+              {
+                "type": "raw_text",
+                "text": "Row 2 Col 3"
+              }
+            ]
+          ],
+          "column_settings": [
+            {
+              "align": "left",
+              "is_wrapped": false
+            },
+            {
+              "align": "left",
+              "is_wrapped": false
+            },
+            {
+              "align": "left",
+              "is_wrapped": false
+            }
+          ]
         },
         {
           "type": "section",

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_200_1.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_200_1.json
@@ -1,11 +1,64 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```Column 0\n----------------------------------------\nLorem ipsum dolor sit amet, consectetu..\nLorem ipsum dolor sit amet, consectetu..\nLorem ipsum dolor sit amet, consectetu..\nLorem ipsum dolor sit amet, consectetu..\nLorem ipsum dolor sit amet, consectetu..```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_200_2.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_200_2.json
@@ -1,11 +1,105 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```Column 0                Column 1\n----------------------  ----------------------\nLorem ipsum dolor si..  Lorem ipsum dolor si..\nLorem ipsum dolor si..  Lorem ipsum dolor si..\nLorem ipsum dolor si..  Lorem ipsum dolor si..\nLorem ipsum dolor si..  Lorem ipsum dolor si..\nLorem ipsum dolor si..  Lorem ipsum dolor si..```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 1",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_200_3.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_200_3.json
@@ -1,11 +1,146 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```Column 0        Column 1        Column 2\n--------------  --------------  --------------\nLorem ipsum ..  Lorem ipsum ..  Lorem ipsum ..\nLorem ipsum ..  Lorem ipsum ..  Lorem ipsum ..\nLorem ipsum ..  Lorem ipsum ..  Lorem ipsum ..\nLorem ipsum ..  Lorem ipsum ..  Lorem ipsum ..\nLorem ipsum ..  Lorem ipsum ..  Lorem ipsum ..```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 1",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 2",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_200_4.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_200_4.json
@@ -1,11 +1,187 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```Column 0     Column 1     Column 2     Column 3\n-----------  -----------  -----------  -----------\nLorem ips..  Lorem ips..  Lorem ips..  Lorem ips..\nLorem ips..  Lorem ips..  Lorem ips..  Lorem ips..\nLorem ips..  Lorem ips..  Lorem ips..  Lorem ips..\nLorem ips..  Lorem ips..  Lorem ips..  Lorem ips..\nLorem ips..  Lorem ips..  Lorem ips..  Lorem ips..```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 1",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 2",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 3",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_200_5.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_200_5.json
@@ -1,11 +1,228 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```[\n  {\n    \"Column 0\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c\",\n    \"Column 1\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c\",\n    \"Column 2\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c\",\n    \"Column 3\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c\",\n    \"Column 4\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c\"\n  },\n  {\n    \"Column 0\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c\",\n    \"Column 1\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c\",\n    \"Column 2\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c\",\n    \"Column 3\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c\",\n    \"Column 4\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c\"\n  },\n  {\n    \"Column 0\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c\",\n    \"Column 1\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c\",\n    \"Column 2\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c\",\n    \"Column 3\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consect...```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 1",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 2",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 3",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 4",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, c"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_30_1.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_30_1.json
@@ -1,11 +1,64 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```Column 0\n------------------------------\nLorem ipsum dolor sit amet, co\nLorem ipsum dolor sit amet, co\nLorem ipsum dolor sit amet, co\nLorem ipsum dolor sit amet, co\nLorem ipsum dolor sit amet, co```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_30_2.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_30_2.json
@@ -1,11 +1,105 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```Column 0                Column 1\n----------------------  ----------------------\nLorem ipsum dolor si..  Lorem ipsum dolor si..\nLorem ipsum dolor si..  Lorem ipsum dolor si..\nLorem ipsum dolor si..  Lorem ipsum dolor si..\nLorem ipsum dolor si..  Lorem ipsum dolor si..\nLorem ipsum dolor si..  Lorem ipsum dolor si..```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 1",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_30_3.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_30_3.json
@@ -1,11 +1,146 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```Column 0        Column 1        Column 2\n--------------  --------------  --------------\nLorem ipsum ..  Lorem ipsum ..  Lorem ipsum ..\nLorem ipsum ..  Lorem ipsum ..  Lorem ipsum ..\nLorem ipsum ..  Lorem ipsum ..  Lorem ipsum ..\nLorem ipsum ..  Lorem ipsum ..  Lorem ipsum ..\nLorem ipsum ..  Lorem ipsum ..  Lorem ipsum ..```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 1",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 2",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_30_4.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_30_4.json
@@ -1,11 +1,187 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```Column 0     Column 1     Column 2     Column 3\n-----------  -----------  -----------  -----------\nLorem ips..  Lorem ips..  Lorem ips..  Lorem ips..\nLorem ips..  Lorem ips..  Lorem ips..  Lorem ips..\nLorem ips..  Lorem ips..  Lorem ips..  Lorem ips..\nLorem ips..  Lorem ips..  Lorem ips..  Lorem ips..\nLorem ips..  Lorem ips..  Lorem ips..  Lorem ips..```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 1",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 2",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 3",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_30_5.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_30_5.json
@@ -1,11 +1,228 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```[\n  {\n    \"Column 0\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 1\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 2\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 3\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 4\": \"Lorem ipsum dolor sit amet, co\"\n  },\n  {\n    \"Column 0\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 1\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 2\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 3\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 4\": \"Lorem ipsum dolor sit amet, co\"\n  },\n  {\n    \"Column 0\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 1\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 2\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 3\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 4\": \"Lorem ipsum dolor sit amet, co\"\n  },\n  {\n    \"Column 0\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 1\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 2\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 3\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 4\": \"Lorem ipsum dolor sit amet, co\"\n  },\n  {\n    \"Column 0\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 1\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 2\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 3\": \"Lorem ipsum dolor sit amet, co\",\n    \"Column 4\": \"Lorem ipsum dolor sit amet, co\"\n  }\n]```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 1",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 2",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 3",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 4",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ipsum dolor sit amet, co"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_8_1.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_8_1.json
@@ -1,11 +1,64 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```Column 0\n----------\nLorem ip\nLorem ip\nLorem ip\nLorem ip\nLorem ip```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_8_2.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_8_2.json
@@ -1,11 +1,105 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```Column 0    Column 1\n----------  ----------\nLorem ip    Lorem ip\nLorem ip    Lorem ip\nLorem ip    Lorem ip\nLorem ip    Lorem ip\nLorem ip    Lorem ip```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 1",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_8_3.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_8_3.json
@@ -1,11 +1,146 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```Column 0    Column 1    Column 2\n----------  ----------  ----------\nLorem ip    Lorem ip    Lorem ip\nLorem ip    Lorem ip    Lorem ip\nLorem ip    Lorem ip    Lorem ip\nLorem ip    Lorem ip    Lorem ip\nLorem ip    Lorem ip    Lorem ip```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 1",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 2",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_8_4.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_8_4.json
@@ -1,11 +1,187 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```Column 0    Column 1    Column 2    Column 3\n----------  ----------  ----------  ----------\nLorem ip    Lorem ip    Lorem ip    Lorem ip\nLorem ip    Lorem ip    Lorem ip    Lorem ip\nLorem ip    Lorem ip    Lorem ip    Lorem ip\nLorem ip    Lorem ip    Lorem ip    Lorem ip\nLorem ip    Lorem ip    Lorem ip    Lorem ip```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 1",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 2",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 3",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/fixtures/table_block_8_5.json
+++ b/tests/unit/messages/formats/block_kit/fixtures/table_block_8_5.json
@@ -1,11 +1,228 @@
 {
   "blocks": [
     {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "```[\n  {\n    \"Column 0\": \"Lorem ip\",\n    \"Column 1\": \"Lorem ip\",\n    \"Column 2\": \"Lorem ip\",\n    \"Column 3\": \"Lorem ip\",\n    \"Column 4\": \"Lorem ip\"\n  },\n  {\n    \"Column 0\": \"Lorem ip\",\n    \"Column 1\": \"Lorem ip\",\n    \"Column 2\": \"Lorem ip\",\n    \"Column 3\": \"Lorem ip\",\n    \"Column 4\": \"Lorem ip\"\n  },\n  {\n    \"Column 0\": \"Lorem ip\",\n    \"Column 1\": \"Lorem ip\",\n    \"Column 2\": \"Lorem ip\",\n    \"Column 3\": \"Lorem ip\",\n    \"Column 4\": \"Lorem ip\"\n  },\n  {\n    \"Column 0\": \"Lorem ip\",\n    \"Column 1\": \"Lorem ip\",\n    \"Column 2\": \"Lorem ip\",\n    \"Column 3\": \"Lorem ip\",\n    \"Column 4\": \"Lorem ip\"\n  },\n  {\n    \"Column 0\": \"Lorem ip\",\n    \"Column 1\": \"Lorem ip\",\n    \"Column 2\": \"Lorem ip\",\n    \"Column 3\": \"Lorem ip\",\n    \"Column 4\": \"Lorem ip\"\n  }\n]```"
-      }
+      "type": "table",
+      "rows": [
+        [
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 0",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 1",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 2",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 3",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "text",
+                    "text": "Column 4",
+                    "style": {
+                      "bold": true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ],
+        [
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          },
+          {
+            "type": "raw_text",
+            "text": "Lorem ip"
+          }
+        ]
+      ],
+      "column_settings": [
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        },
+        {
+          "align": "left",
+          "is_wrapped": false
+        }
+      ]
     }
   ],
   "attachments": [

--- a/tests/unit/messages/formats/block_kit/test_block_kit.py
+++ b/tests/unit/messages/formats/block_kit/test_block_kit.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
+from elementary.messages.blocks import TableBlock
 from elementary.messages.formats.block_kit import (
     FormattedBlockKitMessage,
     format_block_kit,
@@ -36,3 +37,15 @@ class TestBlockKit(BaseTestFormat[FormattedBlockKitMessage]):
                 os.environ["TEST_SLACK_CHANNEL"], result
             )
         assert_expected_json(result.dict(), expected_file_path)
+
+    def test_table_block_none_and_empty_cells_produce_non_empty_text(self):
+        table = TableBlock.from_dicts([
+            {"col_a": None, "col_b": "value"},
+            {"col_a": "",   "col_b": "other"},
+        ])
+        result = format_block_kit(MessageBody(blocks=[table]))
+        table_block = result.blocks[0]
+        assert table_block["type"] == "table"
+        for row in table_block["rows"][1:]:  # skip header row
+            for cell in row:
+                assert cell["text"], f"raw_text cell must not be empty, got: {cell}"

--- a/tests/unit/messages/formats/block_kit/test_block_kit.py
+++ b/tests/unit/messages/formats/block_kit/test_block_kit.py
@@ -39,10 +39,12 @@ class TestBlockKit(BaseTestFormat[FormattedBlockKitMessage]):
         assert_expected_json(result.dict(), expected_file_path)
 
     def test_table_block_none_and_empty_cells_produce_non_empty_text(self):
-        table = TableBlock.from_dicts([
-            {"col_a": None, "col_b": "value"},
-            {"col_a": "",   "col_b": "other"},
-        ])
+        table = TableBlock.from_dicts(
+            [
+                {"col_a": None, "col_b": "value"},
+                {"col_a": "", "col_b": "other"},
+            ]
+        )
         result = format_block_kit(MessageBody(blocks=[table]))
         table_block = result.blocks[0]
         assert table_block["type"] == "table"


### PR DESCRIPTION
## Summary

- Replaces the `tabulate`-based ASCII table-in-code-block rendering with Slack's native **Table Block** (`"type": "table"`) in `BlockKitBuilder._add_table_block()`
- Header row uses bold `rich_text` cells; data rows use `raw_text` cells
- Falls back to a JSON code block for tables with >20 columns (Slack limit) or if a second table would appear in the same message (Slack allows one table per message)
- Removes the now-unused `tabulate` import and cell-truncation helpers from `BlockKitBuilder`
- Regenerates all 19 affected block_kit test fixtures

Screenshot on how this looks like in Slack (manually rendered via a script):  
<img width="708" height="756" alt="image" src="https://github.com/user-attachments/assets/f191fef2-6856-4a6b-8978-7a6d471f41e3" />


Closes #2225

## Test plan

- [x] `pytest tests/unit/messages/formats/block_kit/` passes with regenerated fixtures
- [x] Sent a full realistic alert message to a Slack channel and visually verified the table renders correctly (screenshot above)
- [x] Verified fallback to JSON code block works for the second-table-in-message edge case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tables now render using Slack's native table block with bold headers, left-aligned columns, and non-wrapping cells.
  * Empty or null cell values are shown as blank cells.

* **Improvements / Bug Fixes**
  * Table size limits are enforced; when limits or multiple tables would occur, content falls back to a JSON/code-block representation.

* **Tests**
  * Added a test ensuring None/empty cells produce non-empty table cell text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->