### PR TITLE
docs: clarify BigQuery project-level permissions for query history and Hex integration

### DIFF
--- a/docs/cloud/integrations/bi/hex.mdx
+++ b/docs/cloud/integrations/bi/hex.mdx
@@ -10,7 +10,7 @@ This will provide you end-to-end data lineage to understand your downstream depe
 
 The Hex integration relies on BigQuery query history to discover which tables Hex projects query. For the integration to work, Elementary's service account must have **read access to `INFORMATION_SCHEMA.JOBS`** in the BigQuery project(s) where Hex executes queries.
 
-This requires the **BigQuery Resource Viewer** role (`roles/bigquery.resourceViewer`) granted at the **project level**. See [BigQuery permissions](/cloud/integrations/dwh/bigquery) for detailed setup instructions.
+This requires the **BigQuery Metadata Viewer** (`roles/bigquery.metadataViewer`) and **BigQuery Resource Viewer** (`roles/bigquery.resourceViewer`) roles granted at the **project level**. See [BigQuery permissions](/cloud/integrations/dwh/bigquery) for detailed setup instructions.
 
 <Note>
 If Elementary cannot read query history, the Hex integration will not discover any exposures. Verify that the service account has the `bigquery.jobs.listAll` permission on the relevant GCP project(s).

--- a/docs/cloud/integrations/bi/hex.mdx
+++ b/docs/cloud/integrations/bi/hex.mdx
@@ -8,12 +8,11 @@ This will provide you end-to-end data lineage to understand your downstream depe
 
 ### Prerequisites
 
-The Hex integration relies on **query history** to discover which tables Hex projects query. Elementary's service account must have permissions to read query history from the data warehouse where Hex executes queries.
+The Hex integration relies on **query history** to discover which tables Hex projects query. It is supported on **BigQuery** and **Snowflake**.
 
