### PR TITLE
Pin PyAthena <3.35 for Athena CI

### DIFF
--- a/.github/workflows/cleanup-stale-schemas.yml
+++ b/.github/workflows/cleanup-stale-schemas.yml
@@ -42,6 +42,14 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: eu-west-1
 
+      - name: Checkout Elementary constraints
+        if: matrix.warehouse-type == 'athena'
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            tests/ci/athena-constraints.txt
+          sparse-checkout-cone-mode: false
+
       - name: Checkout dbt package
         uses: actions/checkout@v6
         with:
@@ -58,14 +66,13 @@ jobs:
           cache: "pip"
 
       - name: Install dbt
-        run: >
-          pip install
-          "dbt-core"
-          "dbt-${{ (matrix.warehouse-type == 'databricks_catalog' && 'databricks') || (matrix.warehouse-type == 'athena' && 'athena-community') || matrix.warehouse-type }}"
-
-      - name: Pin PyAthena for dbt-athena compatibility
-        if: matrix.warehouse-type == 'athena'
-        run: pip install "pyathena>=2.25,<3.35"
+        run: |
+          CONSTRAINTS_ARGS=()
+          if [ "${{ matrix.warehouse-type }}" = "athena" ]; then
+            CONSTRAINTS_ARGS=(-c "${{ github.workspace }}/tests/ci/athena-constraints.txt")
+          fi
+          pip install "${CONSTRAINTS_ARGS[@]}" dbt-core \
+            "dbt-${{ (matrix.warehouse-type == 'databricks_catalog' && 'databricks') || (matrix.warehouse-type == 'athena' && 'athena-community') || matrix.warehouse-type }}"
 
       - name: Write dbt profiles
         env:

--- a/.github/workflows/cleanup-stale-schemas.yml
+++ b/.github/workflows/cleanup-stale-schemas.yml
@@ -63,6 +63,10 @@ jobs:
           "dbt-core"
           "dbt-${{ (matrix.warehouse-type == 'databricks_catalog' && 'databricks') || (matrix.warehouse-type == 'athena' && 'athena-community') || matrix.warehouse-type }}"
 
+      - name: Pin PyAthena for dbt-athena compatibility
+        if: matrix.warehouse-type == 'athena'
+        run: pip install "pyathena>=2.25,<3.35"
+
       - name: Write dbt profiles
         env:
           CI_WAREHOUSE_SECRETS: ${{ secrets.CI_WAREHOUSE_SECRETS || '' }}

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -247,7 +247,12 @@ jobs:
             DBT_ADAPTER_VERSION_SPEC="~=$DBT_VERSION"
           fi
 
-          pip install "$DBT_CORE_SPEC" "dbt-${DBT_ADAPTER}${DBT_ADAPTER_EXTRA}${DBT_ADAPTER_VERSION_SPEC}"
+          CONSTRAINTS_ARGS=()
+          if [ "$WAREHOUSE_TYPE" = "athena" ]; then
+            CONSTRAINTS_ARGS=(-c tests/ci/athena-constraints.txt)
+          fi
+
+          pip install "${CONSTRAINTS_ARGS[@]}" "$DBT_CORE_SPEC" "dbt-${DBT_ADAPTER}${DBT_ADAPTER_EXTRA}${DBT_ADAPTER_VERSION_SPEC}"
 
       # dbt-vertica pins dbt-core~=1.8 which lacks the 'arguments' attribute
       # used by newer dbt-core.  Install dbt-vertica without deps first, then
@@ -279,14 +284,6 @@ jobs:
             fi
             pip install ".[$EXTRA]"
           fi
-
-      - name: Pin PyAthena for dbt-athena compatibility
-        if: inputs.warehouse-type == 'athena'
-        run: |
-          # dbt-athena 1.10.x calls PyAthena's internal _execute(work_group=...) API,
-          # removed in PyAthena 3.35. Unpin once dbt-athena ships the boto3 connection
-          # manager (dbt-labs/dbt-adapters#1637).
-          pip install "pyathena>=2.25,<3.35"
 
       - name: Write dbt profiles
         env:

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -247,12 +247,7 @@ jobs:
             DBT_ADAPTER_VERSION_SPEC="~=$DBT_VERSION"
           fi
 
-          CONSTRAINTS_ARGS=()
-          if [ "$WAREHOUSE_TYPE" = "athena" ]; then
-            CONSTRAINTS_ARGS=(-c tests/ci/athena-constraints.txt)
-          fi
-
-          pip install "${CONSTRAINTS_ARGS[@]}" "$DBT_CORE_SPEC" "dbt-${DBT_ADAPTER}${DBT_ADAPTER_EXTRA}${DBT_ADAPTER_VERSION_SPEC}"
+          pip install "$DBT_CORE_SPEC" "dbt-${DBT_ADAPTER}${DBT_ADAPTER_EXTRA}${DBT_ADAPTER_VERSION_SPEC}"
 
       # dbt-vertica pins dbt-core~=1.8 which lacks the 'arguments' attribute
       # used by newer dbt-core.  Install dbt-vertica without deps first, then

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -280,6 +280,14 @@ jobs:
             pip install ".[$EXTRA]"
           fi
 
