### PR TITLE
chore: update dbt-data-reliability to v0.24.0 (CORE-877)

### DIFF
--- a/elementary/monitor/dbt_project/package-lock.yml
+++ b/elementary/monitor/dbt_project/package-lock.yml
@@ -2,5 +2,5 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 0.8.6
   - package: elementary-data/elementary
-    version: 0.23.1
-sha1_hash: 59bbd36f7ccb725a85b3ce3db2ce7093d7ee81a5
+    version: 0.24.0
+sha1_hash: d043a0bdd88a74d9c30b8a9360eb35184f1f5a7e

--- a/elementary/monitor/dbt_project/packages.yml
+++ b/elementary/monitor/dbt_project/packages.yml
@@ -2,7 +2,7 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=0.8.0", "<0.9.0"]
   - package: elementary-data/elementary
-    version: 0.23.1
+    version: 0.24.0
 
   #  NOTE - for unreleased CLI versions we often need to update the package version to a commit hash (please leave this
   #  commented, so it will be easy to access)


### PR DESCRIPTION
## Summary
- Bump `elementary-data/elementary` in `packages.yml` from `0.23.1` to `0.24.0`
- Regenerate `package-lock.yml` via `dbt deps`

## Context
Part of [CORE-877](https://linear.app/elementary/issue/CORE-877) OSS release. dbt Hub confirms `0.24.0` is live.

## Test plan
- [ ] CI passes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to latest stable versions for improved stability and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elementary-data/elementary/pull/2242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->