### PR TITLE
chore: update dbt-data-reliability to include elementary_extra_indexes support

### DIFF
--- a/elementary/monitor/dbt_project/package-lock.yml
+++ b/elementary/monitor/dbt_project/package-lock.yml
@@ -2,5 +2,5 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 0.8.6
   - git: https://github.com/elementary-data/dbt-data-reliability.git
-    revision: 1aa94e4dd7c084d01e3341a57f61aa325bf4f8a3
-sha1_hash: 60b7e83f1c6408360e9595916d0490b577f0b60b
+    revision: 3dc104a13cda8dd4a0fbcec41a97706acb110643
+sha1_hash: bf82996361ff131551875e36b5e016f7c77fa230

--- a/elementary/monitor/dbt_project/packages.yml
+++ b/elementary/monitor/dbt_project/packages.yml
@@ -2,7 +2,7 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=0.8.0", "<0.9.0"]
   - git: https://github.com/elementary-data/dbt-data-reliability.git
-    revision: 1aa94e4dd7c084d01e3341a57f61aa325bf4f8a3
+    revision: 3dc104a13cda8dd4a0fbcec41a97706acb110643
 
   #  NOTE - for unreleased CLI versions we often need to update the package version to a commit hash (please leave this
   #  commented, so it will be easy to access)


### PR DESCRIPTION
## Summary

Updates `packages.yml` to point to the merged commit on `dbt-data-reliability` master (`3dc104a1`) which includes the `elementary_extra_indexes` config var support (PR #1019).

This is a dependency-chain update — the elementary-internal cloud runner passes `elementary_extra_indexes` via dbt vars to inject custom indexes (e.g., `(created_at, resource_type)` on `dbt_run_results`) into synced schema tables. This PR picks up that macro support so elementary-internal can reference it.

**Merge order:** ~~dbt-data-reliability #1019~~ (merged) → **this PR** → elementary-internal #6500

Link to Devin session: https://app.devin.ai/sessions/278ceddbe6d24dbea36a83ecc232f3b6
Requested by: @haritamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the dbt dependency to the data-reliability package using a git-based source for dependency management.
  * Updated project lock/configuration to reflect the new git-sourced dependency and refreshed integrity information to ensure reproducible installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->