### PR TITLE
docs: correct dbt-quoting short flag to -dq

### DIFF
--- a/docs/oss/cli-commands.mdx
+++ b/docs/oss/cli-commands.mdx
@@ -160,7 +160,7 @@ Here is a list of all the available options:
   You should use this setting if you are overriding dbt's default quoting in your main dbt package.
 
 ```shell
--q, --dbt-quoting [all|none|combination of any of: database,schema,identifier]
+-dq, --dbt-quoting [all|none|combination of any of: database,schema,identifier]
 
 # Examples:
 # * --dbt-quoting all


### PR DESCRIPTION
The docs list `-q` as the short flag for `--dbt-quoting`, but the CLI registers it as `-dq` (`elementary/monitor/cli.py`), so `edr monitor -q all` fails with `No such option: -q`.

This updates the docs to `-dq` so the short flag matches the code. The long form and the examples right below it are already correct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the short alias for the `--dbt-quoting` CLI option from `-q` to `-dq`.
  * Supported option values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->