### PR TITLE
docs: point Cloud performance alerts to the native monitor

### DIFF
--- a/docs/cloud/features/anomaly-detection/cloud-pipeline-task-performance.mdx
+++ b/docs/cloud/features/anomaly-detection/cloud-pipeline-task-performance.mdx
@@ -54,5 +54,5 @@ By default, alerts are not active. To enable them, go to **Setup → Alert Rules
 
 ## Related
 
-- [Performance Alerts](/cloud/features/performance-monitoring/performance-alerts) — setup guide and API reference for creating `pipeline_task_performance` monitors
+- [Performance Alerts](/cloud/features/performance-monitoring/performance-alerts) — the legacy dbt-test method for performance alerts (Elementary OSS); not required in Cloud, where this monitor is created automatically
 - [Automated monitors overview](/cloud/features/anomaly-detection/automated-monitors) — how automated monitors work across freshness, volume, and performance

--- a/docs/cloud/features/performance-monitoring/performance-alerts.mdx
+++ b/docs/cloud/features/performance-monitoring/performance-alerts.mdx
@@ -6,4 +6,10 @@ badge: "Elementary Cloud"
 
 import PerformanceAlerts from '/snippets/guides/performance-alerts.mdx';
 
+<Note>
+  **In Elementary Cloud, pipeline task performance is monitored natively — no dbt tests required.** Elementary automatically creates a [Cloud pipeline task performance](/cloud/features/anomaly-detection/cloud-pipeline-task-performance) monitor for every model, seed, and snapshot, with anomaly detection or a static SLA. Use that monitor instead of the dbt-test setup below.
+
+  The dbt-test approach on this page still works, but it is the legacy method (and the only option in Elementary OSS). It will not appear as a native performance monitor in Cloud and produces alerts with less context.
+</Note>
+
 <PerformanceAlerts />


### PR DESCRIPTION
Cloud users landing on the performance-alerts page only saw the legacy dbt-test method (elementary.column_anomalies on model_run_results), with no indication that pipeline task performance is now monitored natively in Cloud. This led a customer to set up the deprecated approach.

- Add a callout on the Cloud performance-alerts page directing users to the native Cloud pipeline task performance monitor; mark the dbt-test method as legacy / OSS-only.
- Fix the misleading "Related" link on the cloud-pipeline-task-performance page that described performance-alerts as the monitor's setup guide.

The shared OSS snippet is left intact, since the dbt-test method remains the only option in Elementary OSS.