+      - name: Pin PyAthena for dbt-athena compatibility
+        if: inputs.warehouse-type == 'athena'
+        run: |
+          # dbt-athena 1.10.x calls PyAthena's internal _execute(work_group=...) API,
+          # removed in PyAthena 3.35. Unpin once dbt-athena ships the boto3 connection
+          # manager (dbt-labs/dbt-adapters#1637).
+          pip install "pyathena>=2.25,<3.35"
+
       - name: Write dbt profiles
         env:
           CI_WAREHOUSE_SECRETS: ${{ secrets.CI_WAREHOUSE_SECRETS || '' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ dbt-postgres = {version = ">=1.8,<2.0.0", optional = true}
 dbt-databricks = {version = ">=1.8,<2.0.0", optional = true}
 dbt-spark = {version = ">=1.8,<2.0.0", optional = true}
 dbt-athena-community = {version = ">=1.8,<2.0.0", optional = true}
+# dbt-athena 1.10.x is incompatible with PyAthena 3.35+; remove when dbt-athena ships boto3 connection manager.
+pyathena = {version = ">=2.25,<3.35", optional = true}
 dbt-trino = {version = ">=1.8,<2.0.0", optional = true}
 dbt-clickhouse = {version = ">=1.8,<2.0.0", optional = true}
 dbt-duckdb = {version = ">=1.8,<2.0.0", optional = true}
@@ -69,7 +71,7 @@ redshift = ["dbt-redshift"]
 postgres = ["dbt-postgres"]
 databricks = ["dbt-databricks"]
 spark = ["dbt-spark"]
-athena = ["dbt-athena-community"]
+athena = ["dbt-athena-community", "pyathena"]
 clickhouse = ["dbt-clickhouse"]
 trino = ["dbt-trino"]
 duckdb = ["dbt-duckdb"]
@@ -80,7 +82,7 @@ sqlserver = ["dbt-sqlserver"]
 # outdated transitive dependencies (dbt-core==1.8.5, azure-cli pre-release) that block
 # security patches for deepdiff, protobuf, and pyopenssl. Users who need these adapters
 # can still install them directly (e.g. pip install dbt-fabricspark dbt-vertica).
-all = ["dbt-snowflake", "dbt-bigquery", "dbt-redshift", "dbt-postgres", "dbt-databricks", "dbt-spark", "dbt-athena-community", "dbt-trino", "dbt-clickhouse", "dbt-duckdb", "dbt-dremio", "dbt-fabric", "dbt-sqlserver"]
+all = ["dbt-snowflake", "dbt-bigquery", "dbt-redshift", "dbt-postgres", "dbt-databricks", "dbt-spark", "dbt-athena-community", "pyathena", "dbt-trino", "dbt-clickhouse", "dbt-duckdb", "dbt-dremio", "dbt-fabric", "dbt-sqlserver"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/ci/athena-constraints.txt
+++ b/tests/ci/athena-constraints.txt
@@ -1,0 +1,3 @@
+# Temporary pin: dbt-athena 1.10.x breaks on PyAthena 3.35+ (ExecuteOptions refactor).
+# Remove when dbt-athena ships the boto3 connection manager (dbt-labs/dbt-adapters#1637).
+pyathena>=2.25,<3.35


### PR DESCRIPTION
## Summary
- Pin `pyathena>=2.25,<3.35` in `pyproject.toml` as part of the `athena` extra (and `all`)
- Add shared `tests/ci/athena-constraints.txt` for workflows that install dbt without Elementary
- Use pip constraints in `test-warehouse.yml` and `cleanup-stale-schemas.yml` instead of ad-hoc `pip install pyathena...` steps

## Context
PyAthena 3.35.0 refactored internal `_execute()` to use `ExecuteOptions`, breaking dbt-athena 1.10.2 (`work_group` kwarg error). This is an interim pin until dbt-athena ships the boto3 connection manager ([dbt-labs/dbt-adapters#1637](https://github.com/dbt-labs/dbt-adapters/pull/1637)).

## Test plan
- [ ] Athena warehouse CI job passes on this PR
- [ ] Cherry-pick to `release/v0.25.1` to unblock the release run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability for Athena-based jobs by using an Athena-compatible Python package version for the required driver.
  * Reduced workflow failures during schema cleanup and warehouse testing by applying Athena-specific installation constraints.
  * Updated Athena dependency handling to include the required package version range and ensure “all”/“athena” extras install correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->