### PR TITLE
APP-1123: add skip_test_result_rows to skip test_result_rows query in get_test_results macro

### DIFF
--- a/elementary/monitor/api/report/report.py
+++ b/elementary/monitor/api/report/report.py
@@ -76,6 +76,7 @@ class ReportAPI(APIClient):
         exclude_elementary_models: bool = False,
         project_name: Optional[str] = None,
         disable_samples: bool = False,
+        skip_test_result_rows: bool = False,
         filter: SelectorFilterSchema = SelectorFilterSchema(),
         env: Optional[str] = None,
         warehouse_type: Optional[str] = None,
@@ -86,7 +87,7 @@ class ReportAPI(APIClient):
                 days_back=days_back,
                 invocations_per_test=test_runs_amount,
                 disable_passed_test_metrics=disable_passed_test_metrics,
-                disable_samples=disable_samples,
+                skip_test_result_rows=skip_test_result_rows,
             )
             source_freshnesses_api = SourceFreshnessesAPI(
                 dbt_runner=self.dbt_runner,

--- a/elementary/monitor/api/report/report.py
+++ b/elementary/monitor/api/report/report.py
@@ -86,6 +86,7 @@ class ReportAPI(APIClient):
                 days_back=days_back,
                 invocations_per_test=test_runs_amount,
                 disable_passed_test_metrics=disable_passed_test_metrics,
+                disable_samples=disable_samples,
             )
             source_freshnesses_api = SourceFreshnessesAPI(
                 dbt_runner=self.dbt_runner,

--- a/elementary/monitor/api/tests/tests.py
+++ b/elementary/monitor/api/tests/tests.py
@@ -46,6 +46,7 @@ class TestsAPI(APIClient):
         days_back: int = 7,
         invocations_per_test: int = 720,
         disable_passed_test_metrics: bool = False,
+        disable_samples: bool = False,
     ):
         super().__init__(dbt_runner)
         self.tests_fetcher = TestsFetcher(dbt_runner=self.dbt_runner)
@@ -53,6 +54,7 @@ class TestsAPI(APIClient):
             days_back=days_back,
             invocations_per_test=invocations_per_test,
             disable_passed_test_metrics=disable_passed_test_metrics,
+            disable_samples=disable_samples,
         )
 
     def _get_test_results_db_rows(
@@ -60,11 +62,13 @@ class TestsAPI(APIClient):
         days_back: Optional[int] = 7,
         invocations_per_test: int = 720,
         disable_passed_test_metrics: bool = False,
+        disable_samples: bool = False,
     ) -> List[TestResultDBRowSchema]:
         return self.tests_fetcher.get_all_test_results_db_rows(
             days_back=days_back,
             invocations_per_test=invocations_per_test,
             disable_passed_test_metrics=disable_passed_test_metrics,
+            disable_samples=disable_samples,
         )
 
     def get_test_results_summary(

--- a/elementary/monitor/api/tests/tests.py
+++ b/elementary/monitor/api/tests/tests.py
@@ -46,7 +46,7 @@ class TestsAPI(APIClient):
         days_back: int = 7,
         invocations_per_test: int = 720,
         disable_passed_test_metrics: bool = False,
-        disable_samples: bool = False,
+        skip_test_result_rows: bool = False,
     ):
         super().__init__(dbt_runner)
         self.tests_fetcher = TestsFetcher(dbt_runner=self.dbt_runner)
@@ -54,7 +54,7 @@ class TestsAPI(APIClient):
             days_back=days_back,
             invocations_per_test=invocations_per_test,
             disable_passed_test_metrics=disable_passed_test_metrics,
