### PR TITLE
docs: correct pipeline task performance monitor creation and anomaly settings

### DIFF
--- a/docs/cloud/features/anomaly-detection/cloud-pipeline-task-performance.mdx
+++ b/docs/cloud/features/anomaly-detection/cloud-pipeline-task-performance.mdx
@@ -8,7 +8,7 @@ badge: "Elementary Cloud"
 
 The pipeline task performance monitor tracks the **execution duration** of dbt models, seeds, and snapshots on each run, and alerts when a node takes significantly longer than expected — or exceeds a fixed SLA threshold.
 
-You create this monitor manually from the UI for the dbt models, seeds, and snapshots you want to track.
+You create this monitor manually from the UI for the dbt models you want to track.
 
 <Note>
   **Coming soon:** automated creation of pipeline task performance monitors on models, seeds, and snapshots.
@@ -22,18 +22,18 @@ Elementary uses a z-score seasonal model to learn normal execution duration for 
 
 Elementary builds the baseline from your pipeline run history.
 
-### Threshold
+### Static SLA
 
 Set a fixed duration threshold. The monitor fails whenever the observed execution time exceeds that threshold, regardless of historical norms.
 
-Use threshold mode when you have a hard operational or contractual limit (e.g., "this model must finish within 10 minutes").
+Use static SLA when you have a hard operational or contractual limit (e.g., "this model must finish within 10 minutes").
 
 ## Understand the monitor result
 
 The result shows the execution duration of the dbt node for the latest run alongside the historical baseline.
 
 - **Anomaly detection** — data points outside the expected range (grey band) are flagged. The expected range is derived from the seasonal model trained on historical durations.
-- **Threshold** — a horizontal line marks the threshold. Any run that crosses it is a failure.
+- **Static SLA** — a horizontal line marks the threshold. Any run that crosses it is a failure.
 
 Use the **Anomaly settings** button to adjust mode, sensitivity, or training period after the monitor is created.
 
@@ -46,7 +46,7 @@ Use the **Anomaly settings** button to adjust mode, sensitivity, or training per
 | `training_period` | Days of history used to train the model (anomaly mode only) | `23` |
 | `anomaly_direction` | `"spike"` (duration longer than expected), `"drop"`, or `"both"` (anomaly mode only) | `"spike"` |
 | `excluded_time_ranges` | Time ranges excluded from training and detection (anomaly mode only) | `[]` |
-| `fixed_threshold` | Max allowed execution duration in seconds (threshold mode only) | — |
+| `fixed_threshold` | Max allowed execution duration in seconds (static SLA mode only) | — |
 
 <Snippet file="cloud/features/anomaly-detection/all-anomalies-configuration.mdx" />
 

--- a/docs/cloud/features/anomaly-detection/cloud-pipeline-task-performance.mdx
+++ b/docs/cloud/features/anomaly-detection/cloud-pipeline-task-performance.mdx
@@ -22,18 +22,18 @@ Elementary uses a z-score seasonal model to learn normal execution duration for 
 
 Elementary builds the baseline from your pipeline run history.
 
-### Static SLA
+### Threshold
 
 Set a fixed duration threshold. The monitor fails whenever the observed execution time exceeds that threshold, regardless of historical norms.
 
-Use static SLA when you have a hard operational or contractual limit (e.g., "this model must finish within 10 minutes").
+Use threshold mode when you have a hard operational or contractual limit (e.g., "this model must finish within 10 minutes").
 
 ## Understand the monitor result
 
 The result shows the execution duration of the dbt node for the latest run alongside the historical baseline.
 
 - **Anomaly detection** — data points outside the expected range (grey band) are flagged. The expected range is derived from the seasonal model trained on historical durations.
-- **Static SLA** — a horizontal line marks the threshold. Any run that crosses it is a failure.
+- **Threshold** — a horizontal line marks the threshold. Any run that crosses it is a failure.
 
 Use the **Anomaly settings** button to adjust mode, sensitivity, or training period after the monitor is created.
 
@@ -46,7 +46,7 @@ Use the **Anomaly settings** button to adjust mode, sensitivity, or training per
 | `training_period` | Days of history used to train the model (anomaly mode only) | `23` |
 | `anomaly_direction` | `"spike"` (duration longer than expected), `"drop"`, or `"both"` (anomaly mode only) | `"spike"` |
 | `excluded_time_ranges` | Time ranges excluded from training and detection (anomaly mode only) | `[]` |
