### PR TITLE
CORE-1048: pin minimum versions for msgpack and cryptography to fix Dependabot alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dbt-core = ">=1.8,<2.0.0"
 requests = ">=2.28.1,<3.0.0"
 urllib3 = ">=2.7.0,<3.0.0"
 idna = ">=3.15,<4"  # transitive dependency via requests, pinned to address CVE-2025-46816
+msgpack = ">=1.2.1"  # transitive dependency via CacheControl, pinned to address GHSA OOB read
+cryptography = ">=48.0.1"  # transitive dependency via SecretStorage, pinned to address GHSA vulnerable OpenSSL
 beautifulsoup4 = "<5.0.0"
 ratelimit = "*"
 posthog = "<3.0.0"


### PR DESCRIPTION
## Summary

Add minimum version constraints for two transitive dependencies with known Dependabot high-severity alerts:

| Package | Constraint | Via | Advisory |
|---------|-----------|-----|----------|
| msgpack | `>=1.2.1` | CacheControl | OOB read / crash on Unpacker reuse after caught error |
| cryptography | `>=48.0.1` | SecretStorage | Vulnerable OpenSSL included in wheels |

Follows the same pattern used for `idna = \">=3.15,<4\"` (CVE-2025-46816). No lockfile in this repo, so pinning in `pyproject.toml` is the only way to enforce the minimum safe version.

Link to Devin session: https://app.devin.ai/sessions/7a118cfb43a8447e839fbaeace279467
Requested by: @haritamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency declarations by adding explicit minimum version constraints for transitive packages to improve build reproducibility and stability. This also helps ensure timely availability of security fixes addressed by the pinned versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->