### PR TITLE
docs: update Fivetran page for new API-key connection flow

### DIFF
--- a/docs/cloud/integrations/pipeline/fivetran.mdx
+++ b/docs/cloud/integrations/pipeline/fivetran.mdx
@@ -3,57 +3,48 @@ title: "Fivetran"
 badge: "Context Engine"
 ---
 
-Elementary connects to Fivetran via webhook to automatically create incidents when connector syncs fail.
-When a `sync_end` event is received, Elementary evaluates the sync status and opens or updates an incident accordingly.
+Elementary connects to your Fivetran account to automatically create incidents when connector syncs fail.
+When a sync fails, Elementary evaluates the outcome and opens or updates an incident accordingly.
 
 <Warning>
-  **Connector filtering is not yet supported.** Incidents will be created for all connectors in the destination group. Filtering by specific connectors will be added in a future release.
+  **Connector filtering is not yet supported.** Incidents will be created for all connectors in the monitored destination groups. Filtering by specific connectors will be added in a future release.
 </Warning>
 
 ## How it works
 
-1. Register an Elementary webhook with Fivetran for a specific destination group.
-2. Fivetran sends a `sync_end` event to Elementary each time a connector sync completes.
-3. Elementary evaluates the sync outcome and creates or updates an incident when a sync fails.
+1. You connect your Fivetran account to Elementary with a Fivetran API key and select which destination groups to monitor.
+2. Elementary sets up sync monitoring for the selected groups automatically — no manual configuration in Fivetran is required.
+3. Each time a connector sync completes, Elementary evaluates the outcome and creates or updates an incident when the sync fails.
 4. The incident appears in Elementary's Incidents view, where you can investigate, comment, and resolve it.
 
-## Setup
+## Enabling Fivetran
 
-### Step 1 – Generate webhook credentials
+<Info>
+  You need a Fivetran API key with permission to read connectors and manage webhooks, and Elementary permissions to edit integrations.
+</Info>
 
-1. In Elementary, go to **Settings → Environments** and select the environment you want to connect.
-2. Under **Integrations**, click **Connect Fivetran**.
-3. Click **Generate Webhook Credentials**.
-4. Copy the **Webhook URL** and **Secret** — you will need them in the next step.
+<Steps>
+  <Step title="Create a Fivetran API key">
+    In Fivetran, go to your account settings and generate an API key. Copy the **API key** and **API secret** — you'll need both in Elementary.
 
-### Step 2 – Register the webhook in Fivetran
+    See Fivetran's [API key documentation](https://fivetran.com/docs/rest-api/getting-started) for details.
+  </Step>
+  <Step title="Open the Fivetran integration in Elementary">
+    In Elementary, go to **Settings → Environments** and select the environment you want to connect. Under **Integrations**, click **Connect Fivetran**.
+  </Step>
+  <Step title="Enter your Fivetran credentials">
+    Paste the **API key** and **API secret** and continue. Elementary validates the credentials and loads the destination groups available in your Fivetran account.
+  </Step>
+  <Step title="Select destination groups and connect">
+    Choose the destination groups you want to monitor, then save. Elementary connects to Fivetran and starts monitoring the selected groups automatically.
+  </Step>
+</Steps>
 
-Fivetran requires the webhook to be registered via their REST API. Use the following steps:
+### Verify the connection
 