-            disable_samples=disable_samples,
+            skip_test_result_rows=skip_test_result_rows,
         )
 
     def _get_test_results_db_rows(
@@ -62,13 +62,13 @@ class TestsAPI(APIClient):
         days_back: Optional[int] = 7,
         invocations_per_test: int = 720,
         disable_passed_test_metrics: bool = False,
-        disable_samples: bool = False,
+        skip_test_result_rows: bool = False,
     ) -> List[TestResultDBRowSchema]:
         return self.tests_fetcher.get_all_test_results_db_rows(
             days_back=days_back,
             invocations_per_test=invocations_per_test,
             disable_passed_test_metrics=disable_passed_test_metrics,
-            disable_samples=disable_samples,
+            skip_test_result_rows=skip_test_result_rows,
         )
 
     def get_test_results_summary(

--- a/elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql
+++ b/elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql
@@ -1,4 +1,4 @@
-{% macro current_tests_run_results_query(days_back = none, invocation_id = none) %}
+{% macro current_tests_run_results_query(days_back = none, invocation_id = none, disable_samples = false) %}
     with elementary_test_results as (
         select * from {{ ref('elementary', 'elementary_test_results') }}
         {% if days_back %}
@@ -79,7 +79,7 @@
         dbt_tests.short_name,
         elementary_test_results.test_alias,
         elementary_test_results.failures,
-        elementary_test_results.result_rows,
+        {% if disable_samples %}null{% else %}elementary_test_results.result_rows{% endif %} as result_rows,
         dbt_tests.original_path,
         dbt_tests.meta,
         dbt_tests.description as test_description,

--- a/elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql
+++ b/elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql
@@ -1,4 +1,4 @@
-{% macro current_tests_run_results_query(days_back = none, invocation_id = none, disable_samples = false) %}
+{% macro current_tests_run_results_query(days_back = none, invocation_id = none, skip_test_result_rows = false) %}
     with elementary_test_results as (
         select * from {{ ref('elementary', 'elementary_test_results') }}
         {% if days_back %}
@@ -79,7 +79,7 @@
         dbt_tests.short_name,
         elementary_test_results.test_alias,
         elementary_test_results.failures,
-        {% if disable_samples %}null{% else %}elementary_test_results.result_rows{% endif %} as result_rows,
+        {% if skip_test_result_rows %}null{% else %}elementary_test_results.result_rows{% endif %} as result_rows,
         dbt_tests.original_path,
         dbt_tests.meta,
         dbt_tests.description as test_description,

--- a/elementary/monitor/dbt_project/macros/get_test_results.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_results.sql
@@ -1,5 +1,5 @@
-{%- macro get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false) -%}
-    {{ return(adapter.dispatch('get_test_results', 'elementary_cli')(days_back, invocations_per_test, disable_passed_test_metrics)) }}
+{%- macro get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, disable_samples = false) -%}
+    {{ return(adapter.dispatch('get_test_results', 'elementary_cli')(days_back, invocations_per_test, disable_passed_test_metrics, disable_samples)) }}
 {%- endmacro -%}
 
 {#
@@ -40,7 +40,7 @@
     {% do return(test_results) %}
 {%- endmacro -%}
 
-{%- macro default__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false) -%}
+{%- macro default__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, disable_samples = false) -%}
     {% set elementary_tests_allowlist_status = ['fail', 'warn'] if disable_passed_test_metrics else ['fail', 'warn', 'pass']  %}
     {% set select_test_results %}
         with test_results as (
@@ -111,7 +111,11 @@
     {% endset %}
 
     {% set test_results_agate = elementary.run_query(test_results_agate_sql) %}
-    {% set test_result_rows_agate = elementary_cli.get_result_rows_agate(days_back, valid_ids_query) %}
+    {% if not disable_samples %}
+        {% set test_result_rows_agate = elementary_cli.get_result_rows_agate(days_back, valid_ids_query) %}
+    {% else %}
+        {% set test_result_rows_agate = {} %}
+    {% endif %}
     {% if not elementary.has_temp_table_support() %}
         {% do elementary.fully_drop_relation(ordered_test_results_relation) %}
     {% endif %}
@@ -119,7 +123,7 @@
     {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status)) %}
 {%- endmacro -%}
 
