### PR TITLE
CORE-918: Improve bump-version workflow for docs branch and dbt lock

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -96,8 +96,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ env.RELEASE_BRANCH }}
           base: master
-          commit-message: "release v${{ env.CLI_VERSION }}"
-          title: "Release v${{ env.CLI_VERSION }}"
+          commit-message: "release v${{ env.CLI_VERSION }} (dbt package v${{ env.DBT_PACKAGE_VERSION }})"
+          title: "Release v${{ env.CLI_VERSION }} (dbt package v${{ env.DBT_PACKAGE_VERSION }})"
           body: "Opened automatically using bump version workflow"
 
   update-docs-branch:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -83,12 +83,6 @@ jobs:
       # dbt-core==1.8 is the first dbt version we support
       - name: Install dbt-core
         run: pip install "dbt-core==1.8"
-      - name: Create release branch
-        run: git checkout -b "$RELEASE_BRANCH"
-      - name: Initial config
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email noreply@github.com
       - name: Bump version
         run: |
           sed -i "s/^version = \"[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\"/version = \"$CLI_VERSION\"/" ./pyproject.toml
@@ -96,16 +90,13 @@ jobs:
         run: |
           sed -i "s/version: [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$/version: $DBT_PACKAGE_VERSION/" ./elementary/monitor/dbt_project/packages.yml
           dbt deps --lock --project-dir elementary/monitor/dbt_project
-      - name: Commit changes
-        run: git commit -am "release v$CLI_VERSION"
-      - name: Push code
-        run: git push origin "$RELEASE_BRANCH"
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ env.RELEASE_BRANCH }}
           base: master
+          commit-message: "release v${{ env.CLI_VERSION }}"
           title: "Release v${{ env.CLI_VERSION }}"
           body: "Opened automatically using bump version workflow"
 
@@ -123,12 +114,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: docs
-      - name: Create docs release branch
-        run: git checkout -b "$DOCS_RELEASE_BRANCH"
-      - name: Initial config
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email noreply@github.com
       - name: Bump dbt package
         run: |
           files=(
@@ -138,16 +123,12 @@ jobs:
           for file in "${files[@]}"; do
             sed -i "s/version: [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$/version: $DBT_PACKAGE_VERSION/" "./$file"
           done
-      - name: Commit changes
-        run: |
-          git commit -am "docs: bump package version to v$DBT_PACKAGE_VERSION"
-      - name: Push code
-        run: git push origin "$DOCS_RELEASE_BRANCH"
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ env.DOCS_RELEASE_BRANCH }}
           base: docs
+          commit-message: "docs: bump package version to v${{ env.DBT_PACKAGE_VERSION }}"
           title: "Docs: bump dbt package to v${{ env.DBT_PACKAGE_VERSION }}"
           body: "Opened automatically using bump version workflow"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install Python requirements
         run: pip install .
       - name: Create release branch

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -80,8 +80,9 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - name: Install Python requirements
-        run: pip install .
+      # dbt-core==1.8 is the first dbt version we support (see pre-commit verify-dbt-project-packages-lock).
+      - name: Install dbt-core
+        run: pip install "dbt-core==1.8"
       - name: Create release branch
         run: git checkout -b "$RELEASE_BRANCH"
       - name: Initial config

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      # dbt-core==1.8 is the first dbt version we support (see pre-commit verify-dbt-project-packages-lock).
+      # dbt-core==1.8 is the first dbt version we support
       - name: Install dbt-core
         run: pip install "dbt-core==1.8"
       - name: Create release branch

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -106,7 +106,7 @@ jobs:
           source_branch: ${{ env.RELEASE_BRANCH }}
           destination_branch: master
           pr_title: "Release v${{ env.CLI_VERSION }}"
-          pr_body: "Open automatically using bump version workflow"
+          pr_body: "Opened automatically using bump version workflow"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   update-docs-branch:
@@ -150,5 +150,5 @@ jobs:
           source_branch: "release/docs-v${{ needs.validate-version.outputs.validated-cli-version }}"
           destination_branch: "docs"
           pr_title: "Docs: bump dbt package to v${{ env.DBT_PACKAGE_VERSION }}"
-          pr_body: "Open automatically using bump version workflow"
+          pr_body: "Opened automatically using bump version workflow"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -101,14 +101,13 @@ jobs:
       - name: Push code
         run: git push origin "$RELEASE_BRANCH"
       - name: Create pull request
-        # repo-sync/pull-request v2.12.1, checked 2026-04-26.
-        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5
+        uses: peter-evans/create-pull-request@v8.0.0
         with:
-          source_branch: ${{ env.RELEASE_BRANCH }}
-          destination_branch: master
-          pr_title: "Release v${{ env.CLI_VERSION }}"
-          pr_body: "Opened automatically using bump version workflow"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ env.RELEASE_BRANCH }}
+          base: master
+          title: "Release v${{ env.CLI_VERSION }}"
+          body: "Opened automatically using bump version workflow"
 
   update-docs-branch:
     needs: validate-version
@@ -145,11 +144,10 @@ jobs:
       - name: Push code
         run: git push origin "$DOCS_RELEASE_BRANCH"
       - name: Create pull request
-        # repo-sync/pull-request v2.12.1, checked 2026-04-26.
-        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5
+        uses: peter-evans/create-pull-request@v8.0.0
         with:
