### PR TITLE
ci: disable Elementary artifact hooks during seed

### DIFF
--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -348,7 +348,12 @@ jobs:
       - name: Seed e2e dbt project
         working-directory: ${{ env.E2E_DBT_PROJECT_DIR }}
         if: steps.seed-cache.outputs.cache-hit != 'true' && inputs.warehouse-type != 'dremio' && inputs.warehouse-type != 'spark'
-        run: dbt seed -f --target "$WAREHOUSE_TYPE"
+        run: |
+          # The seed step runs before Elementary models exist, so artifact hooks
+          # would try to insert into missing Elementary relations.
+          dbt seed -f \
+            --target "$WAREHOUSE_TYPE" \
+            --vars '{"disable_run_results": true, "disable_dbt_invocation_autoupload": true}'
 
       - name: Save seed cache from Docker volumes
         if: steps.seed-cache.outputs.cache-hit != 'true' && (inputs.warehouse-type == 'postgres' || inputs.warehouse-type == 'clickhouse')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Disable Elementary run-result and invocation artifact uploads during the E2E `dbt seed` step.
- Keep artifact uploads enabled for the later run/test/monitor steps where Elementary models exist.

## Context
The seed step runs before Elementary models are created. With dbt 1.11, missing Elementary relations can propagate as rendered strings into adapter relation APIs during `on-run-end`, causing warehouse CI failures such as `'str' object has no attribute 'database'`.

## Testing
- `ELEMENTARY_DBT_PACKAGE_PATH=/tmp/dbt-data-reliability-ci-inspect HOME=/tmp/elementary-repro-home dbt seed -f --target duckdb --project-dir tests/e2e_dbt_project --vars '{"disable_run_results": true, "disable_dbt_invocation_autoupload": true}'`
- `ELEMENTARY_DBT_PACKAGE_PATH=/tmp/dbt-data-reliability-ci-inspect HOME=/tmp/elementary-repro-bq-home dbt compile --no-populate-cache --inline "{{ elementary.on_run_end() }}" --target bigquery --project-dir tests/e2e_dbt_project --vars '{"disable_run_results": true, "disable_dbt_invocation_autoupload": true}'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a685b3e-b3d9-4de8-a7cc-ec2efbffb5ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a685b3e-b3d9-4de8-a7cc-ec2efbffb5ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow test execution process to improve testing efficiency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elementary-data/elementary/pull/2236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->