-{%- macro fabric__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false) -%}
+{%- macro fabric__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, disable_samples = false) -%}
     {#
         T-SQL does not allow nested CTEs (WITH inside WITH).
         current_tests_run_results_query already starts with WITH, so we
@@ -165,7 +169,11 @@
     {% endset %}
 
     {% set test_results_agate = elementary.run_query(test_results_agate_sql) %}
-    {% set test_result_rows_agate = elementary_cli.get_result_rows_agate(days_back, valid_ids_query) %}
+    {% if not disable_samples %}
+        {% set test_result_rows_agate = elementary_cli.get_result_rows_agate(days_back, valid_ids_query) %}
+    {% else %}
+        {% set test_result_rows_agate = {} %}
+    {% endif %}
 
     {# Clean up intermediate tables #}
     {% do elementary.fully_drop_relation(base_relation) %}
@@ -174,7 +182,7 @@
     {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status)) %}
 {%- endmacro -%}
 
-{%- macro clickhouse__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false) -%}
+{%- macro clickhouse__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, disable_samples = false) -%}
     {% do elementary.run_query('drop table if exists ordered_test_results') %}
     {% set create_table_query %}
     CREATE TABLE ordered_test_results (
@@ -302,7 +310,11 @@
     {% endset %}
 
     {% set test_results_agate = elementary.run_query(test_results_agate_sql) %}
-    {% set test_result_rows_agate = elementary_cli.get_result_rows_agate(days_back, valid_ids_query) %}
+    {% if not disable_samples %}
+        {% set test_result_rows_agate = elementary_cli.get_result_rows_agate(days_back, valid_ids_query) %}
+    {% else %}
+        {% set test_result_rows_agate = {} %}
+    {% endif %}
     {% if not elementary.has_temp_table_support() %}
         {% do elementary.fully_drop_relation(ordered_test_results_relation) %}
     {% endif %}

--- a/elementary/monitor/dbt_project/macros/get_test_results.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_results.sql
@@ -44,7 +44,7 @@
     {% set elementary_tests_allowlist_status = ['fail', 'warn'] if disable_passed_test_metrics else ['fail', 'warn', 'pass']  %}
     {% set select_test_results %}
         with test_results as (
-            {{ elementary_cli.current_tests_run_results_query(days_back=days_back) }}
+            {{ elementary_cli.current_tests_run_results_query(days_back=days_back, disable_samples=disable_samples) }}
         ),
 
         ordered_test_results as (
@@ -136,7 +136,7 @@
 
     {# Step 1 – materialise the base test-results query into a temp table #}
     {% set base_query %}
-        {{ elementary_cli.current_tests_run_results_query(days_back=days_back) }}
+        {{ elementary_cli.current_tests_run_results_query(days_back=days_back, disable_samples=disable_samples) }}
     {% endset %}
 
     {% set elementary_database, elementary_schema = elementary.get_package_database_and_schema() %}
@@ -270,7 +270,7 @@
         {{ elementary.edr_datediff(elementary.edr_cast_as_timestamp('etr.detected_at'), elementary.edr_current_timestamp(), 'day') }} AS days_diff,
         ROW_NUMBER() OVER (PARTITION BY elementary_unique_id ORDER BY etr.detected_at DESC) AS invocations_rank_index,
         etr.failures,
-        etr.result_rows
+        {% if disable_samples %}''{% else %}etr.result_rows{% endif %} AS result_rows
     FROM {{ ref('elementary', 'elementary_test_results') }} etr
     JOIN {{ ref('elementary', 'dbt_tests') }} dt ON etr.test_unique_id = dt.unique_id
     LEFT JOIN (

--- a/elementary/monitor/dbt_project/macros/get_test_results.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_results.sql
@@ -7,7 +7,7 @@
     Called by both default__ and fabric__ dispatches to avoid duplicating the
     Jinja processing loop.
 #}
-{%- macro _process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status) -%}
+{%- macro _process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status, disable_samples = false) -%}
     {% set test_results = [] %}
     {% set tests = elementary.agate_to_dicts(test_results_agate) %}
 
@@ -26,7 +26,7 @@
             {% set test_params = fromjson(test.test_params) %}
             {% set status = test.status | lower %}
 
-            {%- if (test_type == 'dbt_test' and status in ['fail', 'warn']) or (test_type != 'dbt_test' and status in elementary_tests_allowlist_status) -%}
+            {%- if not disable_samples and ((test_type == 'dbt_test' and status in ['fail', 'warn']) or (test_type != 'dbt_test' and status in elementary_tests_allowlist_status)) -%}
                 {% set test_rows_sample = elementary_cli.get_test_rows_sample(test.result_rows, test_result_rows_agate.get(test.id)) %}
             {%- endif -%}
         {% else %}
@@ -120,7 +120,7 @@
         {% do elementary.fully_drop_relation(ordered_test_results_relation) %}
     {% endif %}
 
-    {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status)) %}
+    {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status, disable_samples)) %}
 {%- endmacro -%}
 
 {%- macro fabric__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, disable_samples = false) -%}
