### PR TITLE
fix(dremio): add +root_path to e2e project to fix CI with dbt-dremio 1.10.1

### DIFF
--- a/tests/e2e_dbt_project/dbt_project.yml
+++ b/tests/e2e_dbt_project/dbt_project.yml
@@ -32,4 +32,5 @@ models:
 
   elementary:
     +schema: elementary
+    +root_path: elementary
     +file_format: "{{ 'delta' if target.type == 'spark' else none }}"


### PR DESCRIPTION
## Problem

\`dbt-dremio\` 1.10.1 introduced [a breaking change in TABLE schema resolution](https://github.com/dremio/dbt-dremio/pull/311): it now uses \`+root_path\` instead of \`+schema\` for table materializations. Without \`+root_path\` set, tables fall back to \`target.root_path\` directly — ignoring \`+schema\` entirely.

In the e2e test project, \`elementary\` models had \`+schema: elementary\` but no \`+root_path\`. After the implicit upgrade to 1.10.1 in CI, tables started landing at \`elementary_tests\` instead of \`elementary_tests.elementary\`. The CLI's \`elementary\` profile hardcodes \`enterprise_catalog_folder: elementary_tests.elementary\`, so \`alerts_v2\` couldn't find \`test_result_rows\` → _"Object not found"_ error.

This only affects CI. Real users are unaffected because \`edr generate-profile-yml\` reads the actual compiled graph and writes the correct path into the \`elementary\` profile automatically.

> **Note for Dremio users upgrading to dbt-dremio 1.10.1**: if you upgrade without adding \`+root_path: elementary\` to your project, your Elementary tables will move from \`my_schema.elementary\` to \`my_schema\`. Re-running \`edr generate-profile-yml\` after upgrading will regenerate your \`elementary\` profile to point at the new location. Alternatively, adding \`+root_path: elementary\` to your \`dbt_project.yml\` (as done here) keeps tables at \`my_schema.elementary\` in both versions and avoids the need to regenerate.

## Fix

Add \`+root_path: elementary\` to the e2e project's \`dbt_project.yml\`.

- In **1.10.1**: \`+root_path\` takes precedence for TABLE nodes → tables land at \`elementary_tests.elementary\` ✓
- In **1.10.0**: \`+root_path\` is unused, \`+schema\` still drives table resolution → tables land at \`elementary_tests.elementary\` ✓

Both versions now agree with the CLI profile's hardcoded \`elementary_tests.elementary\`.