### PR TITLE
CORE-1091: Document MONITOR privilege setup for Snowflake dynamic tables

### DIFF
--- a/docs/snippets/cloud/integrations/snowflake.mdx
+++ b/docs/snippets/cloud/integrations/snowflake.mdx
@@ -18,17 +18,15 @@ Run the following in a Snowflake worksheet with **admin permissions**. Set `data
 DECLARE
   databases ARRAY DEFAULT ARRAY_CONSTRUCT('DB1', 'DB2', 'DB3');
   elementary_role STRING DEFAULT 'ELEMENTARY_ROLE';
-  db_cursor CURSOR FOR
-    SELECT VALUE::STRING AS db_name FROM TABLE(FLATTEN(INPUT => :databases));
 BEGIN
-  FOR record IN db_cursor DO
-    LET db_name STRING := record.db_name;
+  FOR i IN 0 TO ARRAY_SIZE(databases) - 1 DO
+    LET db_name STRING := databases[i]::STRING;
     GRANT MONITOR ON ALL DYNAMIC TABLES IN DATABASE IDENTIFIER(:db_name)
       TO ROLE IDENTIFIER(:elementary_role);
     GRANT MONITOR ON FUTURE DYNAMIC TABLES IN DATABASE IDENTIFIER(:db_name)
       TO ROLE IDENTIFIER(:elementary_role);
   END FOR;
-  RETURN 'Granted MONITOR on dynamic tables for ' || ARRAY_SIZE(:databases) || ' database(s).';
+  RETURN 'Granted MONITOR on dynamic tables for ' || ARRAY_SIZE(databases) || ' database(s).';
 END;
 ```
 

--- a/docs/snippets/cloud/integrations/snowflake.mdx
+++ b/docs/snippets/cloud/integrations/snowflake.mdx
@@ -4,6 +4,33 @@ This guide contains the necessary steps to connect a Snowflake environment to yo
 
 <CreateUserOperationSnowflake />
 