-| `fixed_threshold` | Max allowed execution duration in seconds (static SLA mode only) | — |
+| `fixed_threshold` | Max allowed execution duration in seconds (threshold mode only) | — |
 
 <Snippet file="cloud/features/anomaly-detection/all-anomalies-configuration.mdx" />
 

--- a/docs/cloud/features/anomaly-detection/cloud-pipeline-task-performance.mdx
+++ b/docs/cloud/features/anomaly-detection/cloud-pipeline-task-performance.mdx
@@ -8,7 +8,11 @@ badge: "Elementary Cloud"
 
 The pipeline task performance monitor tracks the **execution duration** of dbt models, seeds, and snapshots on each run, and alerts when a node takes significantly longer than expected — or exceeds a fixed SLA threshold.
 
-This is an automated monitor: Elementary creates it for every dbt node in your project, with no configuration required to get started.
+You create this monitor manually from the UI for the dbt models, seeds, and snapshots you want to track.
+
+<Note>
+  **Coming soon:** automated creation of pipeline task performance monitors on models, seeds, and snapshots.
+</Note>
 
 ## Monitoring modes
 
@@ -16,7 +20,7 @@ This is an automated monitor: Elementary creates it for every dbt node in your p
 
 Elementary uses a z-score seasonal model to learn normal execution duration for each node. The model accounts for time-of-day and day-of-week patterns, so a model that reliably runs longer on Monday mornings will not be flagged during that window.
 
-No configuration is required. Elementary builds the baseline from your pipeline run history automatically.
+Elementary builds the baseline from your pipeline run history.
 
 ### Static SLA
 
@@ -37,9 +41,9 @@ Use the **Anomaly settings** button to adjust mode, sensitivity, or training per
 
 | Setting | Description | Default |
 |---|---|---|
-| `mode` | `"anomaly"` or `"static"` | `"anomaly"` |
+| `mode` | `"anomaly"` or `"threshold"` | `"anomaly"` |
 | `sensitivity` | `"low"`, `"medium"`, or `"high"` (anomaly mode only) | `"medium"` |
-| `training_period` | Days of history used to train the model (anomaly mode only) | `14` |
+| `training_period` | Days of history used to train the model (anomaly mode only) | `23` |
 | `anomaly_direction` | `"spike"` (duration longer than expected), `"drop"`, or `"both"` (anomaly mode only) | `"spike"` |
 | `excluded_time_ranges` | Time ranges excluded from training and detection (anomaly mode only) | `[]` |
 | `fixed_threshold` | Max allowed execution duration in seconds (static SLA mode only) | — |
@@ -54,5 +58,5 @@ By default, alerts are not active. To enable them, go to **Setup → Alert Rules
 
 ## Related
 
-- [Performance Alerts](/cloud/features/performance-monitoring/performance-alerts) — the legacy dbt-test method for performance alerts (Elementary OSS); not required in Cloud, where this monitor is created automatically
+- [Performance Alerts](/cloud/features/performance-monitoring/performance-alerts) — the legacy dbt-test method for performance alerts (Elementary OSS); replaced in Cloud by this monitor
 - [Automated monitors overview](/cloud/features/anomaly-detection/automated-monitors) — how automated monitors work across freshness, volume, and performance


### PR DESCRIPTION
## Summary

Corrects inaccuracies on the **Cloud Pipeline Task Performance** page (`docs/cloud/features/anomaly-detection/cloud-pipeline-task-performance.mdx`).

The page wrongly claimed the monitor is created automatically for every dbt node. In reality users create it manually from the UI. Changes:

- Replaced "This is an automated monitor: Elementary creates it for every dbt node..." → "You create this monitor manually from the UI for the dbt models, seeds, and snapshots you want to track."
- Added a **Coming soon** `<Note>`: automated creation of these monitors on models, seeds, and snapshots is coming soon.
- Dropped the inaccurate "No configuration is required." line from the anomaly-detection section (kept the baseline-from-history sentence).
- Anomaly settings table: `mode` description now `"anomaly"` or `"threshold"` (was `"static"`); `training_period` default now `23` (was `14`).
- Related section: reworded the performance-alerts note that also implied automatic creation ("created automatically" → "replaced in Cloud by this monitor") to stay consistent.


Link to Devin session: https://app.devin.ai/sessions/8cb052d303a54e19b607ce1ce5f09534
Requested by: @NoyaArie
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/elementary-data/elementary/pull/2289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->