### PR TITLE
Support custom paths for internal dbt project via env vars

### DIFF
--- a/docs/oss/cli-commands.mdx
+++ b/docs/oss/cli-commands.mdx
@@ -211,3 +211,20 @@ edr monitor --suppression-interval [int]
 ```shell
 edr monitor --override-dbt-project-config --slack-token <your_slack_token> --slack-channel-name <slack_channel_to_post_at> --suppression-interval 0
 ```
+
+## Internal dbt project directories
+
+Elementary ships an internal dbt project that `edr` runs to read your test results. By default it writes its compiled SQL artifacts and installed dbt packages **inside the installed `elementary` package directory**. In restrictive deployments (UAT / production) where the executing user has no write access to that location, override the paths with the following environment variables:
+
+- **`DBT_TARGET_PATH`** — directory for the internal dbt project's compiled SQL and run artifacts. Default is `target` (relative to the internal project). Set it to a writable absolute path, e.g. `/var/tmp/edr_target`.
+- **`DBT_PACKAGES_FOLDER`** — directory where the internal dbt project installs its dbt packages. Default is `dbt_packages` (relative to the internal project). Set it to a writable absolute path, e.g. `/var/tmp/edr_packages`.
+
+```shell
+export DBT_TARGET_PATH="/var/tmp/edr_target"
+export DBT_PACKAGES_FOLDER="/var/tmp/edr_packages"
+edr monitor
+```
+
+<Info>
+  These environment variables configure the **internal** dbt project bundled with Elementary. They are separate from the `--target-path` CLI option above, which controls where `edr`'s own logs and reports are written.
+</Info>

--- a/docs/oss/cli-commands.mdx
+++ b/docs/oss/cli-commands.mdx
@@ -216,11 +216,11 @@ edr monitor --override-dbt-project-config --slack-token <your_slack_token> --sla
 
 Elementary ships an internal dbt project that `edr` runs to read your test results. By default it writes its compiled SQL artifacts and installed dbt packages **inside the installed `elementary` package directory**. In restrictive deployments (UAT / production) where the executing user has no write access to that location, override the paths with the following environment variables:
 
-- **`DBT_TARGET_PATH`** — directory for the internal dbt project's compiled SQL and run artifacts. Default is `target` (relative to the internal project). Set it to a writable absolute path, e.g. `/var/tmp/edr_target`.
+- **`EDR_INTERNAL_TARGET_PATH`** — directory for the internal dbt project's compiled SQL and run artifacts. Default is `target` (relative to the internal project). Set it to a writable absolute path, e.g. `/var/tmp/edr_target`. (This is intentionally distinct from dbt's standard `DBT_TARGET_PATH`, which `edr` uses to locate your own project's artifacts — see `upload-source-freshness`.)
 - **`DBT_PACKAGES_FOLDER`** — directory where the internal dbt project installs its dbt packages. Default is `dbt_packages` (relative to the internal project). Set it to a writable absolute path, e.g. `/var/tmp/edr_packages`.
 
 ```shell
-export DBT_TARGET_PATH="/var/tmp/edr_target"
+export EDR_INTERNAL_TARGET_PATH="/var/tmp/edr_target"
 export DBT_PACKAGES_FOLDER="/var/tmp/edr_packages"
 edr monitor
 ```

--- a/elementary/monitor/dbt_project/dbt_project.yml
+++ b/elementary/monitor/dbt_project/dbt_project.yml
@@ -20,9 +20,9 @@ snapshot-paths: ["snapshots"]
 
 packages-install-path: "{{ env_var('DBT_PACKAGES_FOLDER', 'dbt_packages') }}"
 
-target-path: "{{ env_var('DBT_TARGET_PATH', 'target') }}" # directory which will store compiled SQL files
+target-path: "{{ env_var('EDR_INTERNAL_TARGET_PATH', 'target') }}" # directory which will store compiled SQL files
 clean-targets: # directories to be removed by `dbt clean`
-  - "{{ env_var('DBT_TARGET_PATH', 'target') }}"
+  - "{{ env_var('EDR_INTERNAL_TARGET_PATH', 'target') }}"
   - "{{ env_var('DBT_PACKAGES_FOLDER', 'dbt_packages') }}"
   - "dbt_modules"
 

--- a/elementary/monitor/dbt_project/dbt_project.yml
+++ b/elementary/monitor/dbt_project/dbt_project.yml
@@ -20,7 +20,7 @@ snapshot-paths: ["snapshots"]
 
 packages-install-path: "{{ env_var('DBT_PACKAGES_FOLDER', 'dbt_packages') }}"
 
-target-path: "target" # directory which will store compiled SQL files
+target-path: "{{ env_var('DBT_TARGET_PATH', 'target') }}" # directory which will store compiled SQL files
 clean-targets: # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"

--- a/elementary/monitor/dbt_project/dbt_project.yml
+++ b/elementary/monitor/dbt_project/dbt_project.yml
@@ -22,8 +22,8 @@ packages-install-path: "{{ env_var('DBT_PACKAGES_FOLDER', 'dbt_packages') }}"
 
 target-path: "{{ env_var('DBT_TARGET_PATH', 'target') }}" # directory which will store compiled SQL files
 clean-targets: # directories to be removed by `dbt clean`
-  - "target"
-  - "dbt_packages"
+  - "{{ env_var('DBT_TARGET_PATH', 'target') }}"
+  - "{{ env_var('DBT_PACKAGES_FOLDER', 'dbt_packages') }}"
   - "dbt_modules"
 
 # Configuring models


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now respects EDR_INTERNAL_TARGET_PATH and DBT_PACKAGES_FOLDER to control where its internal dbt project writes compiled artifacts and installs packages; cleanup targets the configured path.

* **Documentation**
  * Added docs with examples for setting these environment variables and a note clarifying they are separate from the CLI's external --target-path option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->