### PR TITLE
fix(alerts): route test alert deep links to the cold-load-safe test-results route (#2283)

### DIFF
--- a/elementary/monitor/data_monitoring/alerts/integrations/utils/report_link.py
+++ b/elementary/monitor/data_monitoring/alerts/integrations/utils/report_link.py
@@ -15,7 +15,8 @@ class ReportLinkData(BaseModel):
 
 
 class ReportPath(Enum):
-    TEST_RUNS = "test-runs"
+    # test-runs/<id> cold-loads to the parent list, not the test (see #2283)
+    TEST_RUNS = "test-results"
     MODEL_RUNS = "model-runs"
 
 

--- a/tests/unit/alerts/test_report_link.py
+++ b/tests/unit/alerts/test_report_link.py
@@ -1,0 +1,44 @@
+from elementary.monitor.data_monitoring.alerts.integrations.utils.report_link import (
+    ReportPath,
+    get_model_runs_link,
+    get_model_test_runs_link,
+    get_test_runs_link,
+)
+
+REPORT_URL = "https://elementary.example.com/#"
+TEST_UNIQUE_ID = "test.my_project.my_test.abc123.row_count"
+MODEL_UNIQUE_ID = "model.my_project.my_model"
+
+
+def test_get_test_runs_link_routes_to_test_results():
+    # Regression for #2283: the test-runs/<id> detail route redirects to the
+    # parent list on a cold page load, so test alert deep links must target the
+    # cold-load-safe test-results/<id> route instead.
+    link = get_test_runs_link(REPORT_URL, TEST_UNIQUE_ID)
+
+    assert link is not None
+    assert link.url == f"{REPORT_URL}/report/test-results/{TEST_UNIQUE_ID}/"
+    assert "/report/test-runs/" not in link.url
+    # Only the URL changes — the button label is unaffected.
+    assert link.text == "View test runs"
+
+
+def test_get_test_runs_link_returns_none_without_url_or_id():
+    assert get_test_runs_link(None, TEST_UNIQUE_ID) is None
+    assert get_test_runs_link(REPORT_URL, None) is None
+
+
+def test_get_model_runs_link_unchanged():
+    link = get_model_runs_link(REPORT_URL, MODEL_UNIQUE_ID)
+
+    assert link is not None
+    assert link.url == f"{REPORT_URL}/report/model-runs/{MODEL_UNIQUE_ID}/"
+    assert link.text == "View model runs"
+
+
+def test_get_model_test_runs_link_routes_to_test_results():
+    link = get_model_test_runs_link(REPORT_URL, MODEL_UNIQUE_ID)
+
+    assert link is not None
+    assert link.url.startswith(f"{REPORT_URL}/report/test-results/?treeNode=")
+    assert ReportPath.TEST_RUNS.value == "test-results"


### PR DESCRIPTION
Fixes the broken cold-load behaviour reported in #2283.

## Problem

Test alert deep links (`edr monitor --report-url ...`) point at `#/report/test-runs/<id>`. Opening one from a Slack alert is always a **cold page load** (fresh tab), and on a cold load the detail route's redirect guard fires while report data is still fetching (empty array) and navigates to the parent Test Performance list — so the alert never opens the specific failing test. Pasting the same URL into an already-open report tab works, which is why it only reproduces from alerts. Affects 0.23.1 → current `master`.

## Change

Reroute test alert deep links to `#/report/test-results/<id>`, which does not hit the guard and cold-loads to the correct test (it also surfaces that test's run history). One-line change in `report_link.py`.

## Caveat (maintainers' call)

This is a **link-layer fix for the symptom**. The underlying bug is the redirect guard in the report UI; fixing it directly (e.g. gating the redirect `useEffect` on `isFetching`, or falling back to embedded report data during fetch) would let `test-runs/<id>` keep working, and might be your preferred fix. I don't have access to the report UI source (this repo ships the compiled `index.html`), so this is the fix I can offer from the public repo. Happy to adjust — e.g. also retext the "View test runs" button so its label matches the results destination — if you'd like.

Verified: with this change, `edr monitor` regenerates the working `test-results/<id>` link and the alert opens the specific failing test on a cold load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated report-history URL generation to use the correct `test-results` path for test runs.
  * Improved link behavior for direct page loads of individual test runs to avoid cold-load issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->