-1. In Fivetran, open the destination you want to monitor.
-2. On the **Overview** tab, copy the **Destination Group ID**.
-3. Call the [Fivetran Webhooks API](https://fivetran.com/docs/rest-api/api-reference/webhooks/create-group-webhook) to register a `sync_end` webhook for that group:
+After connecting, trigger a sync in Fivetran. Elementary processes sync events asynchronously, so it may take a short time before a resulting incident appears.
 
-```bash
-curl --request POST \
-  --url https://api.fivetran.com/v1/webhooks/group/{group_id} \
-  --header 'Authorization: Bearer <your-fivetran-api-key>' \
-  --header 'Content-Type: application/json' \
-  --data '{
-    "url": "<Webhook URL from Elementary>",
-    "events": ["sync_end"],
-    "active": true,
-    "secret": "<Secret from Elementary>"
-  }'
-```
-
-Replace `{group_id}` with your Destination Group ID, and fill in the Webhook URL and Secret copied from Elementary.
-
-### Step 3 – Verify the connection
-
-After registering the webhook, trigger a sync in Fivetran. Once the sync completes, Fivetran will send a `sync_end` event to Elementary. Elementary processes these events asynchronously, so it may take a short time before the resulting incident appears.
-
-To confirm the webhook is wired up correctly, check the **Incidents** view in Elementary after a failed sync — a new incident should appear for the affected connector.
+To confirm monitoring is working, check the **Incidents** view in Elementary after a failed sync — a new incident should appear for the affected connector.
 
 ## Where to see Fivetran incidents
 
@@ -65,5 +56,5 @@ Fivetran sync failures appear in the **Incidents** view in Elementary. Each inci
 - Destination group ID
 
 <Note>
-  At this time, Fivetran incidents cannot be filtered by connector — all connectors in the registered destination group are monitored.
+  At this time, Fivetran incidents cannot be filtered by connector — all connectors in the monitored destination groups are included.
 </Note>

--- a/docs/cloud/integrations/pipeline/fivetran.mdx
+++ b/docs/cloud/integrations/pipeline/fivetran.mdx
@@ -4,7 +4,7 @@ badge: "Context Engine"
 ---
 
 Elementary connects to your Fivetran account to automatically create incidents when connector syncs fail.
-When a sync fails, Elementary evaluates the outcome and opens or updates an incident accordingly.
+When a sync ends, Elementary evaluates the outcome and opens or updates an incident accordingly.
 
 <Warning>
   **Connector filtering is not yet supported.** Incidents will be created for all connectors in the monitored destination groups. Filtering by specific connectors will be added in a future release.
@@ -13,7 +13,7 @@ When a sync fails, Elementary evaluates the outcome and opens or updates an inci
 ## How it works
 
 1. You connect your Fivetran account to Elementary with a Fivetran API key and select which destination groups to monitor.
-2. Elementary sets up sync monitoring for the selected groups automatically — no manual configuration in Fivetran is required.
+2. Elementary subscribes to Fivetran's sync_end events for the selected groups automatically - no manual configuration in Fivetran is required.
 3. Each time a connector sync completes, Elementary evaluates the outcome and creates or updates an incident when the sync fails.
 4. The incident appears in Elementary's Incidents view, where you can investigate, comment, and resolve it.
 
@@ -25,7 +25,7 @@ When a sync fails, Elementary evaluates the outcome and opens or updates an inci
 
 <Steps>
   <Step title="Create a Fivetran API key">
-    In Fivetran, go to your account settings and generate an API key. Copy the **API key** and **API secret** — you'll need both in Elementary.
+    In Fivetran, go to your account settings and generate an API key. Copy the **API key** and **API secret** .
 
     See Fivetran's [API key documentation](https://fivetran.com/docs/rest-api/getting-started) for details.
   </Step>
@@ -36,7 +36,7 @@ When a sync fails, Elementary evaluates the outcome and opens or updates an inci
     Paste the **API key** and **API secret** and continue. Elementary validates the credentials and loads the destination groups available in your Fivetran account.
   </Step>
   <Step title="Select destination groups and connect">
-    Choose the destination groups you want to monitor, then save. Elementary connects to Fivetran and starts monitoring the selected groups automatically.
+    Choose the destination groups you want to monitor, then save. Elementary connects to Fivetran and automatically starts syncing and monitoring the selected groups.
   </Step>
 </Steps>
 
@@ -56,5 +56,5 @@ Fivetran sync failures appear in the **Incidents** view in Elementary. Each inci
 - Destination group ID
 
 <Note>
-  At this time, Fivetran incidents cannot be filtered by connector — all connectors in the monitored destination groups are included.
+  At this time, Fivetran incidents cannot be filtered by connector - all connectors in the monitored destination groups are included.
 </Note>

--- a/docs/cloud/integrations/pipeline/fivetran.mdx
+++ b/docs/cloud/integrations/pipeline/fivetran.mdx
@@ -40,12 +40,6 @@ When a sync ends, Elementary evaluates the outcome and opens or updates an incid
   </Step>
 </Steps>
 
-### Verify the connection
-
-After connecting, trigger a sync in Fivetran. Elementary processes sync events asynchronously, so it may take a short time before a resulting incident appears.
-
-To confirm monitoring is working, check the **Incidents** view in Elementary after a failed sync — a new incident should appear for the affected connector.
-
 ## Where to see Fivetran incidents
 
 Fivetran sync failures appear in the **Incidents** view in Elementary. Each incident includes:
@@ -54,7 +48,3 @@ Fivetran sync failures appear in the **Incidents** view in Elementary. Each inci
 - Sync status and failure reason (when available)
 - Event timestamp
 - Destination group ID
-
-<Note>
-  At this time, Fivetran incidents cannot be filtered by connector - all connectors in the monitored destination groups are included.
-</Note>


### PR DESCRIPTION
## What

Updates the Fivetran integration docs page to match the new way customers connect the integration.

**Before:** generate webhook credentials in Elementary, then manually register the webhook in Fivetran via a `curl` call to their REST API.

**After:** connect with a Fivetran API key + secret, select which destination groups to monitor, and Elementary sets up sync monitoring automatically.

## Changes
- Rewrote **How it works** and **Enabling Fivetran** (now `<Steps>`) for the API-key flow
- Removed the manual `curl` webhook-registration block
- Kept the connector-filtering caveat and the "Where to see Fivetran incidents" section

## Notes
- Customer-facing only — no internal implementation details
- Linear: CORE-1239
- ⚠️ Screenshot TODO: guide wants a screenshot after the "Connect Fivetran" UI step — not added (couldn't capture the product UI). Someone should add it before/after merge.
- Local `mintlify validate` / `broken-links` couldn't run here — broken `sharp` native module in this environment, not a content issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/elementary-data/elementary/pull/2313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->