+### Grant permissions to monitor dynamic tables
+
+To monitor [Snowflake dynamic tables](https://docs.snowflake.com/en/user-guide/dynamic-tables/overview), Elementary needs the `MONITOR` privilege on those dynamic tables, granted per database.
+
+<Note>
+  This privilege isn't included in the roles granted during user creation. Grant it separately for each database containing dynamic tables you want Elementary to monitor.
+</Note>
+
+Run the following in a Snowflake worksheet with **admin permissions**. Set `databases` to the list of databases containing the dynamic tables you want Elementary to monitor, and `elementary_role` to your Elementary role name:
+
+```sql
+DECLARE
+  databases ARRAY DEFAULT ARRAY_CONSTRUCT('DB1', 'DB2', 'DB3');
+  elementary_role STRING DEFAULT 'ELEMENTARY_ROLE';
+  db_cursor CURSOR FOR
+    SELECT VALUE::STRING AS db_name FROM TABLE(FLATTEN(INPUT => :databases));
+BEGIN
+  FOR record IN db_cursor DO
+    GRANT MONITOR ON ALL DYNAMIC TABLES IN DATABASE IDENTIFIER(:record.db_name)
+      TO ROLE IDENTIFIER(:elementary_role);
+    GRANT MONITOR ON FUTURE DYNAMIC TABLES IN DATABASE IDENTIFIER(:record.db_name)
+      TO ROLE IDENTIFIER(:elementary_role);
+  END FOR;
+  RETURN 'Granted MONITOR on dynamic tables for ' || ARRAY_SIZE(:databases) || ' database(s).';
+END;
+```
+
 ### Fill the connection form
 
 Provide the following fields:
@@ -47,31 +74,4 @@ After creating a network policy you would need to activate it. To activate a net
 
 ```sql
 ALTER USER <user_name> SET NETWORK_POLICY = ELEMENTARY_CLOUD;
-```
-
-### Grant permissions to monitor dynamic tables
-
-To monitor Snowflake dynamic tables that aren't managed by your dbt project, Elementary needs the `MONITOR` privilege on those dynamic tables, granted per database.
-
-<Note>
-  This privilege isn't included in the roles granted during user creation. Grant it separately for each database containing dynamic tables you want Elementary to monitor.
-</Note>
-
-Run the following in a Snowflake worksheet with **admin permissions**. Set `databases` to the list of databases containing the dynamic tables you want Elementary to monitor, and `elementary_role` to your Elementary role name:
-
-```sql
-DECLARE
-  databases ARRAY DEFAULT ARRAY_CONSTRUCT('DB1', 'DB2', 'DB3');
-  elementary_role STRING DEFAULT 'ELEMENTARY_ROLE';
-  db_cursor CURSOR FOR
-    SELECT VALUE::STRING AS db_name FROM TABLE(FLATTEN(INPUT => :databases));
-BEGIN
-  FOR record IN db_cursor DO
-    GRANT MONITOR ON ALL DYNAMIC TABLES IN DATABASE IDENTIFIER(:record.db_name)
-      TO ROLE IDENTIFIER(:elementary_role);
-    GRANT MONITOR ON FUTURE DYNAMIC TABLES IN DATABASE IDENTIFIER(:record.db_name)
-      TO ROLE IDENTIFIER(:elementary_role);
-  END FOR;
-  RETURN 'Granted MONITOR on dynamic tables for ' || ARRAY_SIZE(:databases) || ' database(s).';
-END;
 ```

--- a/docs/snippets/cloud/integrations/snowflake.mdx
+++ b/docs/snippets/cloud/integrations/snowflake.mdx
@@ -22,9 +22,10 @@ DECLARE
     SELECT VALUE::STRING AS db_name FROM TABLE(FLATTEN(INPUT => :databases));
 BEGIN
   FOR record IN db_cursor DO
-    GRANT MONITOR ON ALL DYNAMIC TABLES IN DATABASE IDENTIFIER(:record.db_name)
+    LET db_name STRING := record.db_name;
+    GRANT MONITOR ON ALL DYNAMIC TABLES IN DATABASE IDENTIFIER(:db_name)
       TO ROLE IDENTIFIER(:elementary_role);
-    GRANT MONITOR ON FUTURE DYNAMIC TABLES IN DATABASE IDENTIFIER(:record.db_name)
+    GRANT MONITOR ON FUTURE DYNAMIC TABLES IN DATABASE IDENTIFIER(:db_name)
       TO ROLE IDENTIFIER(:elementary_role);
   END FOR;
   RETURN 'Granted MONITOR on dynamic tables for ' || ARRAY_SIZE(:databases) || ' database(s).';

--- a/docs/snippets/cloud/integrations/snowflake.mdx
+++ b/docs/snippets/cloud/integrations/snowflake.mdx
@@ -49,9 +49,9 @@ After creating a network policy you would need to activate it. To activate a net
 ALTER USER <user_name> SET NETWORK_POLICY = ELEMENTARY_CLOUD;
 ```
 
-### Enable column-level lineage for dynamic tables
+### Grant permissions to monitor dynamic tables
 
-Elementary can extend [column-level lineage](/cloud/features/data-lineage/column-level-lineage) to Snowflake dynamic tables that aren't managed by your dbt project. This requires the `MONITOR` privilege on those dynamic tables, granted per database.
+To monitor Snowflake dynamic tables that aren't managed by your dbt project, Elementary needs the `MONITOR` privilege on those dynamic tables, granted per database.
 
 <Note>
   This privilege isn't included in the roles granted during user creation. Grant it separately for each database containing dynamic tables you want Elementary to monitor.

--- a/docs/snippets/cloud/integrations/snowflake.mdx
+++ b/docs/snippets/cloud/integrations/snowflake.mdx
@@ -48,3 +48,30 @@ After creating a network policy you would need to activate it. To activate a net
 ```sql
 ALTER USER <user_name> SET NETWORK_POLICY = ELEMENTARY_CLOUD;
 ```
+
+### Enable column-level lineage for dynamic tables
+
+Elementary can extend [column-level lineage](/cloud/features/data-lineage/column-level-lineage) to Snowflake dynamic tables that aren't managed by your dbt project. This requires the `MONITOR` privilege on those dynamic tables, granted per database.
+
+<Note>
+  This privilege isn't included in the roles granted during user creation. Grant it separately for each database containing dynamic tables you want Elementary to monitor.
+</Note>
+
+Run the following in a Snowflake worksheet with **admin permissions**. Set `databases` to the list of databases containing the dynamic tables you want Elementary to monitor, and `elementary_role` to your Elementary role name:
+
+```sql
+DECLARE
+  databases ARRAY DEFAULT ARRAY_CONSTRUCT('DB1', 'DB2', 'DB3');
+  elementary_role STRING DEFAULT 'ELEMENTARY_ROLE';
+  db_cursor CURSOR FOR
+    SELECT VALUE::STRING AS db_name FROM TABLE(FLATTEN(INPUT => :databases));
+BEGIN
+  FOR record IN db_cursor DO
+    GRANT MONITOR ON ALL DYNAMIC TABLES IN DATABASE IDENTIFIER(:record.db_name)
+      TO ROLE IDENTIFIER(:elementary_role);
+    GRANT MONITOR ON FUTURE DYNAMIC TABLES IN DATABASE IDENTIFIER(:record.db_name)
+      TO ROLE IDENTIFIER(:elementary_role);
+  END FOR;
+  RETURN 'Granted MONITOR on dynamic tables for ' || ARRAY_SIZE(:databases) || ' database(s).';
+END;
+```


### PR DESCRIPTION
## Summary
- Adds a "Grant permissions to monitor dynamic tables" section to the Connect to Snowflake page, covering the `MONITOR` privilege required for Elementary to monitor Snowflake dynamic tables not discovered through dbt.
- Includes a Snowflake Scripting snippet that grants `MONITOR` (current + future dynamic tables) across a list of databases in one run, instead of requiring a manual copy-paste per database.
- Section is placed right after the user-creation step, before "Fill the connection form".

## Test plan
- [x] `mintlify broken-links` passes
- [x] The Snowflake Scripting snippet verified working directly against a live Snowflake account

Linear: CORE-1091