### PR TITLE
docs: add required Fivetran API key permissions

### DIFF
--- a/docs/cloud/integrations/pipeline/fivetran.mdx
+++ b/docs/cloud/integrations/pipeline/fivetran.mdx
@@ -20,12 +20,20 @@ When a sync ends, Elementary evaluates the outcome and opens or updates an incid
 ## Enabling Fivetran
 
 <Info>
-  You need a Fivetran API key with permission to read connectors and manage webhooks, and Elementary permissions to edit integrations.
+  Connecting Fivetran requires permission to edit integrations in Elementary.
 </Info>
 
 <Steps>
   <Step title="Create a Fivetran API key">
     In Fivetran, go to your account settings and generate an API key. Copy the **API key** and **API secret** .
+
+    The API key must have the following permissions:
+
+    | Resource | Access | Used for |
+    | --- | --- | --- |
+    | Destinations | Read | Listing your destination groups |
+    | Connectors | Read | Identifying connectors and their tables |
+    | Webhooks | Manage | Setting up and maintaining sync monitoring |
 
     See Fivetran's [API key documentation](https://fivetran.com/docs/rest-api/getting-started) for details.
   </Step>

--- a/docs/cloud/integrations/pipeline/fivetran.mdx
+++ b/docs/cloud/integrations/pipeline/fivetran.mdx
@@ -33,7 +33,7 @@ When a sync ends, Elementary evaluates the outcome and opens or updates an incid
     | --- | --- | --- |
     | Destinations | Read | Listing your destination groups |
     | Connectors | Read | Identifying connectors and their tables |
-    | Webhooks | Manage | Setting up and maintaining sync monitoring |
+    | Webhooks | Read, Manage | Setting up and maintaining sync monitoring |
 
     See Fivetran's [API key documentation](https://fivetran.com/docs/rest-api/getting-started) for details.
   </Step>

--- a/docs/cloud/integrations/pipeline/fivetran.mdx
+++ b/docs/cloud/integrations/pipeline/fivetran.mdx
@@ -27,13 +27,10 @@ When a sync ends, Elementary evaluates the outcome and opens or updates an incid
   <Step title="Create a Fivetran API key">
     In Fivetran, go to your account settings and generate an API key. Copy the **API key** and **API secret** .
 
-    The API key must have **read** permission to the Fivetran resources, and **manage** permission to the webhook resource:
+    **Which permissions should I provide to the API key?**
 
-    | Resource | Access | Used for |
-    | --- | --- | --- |
-    | Destinations | Read | Listing your destination groups |
-    | Connectors | Read | Identifying connectors and their tables |
-    | Webhooks | Read, Manage | Setting up and maintaining sync monitoring |
+    - Read permission to all resources
+    - Manage permission to the webhook resource
 
     See Fivetran's [API key documentation](https://fivetran.com/docs/rest-api/getting-started) for details.
   </Step>

--- a/docs/cloud/integrations/pipeline/fivetran.mdx
+++ b/docs/cloud/integrations/pipeline/fivetran.mdx
@@ -27,7 +27,7 @@ When a sync ends, Elementary evaluates the outcome and opens or updates an incid
   <Step title="Create a Fivetran API key">
     In Fivetran, go to your account settings and generate an API key. Copy the **API key** and **API secret** .
 
-    The API key must have the following permissions:
+    The API key must have **read** permission to the Fivetran resources, and **manage** permission to the webhook resource:
 
     | Resource | Access | Used for |
     | --- | --- | --- |


### PR DESCRIPTION
## What

Follow-up to #2313 (already merged). Adds the required Fivetran API key permissions to the Fivetran integration docs page, so customers know what access to grant the key before connecting.

## Change
`docs/cloud/integrations/pipeline/fivetran.mdx` — permissions table in the "Create a Fivetran API key" step:

| Resource | Access | Used for |
| --- | --- | --- |
| Destinations | Read | Listing your destination groups |
| Connectors | Read | Identifying connectors and their tables |
| Webhooks | Manage | Setting up and maintaining sync monitoring |

## Verification
Permission set validated against every Fivetran API call in the integration client — all covered, none missing.

## Notes
- Customer-facing only — no internal endpoints/implementation details.
- Linear: CORE-1239 (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/elementary-data/elementary/pull/2315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->