### PR TITLE
fix: invalid yaml syntax for owner field

### DIFF
--- a/docs/cloud/best-practices/governance-for-observability.mdx
+++ b/docs/cloud/best-practices/governance-for-observability.mdx
@@ -48,7 +48,7 @@ models:
         - marketing-public
         - marketing
       meta:
-        owner: :"@analytics.engineer"
+        owner: "@analytics.engineer"
         subscribers:
         - "@marketing.data.analyst"
         - "@another.marketing.data.analyst"


### PR DESCRIPTION
The `owner` field in the governance-for-observability best practices page had a double colon (`::`) in the YAML example, making it invalid YAML syntax. Removed the extra colon to correct the example.