@@ -179,7 +179,7 @@
     {% do elementary.fully_drop_relation(base_relation) %}
     {% do elementary.fully_drop_relation(ordered_relation) %}
 
-    {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status)) %}
+    {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status, disable_samples)) %}
 {%- endmacro -%}
 
 {%- macro clickhouse__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, disable_samples = false) -%}
@@ -319,5 +319,5 @@
         {% do elementary.fully_drop_relation(ordered_test_results_relation) %}
     {% endif %}
 
-    {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status)) %}
+    {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status, disable_samples)) %}
 {%- endmacro -%}

--- a/elementary/monitor/dbt_project/macros/get_test_results.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_results.sql
@@ -183,6 +183,7 @@
 {%- endmacro -%}
 
 {%- macro clickhouse__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, skip_test_result_rows = false) -%}
+    {% set elementary_tests_allowlist_status = ['fail', 'warn'] if disable_passed_test_metrics else ['fail', 'warn', 'pass']  %}
     {% do elementary.run_query('drop table if exists ordered_test_results') %}
     {% set create_table_query %}
     CREATE TABLE ordered_test_results (

--- a/elementary/monitor/dbt_project/macros/get_test_results.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_results.sql
@@ -1,5 +1,5 @@
-{%- macro get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, disable_samples = false) -%}
-    {{ return(adapter.dispatch('get_test_results', 'elementary_cli')(days_back, invocations_per_test, disable_passed_test_metrics, disable_samples)) }}
+{%- macro get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, skip_test_result_rows = false) -%}
+    {{ return(adapter.dispatch('get_test_results', 'elementary_cli')(days_back, invocations_per_test, disable_passed_test_metrics, skip_test_result_rows)) }}
 {%- endmacro -%}
 
 {#
@@ -7,7 +7,7 @@
     Called by both default__ and fabric__ dispatches to avoid duplicating the
     Jinja processing loop.
 #}
-{%- macro _process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status, disable_samples = false) -%}
+{%- macro _process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status, skip_test_result_rows = false) -%}
     {% set test_results = [] %}
     {% set tests = elementary.agate_to_dicts(test_results_agate) %}
 
@@ -26,7 +26,7 @@
             {% set test_params = fromjson(test.test_params) %}
             {% set status = test.status | lower %}
 
-            {%- if not disable_samples and ((test_type == 'dbt_test' and status in ['fail', 'warn']) or (test_type != 'dbt_test' and status in elementary_tests_allowlist_status)) -%}
+            {%- if not skip_test_result_rows and ((test_type == 'dbt_test' and status in ['fail', 'warn']) or (test_type != 'dbt_test' and status in elementary_tests_allowlist_status)) -%}
                 {% set test_rows_sample = elementary_cli.get_test_rows_sample(test.result_rows, test_result_rows_agate.get(test.id)) %}
             {%- endif -%}
         {% else %}
@@ -40,11 +40,11 @@
     {% do return(test_results) %}
 {%- endmacro -%}
 