-          source_branch: "release/docs-v${{ needs.validate-version.outputs.validated-cli-version }}"
-          destination_branch: "docs"
-          pr_title: "Docs: bump dbt package to v${{ env.DBT_PACKAGE_VERSION }}"
-          pr_body: "Opened automatically using bump version workflow"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ env.DOCS_RELEASE_BRANCH }}
+          base: docs
+          title: "Docs: bump dbt package to v${{ env.DBT_PACKAGE_VERSION }}"
+          body: "Opened automatically using bump version workflow"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -68,6 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     env:
       CLI_VERSION: ${{ needs.validate-version.outputs.validated-cli-version }}
       DBT_PACKAGE_VERSION: ${{ needs.validate-version.outputs.validated-dbt-package-version || needs.validate-version.outputs.default-dbt-package-version }}
@@ -75,6 +76,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install Python requirements
+        run: pip install .
       - name: Create release branch
         run: git checkout -b "$RELEASE_BRANCH"
       - name: Initial config
@@ -84,37 +91,64 @@ jobs:
       - name: Bump version
         run: |
           sed -i "s/^version = \"[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\"/version = \"$CLI_VERSION\"/" ./pyproject.toml
-      - name: Bump version for package (using input)
-        if: ${{ needs.validate-version.outputs.validated-dbt-package-version != ''}}
+      - name: Bump dbt package version
         run: |
           sed -i "s/version: [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$/version: $DBT_PACKAGE_VERSION/" ./elementary/monitor/dbt_project/packages.yml
-          sed -i "s/version: [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$/version: $DBT_PACKAGE_VERSION/" ./docs/_snippets/quickstart-package-install.mdx
-      - name: Bump version for package (using default)
-        if: ${{ needs.validate-version.outputs.validated-dbt-package-version == ''}}
-        run: |
-          sed -i "s/version: [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$/version: $DBT_PACKAGE_VERSION/" ./elementary/monitor/dbt_project/packages.yml
-          sed -i "s/version: [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$/version: $DBT_PACKAGE_VERSION/" ./docs/_snippets/quickstart-package-install.mdx
+          dbt deps --lock --project-dir elementary/monitor/dbt_project
       - name: Commit changes
         run: git commit -am "release v$CLI_VERSION"
       - name: Push code
         run: git push origin "$RELEASE_BRANCH"
-
-  create-pr:
-    needs:
-      - validate-version
-      - bump-version
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v6
-      - name: create pull request
+      - name: Create pull request
         # repo-sync/pull-request v2.12.1, checked 2026-04-26.
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5
         with:
-          source_branch: "release/v${{ needs.validate-version.outputs.validated-cli-version }}"
-          destination_branch: "master"
-          pr_title: "release/v${{ needs.validate-version.outputs.validated-cli-version }}"
+          source_branch: ${{ env.RELEASE_BRANCH }}
+          destination_branch: master
+          pr_title: "Release v${{ env.CLI_VERSION }}"
+          pr_body: "Open automatically using bump version workflow"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  update-docs-branch:
+    needs: validate-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      DBT_PACKAGE_VERSION: ${{ needs.validate-version.outputs.validated-dbt-package-version || needs.validate-version.outputs.default-dbt-package-version }}
+      DOCS_RELEASE_BRANCH: release/docs-v${{ needs.validate-version.outputs.validated-cli-version }}
+    steps:
+      - name: Checkout docs branch
+        uses: actions/checkout@v6
+        with:
+          ref: docs
+      - name: Create docs release branch
+        run: git checkout -b "$DOCS_RELEASE_BRANCH"
+      - name: Initial config
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email noreply@github.com
+      - name: Bump dbt package
+        run: |
+          files=(
+            docs/snippets/quickstart-package-install.mdx
+            docs/data-tests/dbt/upgrade-package.mdx
+          )
+          for file in "${files[@]}"; do
+            sed -i "s/version: [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$/version: $DBT_PACKAGE_VERSION/" "./$file"
+          done
+      - name: Commit changes
+        run: |
+          git commit -am "docs: bump package version to v$DBT_PACKAGE_VERSION"
+      - name: Push code
+        run: git push origin "$DOCS_RELEASE_BRANCH"
+      - name: Create pull request
+        # repo-sync/pull-request v2.12.1, checked 2026-04-26.
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5
+        with:
+          source_branch: "release/docs-v${{ needs.validate-version.outputs.validated-cli-version }}"
+          destination_branch: "docs"
+          pr_title: "Docs: bump dbt package to v${{ env.DBT_PACKAGE_VERSION }}"
           pr_body: "Open automatically using bump version workflow"
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Opens a separate docs PR from the `docs` branch, updating package version in configurable doc paths
- Runs `dbt deps --lock` after bumping `packages.yml` so `package-lock.yml` is included in the release
- Merges release PR creation into the `bump-version` job with human-readable PR titles
- Replacing archived `repo-sync/pull-request` with new `peter-evans/create-pull-request@v8.0.0` action.

## Test plan
- [x] Verify `update-docs-branch` job opens a PR to `docs` with updated snippet paths: https://github.com/elementary-data/elementary/pull/2256
- [x] Verify the `bump-version` job opens a PR to `master` with the new version: https://github.com/elementary-data/elementary/pull/2257

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release automation to make version bumps for the dbt package more reliable and automated (including dependency lock updates and branch commits).
  * Added environment validation and runtime setup to ensure consistent CLI/dbt versions during releases.
  * Streamlined documentation flow: docs release branches are created, versioned, pushed, and PRs opened automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->