### PR TITLE
fix: update microbatch compiled code docs to use new macro name

### DIFF
--- a/docs/snippets/guides/microbatch-compiled-code.mdx
+++ b/docs/snippets/guides/microbatch-compiled-code.mdx
@@ -2,7 +2,7 @@ Elementary can capture and store the compiled SQL of [dbt microbatch incremental
 
 ## How it works
 
-Elementary provides the `capture_microbatch_compiled_code_sql` macro that captures the compiled SQL of each batch as it runs. The captured code is cached during the invocation and later written to `dbt_run_results.compiled_code`, so microbatch models populate this column the same way other incremental strategies do.
+Elementary provides the `capture_and_execute_microbatch_compiled_code_sql` macro that captures the compiled SQL of each batch as it runs. The captured code is cached during the invocation and later written to `dbt_run_results.compiled_code`, so microbatch models populate this column the same way other incremental strategies do.
 
 ## Enabling microbatch compiled code capture
 
@@ -12,7 +12,7 @@ Elementary provides the `capture_microbatch_compiled_code_sql` macro that captur
 
     ```sql filename="macros/get_incremental_microbatch_sql.sql"
     {% macro get_incremental_microbatch_sql(arg_dict) %}
-      {{ return(elementary.capture_microbatch_compiled_code_sql(arg_dict)) }}
+      {{ return(elementary.capture_and_execute_microbatch_compiled_code_sql(arg_dict)) }}
     {% endmacro %}
     ```
   </Step>
@@ -49,4 +49,3 @@ It is also not supported on dbt Fusion.
 
 On unsupported adapters and on Fusion, microbatch models continue to run normally but `dbt_run_results.compiled_code` remains empty for them.
 </Warning>
-

--- a/docs/snippets/guides/microbatch-compiled-code.mdx
+++ b/docs/snippets/guides/microbatch-compiled-code.mdx
@@ -2,7 +2,7 @@ Elementary can capture and store the compiled SQL of [dbt microbatch incremental
 
 ## How it works
 
-Elementary provides an override macro for dbt's `get_incremental_microbatch_sql` that captures the compiled SQL of each batch as it runs. The captured code is cached during the invocation and later written to `dbt_run_results.compiled_code`, so microbatch models populate this column the same way other incremental strategies do.
+Elementary provides the `capture_microbatch_compiled_code_sql` macro that captures the compiled SQL of each batch as it runs. The captured code is cached during the invocation and later written to `dbt_run_results.compiled_code`, so microbatch models populate this column the same way other incremental strategies do.
 
 ## Enabling microbatch compiled code capture
 
@@ -12,7 +12,7 @@ Elementary provides an override macro for dbt's `get_incremental_microbatch_sql`
 
     ```sql filename="macros/get_incremental_microbatch_sql.sql"
     {% macro get_incremental_microbatch_sql(arg_dict) %}
-      {{ return(elementary.get_incremental_microbatch_sql(arg_dict)) }}
+      {{ return(elementary.capture_microbatch_compiled_code_sql(arg_dict)) }}
     {% endmacro %}
     ```
   </Step>
@@ -49,3 +49,4 @@ It is also not supported on dbt Fusion.
 
 On unsupported adapters and on Fusion, microbatch models continue to run normally but `dbt_run_results.compiled_code` remains empty for them.
 </Warning>
+


### PR DESCRIPTION
## Summary

Updates docs to reflect the macro rename in dbt-data-reliability (companion PR: elementary-data/dbt-data-reliability).

The package-level macro is renamed from `get_incremental_microbatch_sql` to `capture_microbatch_compiled_code_sql` to avoid silently breaking microbatch execution for all Elementary users (see dbt-data-reliability PR for full root cause explanation).

**Docs change:** The user's root project wrapper macro name (`get_incremental_microbatch_sql`) stays the same — only the Elementary macro it delegates to changes.

Before:
```sql
{% macro get_incremental_microbatch_sql(arg_dict) %}
  {{ return(elementary.get_incremental_microbatch_sql(arg_dict)) }}
{% endmacro %}
```

After:
```sql
{% macro get_incremental_microbatch_sql(arg_dict) %}
  {{ return(elementary.capture_microbatch_compiled_code_sql(arg_dict)) }}
{% endmacro %}
```