-{%- macro default__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, disable_samples = false) -%}
+{%- macro default__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, skip_test_result_rows = false) -%}
     {% set elementary_tests_allowlist_status = ['fail', 'warn'] if disable_passed_test_metrics else ['fail', 'warn', 'pass']  %}
     {% set select_test_results %}
         with test_results as (
-            {{ elementary_cli.current_tests_run_results_query(days_back=days_back, disable_samples=disable_samples) }}
+            {{ elementary_cli.current_tests_run_results_query(days_back=days_back, skip_test_result_rows=skip_test_result_rows) }}
         ),
 
         ordered_test_results as (
@@ -111,7 +111,7 @@
     {% endset %}
 
     {% set test_results_agate = elementary.run_query(test_results_agate_sql) %}
-    {% if not disable_samples %}
+    {% if not skip_test_result_rows %}
         {% set test_result_rows_agate = elementary_cli.get_result_rows_agate(days_back, valid_ids_query) %}
     {% else %}
         {% set test_result_rows_agate = {} %}
@@ -120,10 +120,10 @@
         {% do elementary.fully_drop_relation(ordered_test_results_relation) %}
     {% endif %}
 
-    {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status, disable_samples)) %}
+    {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status, skip_test_result_rows)) %}
 {%- endmacro -%}
 
-{%- macro fabric__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, disable_samples = false) -%}
+{%- macro fabric__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, skip_test_result_rows = false) -%}
     {#
         T-SQL does not allow nested CTEs (WITH inside WITH).
         current_tests_run_results_query already starts with WITH, so we
@@ -136,7 +136,7 @@
 
     {# Step 1 – materialise the base test-results query into a temp table #}
     {% set base_query %}
-        {{ elementary_cli.current_tests_run_results_query(days_back=days_back, disable_samples=disable_samples) }}
+        {{ elementary_cli.current_tests_run_results_query(days_back=days_back, skip_test_result_rows=skip_test_result_rows) }}
     {% endset %}
 
     {% set elementary_database, elementary_schema = elementary.get_package_database_and_schema() %}
@@ -169,7 +169,7 @@
     {% endset %}
 
     {% set test_results_agate = elementary.run_query(test_results_agate_sql) %}
-    {% if not disable_samples %}
+    {% if not skip_test_result_rows %}
         {% set test_result_rows_agate = elementary_cli.get_result_rows_agate(days_back, valid_ids_query) %}
     {% else %}
         {% set test_result_rows_agate = {} %}
@@ -179,10 +179,10 @@
     {% do elementary.fully_drop_relation(base_relation) %}
     {% do elementary.fully_drop_relation(ordered_relation) %}
 
-    {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status, disable_samples)) %}
+    {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status, skip_test_result_rows)) %}
 {%- endmacro -%}
 
-{%- macro clickhouse__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, disable_samples = false) -%}
+{%- macro clickhouse__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, skip_test_result_rows = false) -%}
     {% do elementary.run_query('drop table if exists ordered_test_results') %}
     {% set create_table_query %}
     CREATE TABLE ordered_test_results (
@@ -270,7 +270,7 @@
         {{ elementary.edr_datediff(elementary.edr_cast_as_timestamp('etr.detected_at'), elementary.edr_current_timestamp(), 'day') }} AS days_diff,
         ROW_NUMBER() OVER (PARTITION BY elementary_unique_id ORDER BY etr.detected_at DESC) AS invocations_rank_index,
         etr.failures,
-        {% if disable_samples %}''{% else %}etr.result_rows{% endif %} AS result_rows
+        {% if skip_test_result_rows %}''{% else %}etr.result_rows{% endif %} AS result_rows
     FROM {{ ref('elementary', 'elementary_test_results') }} etr
     JOIN {{ ref('elementary', 'dbt_tests') }} dt ON etr.test_unique_id = dt.unique_id
     LEFT JOIN (
@@ -310,7 +310,7 @@
     {% endset %}
 
     {% set test_results_agate = elementary.run_query(test_results_agate_sql) %}
-    {% if not disable_samples %}
+    {% if not skip_test_result_rows %}
         {% set test_result_rows_agate = elementary_cli.get_result_rows_agate(days_back, valid_ids_query) %}
     {% else %}
         {% set test_result_rows_agate = {} %}
@@ -319,5 +319,5 @@
         {% do elementary.fully_drop_relation(ordered_test_results_relation) %}
     {% endif %}
 
-    {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status, disable_samples)) %}
+    {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status, skip_test_result_rows)) %}
 {%- endmacro -%}

