### PR TITLE
fix: use explicit utf-8 encoding and LF newlines for file I/O

### DIFF
--- a/scripts/generate_report_from_json.py
+++ b/scripts/generate_report_from_json.py
@@ -3,7 +3,7 @@ import sys
 
 
 def gen_report(json_output_path: str):
-    json_output_data = pathlib.Path(json_output_path).read_text()
+    json_output_data = pathlib.Path(json_output_path).read_text(encoding="utf-8")
     report_template_path = (
         pathlib.Path(__file__).parent.parent
         / "elementary"
@@ -12,7 +12,7 @@ def gen_report(json_output_path: str):
         / "report"
         / "index.html"
     )
-    report_template_data = report_template_path.read_text()
+    report_template_data = report_template_path.read_text(encoding="utf-8")
     compiled_output_html = f"{report_template_data}<script>var elementaryData = {json_output_data}</script>"
     with open("manually_generated_report.html", "w", encoding="utf-8") as report_file:
         report_file.write(compiled_output_html)

--- a/tests/unit/messages/utils.py
+++ b/tests/unit/messages/utils.py
@@ -19,17 +19,19 @@ def get_expected_file_path(fixture_dir: Path, filename: str) -> Path:
     if not path.exists():
         path.parent.mkdir(parents=True, exist_ok=True)
         if filename.endswith(".json"):
-            path.write_text(json.dumps({}))
+            path.write_text(json.dumps({}), encoding="utf-8", newline="\n")
         else:
-            path.write_text("")
+            path.write_text("", encoding="utf-8", newline="\n")
     return path
 
 
 def assert_expected_json(result: dict, expected_json_path: Path) -> None:
-    expected = json.loads(expected_json_path.read_text())
+    expected = json.loads(expected_json_path.read_text(encoding="utf-8"))
     if OVERRIDE:
         logger.warning(f"Overriding expected JSON file: {expected_json_path}")
-        expected_json_path.write_text(json.dumps(result, indent=2) + "\n")
+        expected_json_path.write_text(
+            json.dumps(result, indent=2) + "\n", encoding="utf-8", newline="\n"
+        )
     else:
         try:
             assert result == expected
@@ -44,12 +46,12 @@ def assert_expected_json(result: dict, expected_json_path: Path) -> None:
 
 
 def assert_expected_text(result: str, expected_file_path: Path) -> None:
-    expected = expected_file_path.read_text()
+    expected = expected_file_path.read_text(encoding="utf-8")
     if OVERRIDE:
         logger.warning(f"Overriding expected text file: {expected_file_path}")
         if not result.endswith("\n"):
             # for code quality, we want to ensure that all files end with a newline
             result += "\n"
-        expected_file_path.write_text(result)
+        expected_file_path.write_text(result, encoding="utf-8", newline="\n")
     else:
         assert result.strip() == expected.strip()


### PR DESCRIPTION
## What

Pass `encoding="utf-8"` explicitly to every `Path.read_text()` / `Path.write_text()` call in `scripts/generate_report_from_json.py` and `tests/unit/messages/utils.py`, and `newline="\n"` to the fixture writes.

## Why

`read_text()`/`write_text()` fall back to `locale.getpreferredencoding()` and platform newline translation when no encoding is given. That's UTF-8/LF on Linux and macOS, but cp1252/CRLF on Windows.

**Before**
- `scripts/generate_report_from_json.py` raises `UnicodeDecodeError` on Windows when the report template (`elementary/monitor/data_monitoring/report/index.html`) or the JSON output contains any non-cp1252 character.
- `tests/unit/messages/utils.py` run with `OVERRIDE=true` on Windows rewrites the expected JSON/text fixtures with CRLF line endings, producing a diff on every fixture file that touches the repo.

**After**
- Both files are read and written as UTF-8 on every platform.
- Regenerated fixtures keep LF line endings regardless of the platform they were generated on.

## Notes

No behavior change on Linux/macOS — this only makes the already-assumed defaults explicit. `Path.write_text(newline=...)` requires Python 3.10, which matches this project's `python = ">=3.10,<3.14"`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report generation consistency across platforms by standardizing UTF-8 file encoding.
  * Normalized line endings in generated reports and expected test files for more reliable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->