-Refer to the permissions section in your warehouse's setup page for the required roles:
+Elementary's service account must have permissions to read query history. Refer to your warehouse's setup page for the required roles:
 - [BigQuery permissions](/cloud/integrations/dwh/bigquery#grant-service-user-access)
 - [Snowflake permissions](/cloud/integrations/dwh/snowflake)
-- [Databricks permissions](/cloud/integrations/dwh/databricks)
 
 <Note>
 If Elementary cannot read query history, the Hex integration will not discover any exposures.
@@ -35,7 +34,7 @@ Choose the Hex connection and provide the following details to validate and comp
 
 ### Hex queries on a different warehouse environment
 
-By default, Elementary reads query history from the warehouse environments (e.g., BigQuery projects, Snowflake accounts, Databricks workspaces) referenced in your dbt project. If Hex executes queries through a **different environment** (e.g., a dedicated Hex execution environment), you will need to:
+By default, Elementary reads query history from the warehouse environments (e.g., BigQuery projects, Snowflake accounts) referenced in your dbt project. If Hex executes queries through a **different environment** (e.g., a dedicated Hex execution environment), you will need to:
 
 1. **Grant query history permissions** — the same permissions required for your primary environment. See the [prerequisites](#prerequisites) above for links to your warehouse's permissions page.
 

--- a/docs/cloud/integrations/bi/hex.mdx
+++ b/docs/cloud/integrations/bi/hex.mdx
@@ -8,12 +8,15 @@ This will provide you end-to-end data lineage to understand your downstream depe
 
 ### Prerequisites
 
-The Hex integration relies on BigQuery query history to discover which tables Hex projects query. For the integration to work, Elementary's service account must have **read access to `INFORMATION_SCHEMA.JOBS`** in the BigQuery project(s) where Hex executes queries.
+The Hex integration relies on **query history** to discover which tables Hex projects query. Elementary's service account must have permissions to read query history from the data warehouse where Hex executes queries.
 
-This requires the **BigQuery Metadata Viewer** (`roles/bigquery.metadataViewer`) and **BigQuery Resource Viewer** (`roles/bigquery.resourceViewer`) roles granted at the **project level**. See [BigQuery permissions](/cloud/integrations/dwh/bigquery) for detailed setup instructions.
+Refer to the permissions section in your warehouse's setup page for the required roles:
+- [BigQuery permissions](/cloud/integrations/dwh/bigquery#grant-service-user-access)
+- [Snowflake permissions](/cloud/integrations/dwh/snowflake)
+- [Databricks permissions](/cloud/integrations/dwh/databricks)
 
 <Note>
-If Elementary cannot read query history, the Hex integration will not discover any exposures. Verify that the service account has the `bigquery.jobs.listAll` permission on the relevant GCP project(s).
+If Elementary cannot read query history, the Hex integration will not discover any exposures.
 </Note>
 
 ### Create API Token
@@ -30,15 +33,15 @@ Choose the Hex connection and provide the following details to validate and comp
 - **Base URL**: Your Hex workspace URL. For example: `https://app.hex.tech/my-workspace/`
 - **Workspace Token**: The Hex workspace token you've created on the previous step.
 
-### Using a different BigQuery project for Hex queries
+### Hex queries on a different warehouse project
 
-By default, Elementary reads query history from the BigQuery project(s) referenced in your dbt project. If Hex executes queries through a **different GCP project** (e.g., a dedicated Hex execution project), you will need to:
+By default, Elementary reads query history from the warehouse projects and databases referenced in your dbt project. If Hex executes queries through a **different project or database** (e.g., a dedicated Hex execution project), you will need to:
 
-1. **Grant permissions on that project** — assign the **BigQuery Resource Viewer** and **BigQuery Metadata Viewer** roles to the Elementary service account at the project level for the Hex execution project (same as for your primary project).
+1. **Grant query history permissions on that project** — the same permissions required for your primary project. See the [prerequisites](#prerequisites) above for links to your warehouse's permissions page.
 
-2. **Let us know** — contact Elementary support with the GCP project name so we can configure your environment to also read query history from that project.
+2. **Let us know** — contact Elementary support with the project or database name so we can configure your environment to also read query history from it.
 
-Without both steps, Elementary will not find any Hex queries in that project's `INFORMATION_SCHEMA.JOBS`, and no Hex exposures will appear.
+Without both steps, Elementary will not find any Hex queries in that project and no Hex exposures will appear.
 
 ### Limitations
 

--- a/docs/cloud/integrations/bi/hex.mdx
+++ b/docs/cloud/integrations/bi/hex.mdx
@@ -33,15 +33,15 @@ Choose the Hex connection and provide the following details to validate and comp
 - **Base URL**: Your Hex workspace URL. For example: `https://app.hex.tech/my-workspace/`
 - **Workspace Token**: The Hex workspace token you've created on the previous step.
 
-### Hex queries on a different warehouse project
+### Hex queries on a different warehouse environment
 
-By default, Elementary reads query history from the warehouse projects and databases referenced in your dbt project. If Hex executes queries through a **different project or database** (e.g., a dedicated Hex execution project), you will need to:
+By default, Elementary reads query history from the warehouse environments (e.g., BigQuery projects, Snowflake accounts, Databricks workspaces) referenced in your dbt project. If Hex executes queries through a **different environment** (e.g., a dedicated Hex execution environment), you will need to:
 
-1. **Grant query history permissions on that project** — the same permissions required for your primary project. See the [prerequisites](#prerequisites) above for links to your warehouse's permissions page.
+1. **Grant query history permissions** — the same permissions required for your primary environment. See the [prerequisites](#prerequisites) above for links to your warehouse's permissions page.
 
-2. **Let us know** — contact Elementary support with the project or database name so we can configure your environment to also read query history from it.
+2. **Let us know** — contact Elementary support with the environment details so we can configure Elementary to also read query history from it.
 
-Without both steps, Elementary will not find any Hex queries in that project and no Hex exposures will appear.
+Without both steps, Elementary will not find any Hex queries in that environment and no Hex exposures will appear.
 
 ### Limitations
 

--- a/docs/cloud/integrations/bi/hex.mdx
+++ b/docs/cloud/integrations/bi/hex.mdx
@@ -6,6 +6,16 @@ badge: "Context Engine"
 After you connect Hex, Elementary will automatically and continuously extend the lineage to the project & cell level.
 This will provide you end-to-end data lineage to understand your downstream dependencies, called exposures.
 
+### Prerequisites
+
+The Hex integration relies on BigQuery query history to discover which tables Hex projects query. For the integration to work, Elementary's service account must have **read access to `INFORMATION_SCHEMA.JOBS`** in the BigQuery project(s) where Hex executes queries.
+
+This requires the **BigQuery Resource Viewer** role (`roles/bigquery.resourceViewer`) granted at the **project level**. See [BigQuery permissions](/cloud/integrations/dwh/bigquery) for detailed setup instructions.
+
+<Note>
+If Elementary cannot read query history, the Hex integration will not discover any exposures. Verify that the service account has the `bigquery.jobs.listAll` permission on the relevant GCP project(s).
+</Note>
+
 ### Create API Token
 
 Elementary needs a workspace token in your account in order to access Hex's API on your behalf. <br/>
@@ -20,6 +30,15 @@ Choose the Hex connection and provide the following details to validate and comp
 - **Base URL**: Your Hex workspace URL. For example: `https://app.hex.tech/my-workspace/`
 - **Workspace Token**: The Hex workspace token you've created on the previous step.
 
+### Using a different BigQuery project for Hex queries
+
+By default, Elementary reads query history from the BigQuery project(s) referenced in your dbt project. If Hex executes queries through a **different GCP project** (e.g., a dedicated Hex execution project), you will need to:
+
+1. **Grant permissions on that project** — assign the **BigQuery Resource Viewer** and **BigQuery Metadata Viewer** roles to the Elementary service account at the project level for the Hex execution project (same as for your primary project).
+
+2. **Let us know** — contact Elementary support with the GCP project name so we can configure your environment to also read query history from that project.
+
+Without both steps, Elementary will not find any Hex queries in that project's `INFORMATION_SCHEMA.JOBS`, and no Hex exposures will appear.
 
 ### Limitations
 

--- a/docs/snippets/cloud/integrations/bigquery.mdx
+++ b/docs/snippets/cloud/integrations/bigquery.mdx
@@ -25,6 +25,10 @@ Select a tab below and follow the steps for your chosen method.
 
 <PermissionsAndSecurity />
 
+For BigQuery, this translates to:
+- **BigQuery Data Viewer** on the Elementary dataset (for reading Elementary schema data).
+- **BigQuery Metadata Viewer** and **BigQuery Resource Viewer** at the **project level** (for reading `INFORMATION_SCHEMA.JOBS` query history and table metadata). These project-level roles are required for BI integrations like Hex that rely on query history.
+
 ### Fill the connection form
 
 Use the **Authentication method** toggle at the top of the form to select either **Service account** or **Workload Identity Federation**, matching the method you set up above. The credentials upload field changes based on your selection:

--- a/docs/snippets/cloud/integrations/permissions-and-security.mdx
+++ b/docs/snippets/cloud/integrations/permissions-and-security.mdx
@@ -1,9 +1,13 @@
 #### Permissions and security
 
-Elementary cloud doesn't require read permissions to your tables and schemas, but only the following:
+Elementary Cloud doesn't require read permissions to your tables and schemas, but only the following:
 
-- Read-only access to the elementary schema.
-- Access to read metadata in information schema and query history, related to the tables in your dbt project.
+- Read-only access to the Elementary schema.
+- Access to read metadata in `INFORMATION_SCHEMA` (table metadata and query history), related to the tables in your dbt project.
+
+For BigQuery, this translates to:
+- **BigQuery Data Viewer** on the Elementary dataset (for reading Elementary schema data).
+- **BigQuery Metadata Viewer** and **BigQuery Resource Viewer** at the **project level** (for reading `INFORMATION_SCHEMA.JOBS` query history and table metadata). These project-level roles are required for BI integrations like Hex that rely on query history.
 
 It is recommended to create a user using the instructions specified above to avoid granting excess privileges.
 For more details, refer to [security and privacy](/cloud/general/security-and-privacy).

--- a/docs/snippets/cloud/integrations/permissions-and-security.mdx
+++ b/docs/snippets/cloud/integrations/permissions-and-security.mdx
@@ -5,9 +5,5 @@ Elementary Cloud doesn't require read permissions to your tables and schemas, bu
 - Read-only access to the Elementary schema.
 - Access to read metadata in `INFORMATION_SCHEMA` (table metadata and query history), related to the tables in your dbt project.
 
-For BigQuery, this translates to:
-- **BigQuery Data Viewer** on the Elementary dataset (for reading Elementary schema data).
-- **BigQuery Metadata Viewer** and **BigQuery Resource Viewer** at the **project level** (for reading `INFORMATION_SCHEMA.JOBS` query history and table metadata). These project-level roles are required for BI integrations like Hex that rely on query history.
-
 It is recommended to create a user using the instructions specified above to avoid granting excess privileges.
 For more details, refer to [security and privacy](/cloud/general/security-and-privacy).

--- a/docs/snippets/dwh/bigquery/grant_user_access_on_dataset_level.mdx
+++ b/docs/snippets/dwh/bigquery/grant_user_access_on_dataset_level.mdx
@@ -1,15 +1,39 @@
-### Grant service user access to specific datasets
+### Grant service user access
 
-In order for a service user to work with Elementary cloud, it requires the following permissions:
+In order for a service user to work with Elementary Cloud, it requires the following permissions:
 
-- Role "BigQuery Data Viewer" on your Elementary dataset.
-- Roles "BigQuery Metadata Viewer", "BigQuery Resource Viewer" on the entire project and any external sources it is referencing.
+- Role **"BigQuery Data Viewer"** on your Elementary dataset.
+- Roles **"BigQuery Metadata Viewer"** and **"BigQuery Resource Viewer"** at the **project level** for the project containing your dbt models and any external projects it references.
 
-To grant a role on a specific dataset, follow these steps:
+<Note>
+"BigQuery Metadata Viewer" and "BigQuery Resource Viewer" **must be granted at the project level** (via IAM & Admin), not at the dataset level. These roles include permissions such as `bigquery.jobs.listAll` which are required for reading query history and metadata from `INFORMATION_SCHEMA` — they cannot be granted on individual datasets.
+</Note>
 
-1. Go to your project in [BigQuery console](https://console.cloud.google.com/bigquery)
+#### Step 1: Grant project-level roles
 
-2. In the "Explorer" tab, find your desired dataset.
+These roles are required for Elementary to read query history (`INFORMATION_SCHEMA.JOBS`) and table metadata. Without them, BI integrations (such as Hex) that rely on query history will not function.
+
+1. Go to [IAM & Admin](https://console.cloud.google.com/iam-admin/iam) in the Google Cloud Console.
+
+2. Select the project that contains your dbt models.
+
+3. Click **"Grant Access"** at the top.
+
+4. Fill out the form:
+   - In the "New principals" field, enter the **email address** of the Elementary service account.
+   - Add the role **"BigQuery Metadata Viewer"** (`roles/bigquery.metadataViewer`).
+   - Click **"Add another role"** and add **"BigQuery Resource Viewer"** (`roles/bigquery.resourceViewer`).
+   - Click **"Save"**.
+
+5. **Repeat for any additional GCP projects** referenced in your dbt sources or used by BI tools (e.g., Hex, Looker) for query execution.
+
+#### Step 2: Grant dataset-level role on the Elementary dataset
+
+This role provides read access to your Elementary schema data.
+
+1. Go to your project in [BigQuery console](https://console.cloud.google.com/bigquery).
+
+2. In the "Explorer" tab, find your Elementary dataset.
 
 3. Click on the three dots icon next to the dataset name, then Share.
 
@@ -26,13 +50,11 @@ To grant a role on a specific dataset, follow these steps:
 />
 
 5. Fill out the form:
-   - In the "New principals" textbox, write the **email address** of your user.
-   - In the "Select a role" dropdown menu, choose the desired role (BigQuery Data Viewer for your Elementary dataset, BigQuery Metadata Viewer, BigQuery Resource Viewer for your dbt dataset).
+   - In the "New principals" textbox, write the **email address** of your service account.
+   - In the "Select a role" dropdown menu, choose **"BigQuery Data Viewer"**.
    - Click "Save".
 
 <img
   src="https://res.cloudinary.com/diuctyblm/image/upload/f_auto,q_auto/v1/dwh/bigquery/grant_access_form"
   alt="Grant access"
 />
-
-Make sure to grant the correct access to your Elementary dataset **and** your dbt dataset.


### PR DESCRIPTION
## Summary

Fixes documentation gaps that caused customers to miss granting project-level IAM roles needed for query history access (specifically `bigquery.jobs.listAll`), which in turn breaks BI integrations like Hex.

**Problem:** The existing grant instructions showed the dataset-level sharing UI (three-dots → Share on a dataset) but BigQuery Resource Viewer and Metadata Viewer must be granted at the **project level** via IAM & Admin. Customers following the docs literally would miss these project-level roles, resulting in `INFORMATION_SCHEMA.JOBS` access errors and broken Hex integration.

**Changes:**

1. **`grant_user_access_on_dataset_level.mdx`** — restructured into two clear steps:
   - Step 1: Project-level IAM grant (Resource Viewer + Metadata Viewer) via IAM & Admin console, with a `<Note>` explaining why project-level is required
   - Step 2: Dataset-level grant (Data Viewer on Elementary dataset) using the existing dataset sharing UI

2. **`permissions-and-security.mdx`** — kept warehouse-agnostic (shared across all DWH pages); BigQuery-specific role details moved to the BigQuery-only page.

3. **`bigquery.mdx`** — added BigQuery-specific role breakdown (Data Viewer, Metadata Viewer, Resource Viewer) directly after the shared permissions snippet, so it only renders on the BigQuery setup page.

4. **`hex.mdx`** — added (DWH-agnostic):
   - Prerequisites section explaining query history dependency with links to BigQuery, Snowflake, and Databricks permissions pages
   - "Hex queries on a different warehouse project" section for multi-project setups

## Screenshots

### BigQuery page — Grant service user access (new structure with Note callout)
![BigQuery grant access section](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfWWdwTDBnNHNQY3RndkUwMyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19ZZ3BMMGc0c1BjdGd2RTAzLzg5Mjk1Mzk4LThkNTgtNGI2OS1hMDg2LWZiN2EwM2U2MmVmMCIsImlhdCI6MTc4Mjc2Mzc2NSwiZXhwIjoxNzgzMzY4NTY1LCJmaWxlbmFtZSI6ImJpZ3F1ZXJ5LWdyYW50LWFjY2Vzcy5wbmcifQ.3RaopRDJbbpDaOBM3NeM-HA93uNuXvAHMk5eOHf3HJ4)

### BigQuery page — Step 1 (project-level) and Step 2 (dataset-level) instructions
![BigQuery Step 1 and Step 2](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfWWdwTDBnNHNQY3RndkUwMyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19ZZ3BMMGc0c1BjdGd2RTAzLzA0MzAyNmNmLWIzOTAtNGRkYy1hZGZmLTlkZDIyZWExYWY0NCIsImlhdCI6MTc4Mjc2Mzc2NiwiZXhwIjoxNzgzMzY4NTY2LCJmaWxlbmFtZSI6ImJpZ3F1ZXJ5LXN0ZXAxLXN0ZXAyLnBuZyJ9.5CW7sgy8gjqceHwszcVr1z6w1yiUT4S50d9CAaUfkuw)

### BigQuery page — Permissions and security section with BigQuery-specific roles
![BigQuery permissions and security](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfWWdwTDBnNHNQY3RndkUwMyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19ZZ3BMMGc0c1BjdGd2RTAzL2Q3YTgzYjBjLTJkOTgtNDI0ZS04YzI3LTk1ZDgzM2QyMGY5NyIsImlhdCI6MTc4Mjc2Mzc2NiwiZXhwIjoxNzgzMzY4NTY2LCJmaWxlbmFtZSI6ImJpZ3F1ZXJ5LXBlcm1pc3Npb25zLXNlY3VyaXR5LnBuZyJ9.mIBN_vXKWLQ-8gxdgKRo3opj5jegec1tMPZ_QwS9Pqk)

### Hex page — DWH-agnostic prerequisites with links to warehouse permissions
![Hex page top](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfWWdwTDBnNHNQY3RndkUwMyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19ZZ3BMMGc0c1BjdGd2RTAzLzAzY2EwMWZjLWQ1YTMtNDlkNS05OGViLTRhMWU5ODY4NjE0YiIsImlhdCI6MTc4Mjc2Mzc2NiwiZXhwIjoxNzgzMzY4NTY2LCJmaWxlbmFtZSI6ImhleC1wYWdlLXYyLXRvcC5wbmcifQ.e03wDMRLzBkCzjUPWG1lMkiAlX06Vpb3KTcbOXMfXAU)

### Hex page — "Hex queries on a different warehouse project" section
![Hex page bottom](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfWWdwTDBnNHNQY3RndkUwMyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19ZZ3BMMGc0c1BjdGd2RTAzLzU0MGNkNWExLWMxNzAtNGZlNy04YWZlLTQ0MjkzNzE0OGQxZCIsImlhdCI6MTc4Mjc2Mzc2NiwiZXhwIjoxNzgzMzY4NTY2LCJmaWxlbmFtZSI6ImhleC1wYWdlLXYyLWJvdHRvbS5wbmcifQ.GBivTwzJYg_kQgoB0HE3IVw5s9OjiVgNAetysZKVPZE)

Link to Devin session: https://app.devin.ai/sessions/0da02a44dd534e4a909ae504d8eb6a19
Requested by: @arbiv
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/elementary-data/elementary/pull/2285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->