--- a/elementary/monitor/fetchers/tests/tests.py
+++ b/elementary/monitor/fetchers/tests/tests.py
@@ -22,6 +22,7 @@ class TestsFetcher(FetcherClient):
         days_back: Optional[int] = 7,
         invocations_per_test: int = 720,
         disable_passed_test_metrics: bool = False,
+        disable_samples: bool = False,
     ) -> List[TestResultDBRowSchema]:
         run_operation_response = self.dbt_runner.run_operation(
             macro_name="elementary_cli.get_test_results",
@@ -29,6 +30,7 @@ class TestsFetcher(FetcherClient):
                 days_back=days_back,
                 invocations_per_test=invocations_per_test,
                 disable_passed_test_metrics=disable_passed_test_metrics,
+                disable_samples=disable_samples,
             ),
         )
         test_results = (

--- a/elementary/monitor/fetchers/tests/tests.py
+++ b/elementary/monitor/fetchers/tests/tests.py
@@ -22,7 +22,7 @@ class TestsFetcher(FetcherClient):
         days_back: Optional[int] = 7,
         invocations_per_test: int = 720,
         disable_passed_test_metrics: bool = False,
-        disable_samples: bool = False,
+        skip_test_result_rows: bool = False,
     ) -> List[TestResultDBRowSchema]:
         run_operation_response = self.dbt_runner.run_operation(
             macro_name="elementary_cli.get_test_results",
@@ -30,7 +30,7 @@ class TestsFetcher(FetcherClient):
                 days_back=days_back,
                 invocations_per_test=invocations_per_test,
                 disable_passed_test_metrics=disable_passed_test_metrics,
-                disable_samples=disable_samples,
+                skip_test_result_rows=skip_test_result_rows,
             ),
         )
         test_results = (


### PR DESCRIPTION
## Summary

Adds a new `skip_test_result_rows` parameter to `elementary_cli.get_test_results` and threads it from `ReportAPI.get_report_data` through `TestsAPI` → `TestsFetcher` → the dbt macro. When `skip_test_result_rows=true`, the macro skips the `get_result_rows_agate` query against `test_result_rows` entirely, and the `result_rows` column on `elementary_test_results` is also omitted from the main query (no longer materialized into the intermediate `ordered_test_results` table on ClickHouse either).

Ticket: [APP-1123](https://linear.app/elementary/issue/APP-1123/stop-fetching-test-result-rows-in-report-generation-2496m-rows-522-gb)

### Why a new parameter instead of reusing `disable_samples`

`ReportAPI.get_report_data` already had a `disable_samples` parameter, but it has a different concern than what we needed:

- **`disable_samples` (existing, Python-level)** — applied by `_get_test_result_from_test_result_db_row` *after* the SQL has already run, and only sets `sample_data = None` for `test_type == "dbt_test"` rows. This is the OSS `--disable-samples` CLI behavior for PII protection: it masks dbt-test failed-row samples but preserves anomaly metrics and schema-change diffs.
- **`skip_test_result_rows` (new, macro-level)** — a pure DB optimization. Skips the expensive `test_result_rows` table query (~522 GB / 249.6M rows in cloud) and omits the `result_rows` column from the main `elementary_test_results` select. Affects all test types uniformly. The Python-level masking still applies on top of this for dbt-test rows when `disable_samples` is also set.

These are two separate concerns and the cloud consumer wants the optimization unconditionally (regardless of the per-env PII flag), so a new parameter cleanly separates them.

### Changes
- `elementary/monitor/dbt_project/macros/get_test_results.sql` — add `skip_test_result_rows = false` to the dispatch macro, the `default__` / `fabric__` / `clickhouse__` variants, and `_process_raw_test_results`. Wrap the `get_result_rows_agate` call in `{% if not skip_test_result_rows %}` (empty dict otherwise — `_process_raw_test_results.test_result_rows_agate.get(test.id)` returns `None` for missing keys). Also gate the `get_test_rows_sample` call inside `_process_raw_test_results` on the same flag so samples can't leak via the legacy `elementary_test_results.result_rows` JSON column.
- `elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql` — accept `skip_test_result_rows` and conditionally select `null as result_rows` instead of `elementary_test_results.result_rows`. This means the `result_rows` column is never materialized on Snowflake/BQ/Redshift/Postgres/Databricks and never inserted into ClickHouse's intermediate `ordered_test_results` table either.
- `elementary/monitor/fetchers/tests/tests.py` — accept `skip_test_result_rows` and forward it in `macro_args`.
- `elementary/monitor/api/tests/tests.py` — accept `skip_test_result_rows` in `TestsAPI.__init__` and `_get_test_results_db_rows`, forward to the fetcher. The existing `disable_samples` parameter on `get_test_results` / `_get_test_result_from_test_result_db_row` is untouched.
- `elementary/monitor/api/report/report.py` — add new `skip_test_result_rows: bool = False` parameter, forward to the `TestsAPI` constructor. The existing `disable_samples` parameter and its forwarding to `tests_api.get_test_results(disable_samples=...)` is untouched.

### Drive-by fix
- Initialize `elementary_tests_allowlist_status` in `clickhouse__get_test_results`. Pre-existing bug surfaced by CodeRabbit: the ClickHouse variant called `_process_raw_test_results` with an uninitialized variable, which would silently skip sample selection for non-`dbt_test` rows on ClickHouse. The `default__` and `fabric__` variants already set this from `disable_passed_test_metrics`.

### Backwards compatibility
- All new parameters default to `false`, so existing callers (OSS users, `data_monitoring_report.send_test_results_summary`) see no behavior change.
- The existing `disable_samples` parameter on `ReportAPI.get_report_data` and `TestsAPI.get_test_results` is preserved with its original Python-level mask semantics — OSS `edr report --disable-samples` continues to work exactly as before.

## Review & Testing Checklist for Human

- [ ] Verify the macro change covers all three dispatch variants (`default__`, `fabric__`, `clickhouse__`) by inspecting `get_test_results.sql`.
- [ ] Sanity-check that `test_result_rows_agate = {}` (empty dict) is safe input for `_process_raw_test_results` — it relies on `test_result_rows_agate.get(test.id)` which returns `None` for missing keys, and the `get_test_rows_sample` call is now also gated on `skip_test_result_rows` so it's never invoked when samples are skipped.
- [ ] Sanity-check the ClickHouse variant: with `skip_test_result_rows=true`, `current_tests_run_results_query` returns `null` for the `result_rows` column, so the inline `INSERT INTO ordered_test_results` no longer materializes it.
- [ ] Run an end-to-end report against a real warehouse with `skip_test_result_rows=true` and confirm the `test_result_rows` SELECT no longer appears in query history.

### Notes
- This is the OSS side of the change. The cloud consumer (elementary-internal) bumps the pin to this commit and hardcodes `skip_test_result_rows=True` in `get_edr_report` while keeping `disable_samples` driven by the per-env `disable_test_samples` flag.

Link to Devin session: https://app.devin.ai/sessions/d3ae8f0bdf5b484b8ca0cde41ec58529
Requested by: @MikaKerman

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new skip_test_result_rows option available across reporting, fetchers, and dbt macros.
  * When enabled, per-test result rows are omitted from retrievals and persisted result blobs are blanked.
  * Allows running without fetching or storing detailed per-test result rows when that detail isn’t required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elementary-data/elementary/pull/2230)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->