### PR TITLE
fix: add explicit sqlserver__ dispatches in elementary_cli (CORE-877)

### DIFF
--- a/elementary/monitor/dbt_project/macros/get_adapter_type_and_unique_id.sql
+++ b/elementary/monitor/dbt_project/macros/get_adapter_type_and_unique_id.sql
@@ -26,6 +26,10 @@
     {{ return(target.server) }}
 {% endmacro %}
 
+{% macro sqlserver__get_adapter_unique_id() %}
+    {{ return(target.server) }}
+{% endmacro %}
+
 {% macro fabricspark__get_adapter_unique_id() %}
     {{ return(target.workspaceid) }}
 {% endmacro %}

--- a/elementary/monitor/dbt_project/macros/get_test_results.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_results.sql
@@ -129,8 +129,7 @@
         current_tests_run_results_query already starts with WITH, so we
         cannot wrap it in another CTE.  Instead we materialise it into a
         temp table first, then build ordered_test_results on top.
-        Note: sqlserver adapter inherits from fabric, so this dispatch
-        covers both fabric and sqlserver targets automatically.
+        sqlserver targets use sqlserver__get_test_results (delegates here).
     #}
     {% set elementary_tests_allowlist_status = ['fail', 'warn'] if disable_passed_test_metrics else ['fail', 'warn', 'pass']  %}
 
@@ -180,6 +179,10 @@
     {% do elementary.fully_drop_relation(ordered_relation) %}
 
     {% do return(elementary_cli._process_raw_test_results(test_results_agate, test_result_rows_agate, elementary_tests_allowlist_status, skip_test_result_rows)) %}
+{%- endmacro -%}
+
+{%- macro sqlserver__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, skip_test_result_rows = false) -%}
+    {% do return(elementary_cli.fabric__get_test_results(days_back, invocations_per_test, disable_passed_test_metrics, skip_test_result_rows)) %}
 {%- endmacro -%}
 
 {%- macro clickhouse__get_test_results(days_back = 7, invocations_per_test = 720, disable_passed_test_metrics = false, skip_test_result_rows = false) -%}

--- a/elementary/monitor/dbt_project/macros/get_test_results.sql
+++ b/elementary/monitor/dbt_project/macros/get_test_results.sql
@@ -129,7 +129,6 @@
         current_tests_run_results_query already starts with WITH, so we
         cannot wrap it in another CTE.  Instead we materialise it into a
         temp table first, then build ordered_test_results on top.
-        sqlserver targets use sqlserver__get_test_results (delegates here).
     #}
     {% set elementary_tests_allowlist_status = ['fail', 'warn'] if disable_passed_test_metrics else ['fail', 'warn', 'pass']  %}
 


### PR DESCRIPTION
## Summary
- Add `sqlserver__get_test_results` delegating to `fabric__get_test_results` to avoid nested CTE errors on T-SQL during `edr monitor report`
- Add `sqlserver__get_adapter_unique_id` returning `target.server` (sqlserver profiles use `server`, not `host`)
- Fix misleading comment that assumed sqlserver inherits fabric dispatch (same issue fixed in dbt-data-reliability #1013)

## Context
dbt-sqlserver no longer declares dbt-fabric as a dispatch parent (dbt-msft/dbt-sqlserver#628), so `fabric__` macros in the `elementary_cli` namespace are not resolved for sqlserver targets. Warehouse CI on master passes 13/14 adapters; only sqlserver fails at the report step with `Incorrect syntax near the keyword 'with'`.

Audited all `elementary_cli` macros — only these two had `fabric__` implementations without explicit `sqlserver__` delegates. Other T-SQL-aware macros (e.g. `test_conn`) use `elementary.is_tsql()` in `default__`.

## Test plan
- [ ] Warehouse CI passes for sqlserver (especially `edr monitor report`)
- [ ] Fabric CI still passes (unchanged behavior)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SQL Server-specific system identification to provide a stable adapter unique ID.
  * Routed SQL Server test-result retrieval through the fabric implementation for consistent behavior.

* **Documentation**
  * Clarified notes about T-SQL nested-CTE limitations and the need to materialize intermediate results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elementary-data/elementary/pull/2241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->