### PR TITLE
docs: explain how to reason about dimension anomaly tests

### DIFF
--- a/docs/data-tests/anomaly-detection-configuration/detection-delay.mdx
+++ b/docs/data-tests/anomaly-detection-configuration/detection-delay.mdx
@@ -61,17 +61,11 @@ It does not affect the other duration parameters, like `detection_period` or `tr
 
 #### You don't need a delay to avoid partial buckets
 
-Elementary only ever evaluates **complete time buckets**. The newest bucket a test considers is the last one whose *end* falls at or before the invocation time, minus the delay. With daily buckets and dbt running at 02:00, the newest evaluated bucket runs from yesterday 00:00 to today 00:00 — today's two hours of data are never scored, with no delay configured.
+Elementary only ever evaluates **complete time buckets** — the newest one considered is the last whose *end* falls at or before the invocation time, minus the delay. With daily buckets and dbt running at 02:00, the newest evaluated bucket runs from yesterday 00:00 to today 00:00, so today's partial data is never scored without any delay configured.
 
-So a delay is not what protects you from testing a partial day. What it protects you from is **data that arrives after the bucket it belongs to has closed**: if yesterday's load only finishes at 04:00 and your tests run at 02:00, yesterday's bucket is complete by the clock but incomplete in the warehouse, and the test sees a drop.
+A delay is instead for **data that arrives after its bucket has closed**: if yesterday's load finishes at 04:00 but tests run at 02:00, yesterday's bucket is complete by the clock and incomplete in the warehouse, and the test sees a drop.
 
-<Note>
-  The detection boundary comes from the dbt invocation time, which dbt reports in UTC, while buckets are aligned to midnight in the values of your `timestamp_column`. If that column holds local time, the newest bucket can be evaluated before it is actually complete. This is a genuine case for a delay.
-</Note>
-
-#### The delay snaps to bucket boundaries
-
-A delay smaller than one time bucket is rarely a small adjustment. With daily buckets and dbt running at 02:00:
+The delay also snaps to bucket boundaries, so a sub-bucket delay is not a small adjustment. Daily buckets, dbt running at 02:00:
 
 | `detection_delay` | Detection boundary | Newest evaluated bucket |
 | --- | --- | --- |
@@ -79,19 +73,14 @@ A delay smaller than one time bucket is rarely a small adjustment. With daily bu
 | 4 hours | yesterday 22:00 | day before yesterday |
 | 1 day | yesterday 02:00 | day before yesterday |
 
-A four-hour delay pushes the boundary back before midnight, so it costs a full day of freshness — the same as asking for a whole day. Reason about the delay in whole buckets.
-
-#### Choosing a delay
-
-A delay buys completeness and pays in detection latency. There is no setting that avoids the trade-off.
-
-- **No delay** is correct when the pipeline that populates a bucket reliably finishes before the tests run. This is the common case, and the default.
-- **A one-bucket delay** is correct when late-arriving data is normal — event data with a long ingestion tail, a source you don't control, a loader that sometimes finishes after the test. You accept finding out about yesterday tomorrow, in exchange for not being alerted by an artifact of scheduling.
+A four-hour delay pushes the boundary back before midnight, costing a full day of freshness — the same as asking for a whole day.
 
 <Tip>
-  Before reaching for a delay, check whether a different timestamp fixes the problem outright. If `timestamp_column` is an *event* time (`occurred_at`) but rows land hours later, switch to a *load* time (`loaded_at`, `_synced_at`). Bucketing by when rows arrived removes the late-data problem instead of waiting it out, and keeps detection current.
+  Before reaching for a delay, check whether a different timestamp fixes the problem outright. If `timestamp_column` is an *event* time (`occurred_at`) but rows land hours later, switch to a *load* time (`loaded_at`, `_synced_at`). Bucketing by arrival removes the late-data problem instead of waiting it out.
 </Tip>
 
-<Warning>
-  A delay does not shorten the periods, it moves them. With `detection_delay: 1 day`, an incident inside the skipped bucket is caught on the *next* run, once that bucket enters the window. Make sure your delay plus your run cadence still evaluates every bucket.
-</Warning>
+<Note>
+  The boundary comes from the dbt invocation time, which dbt reports in UTC, while buckets align to midnight in the values of your `timestamp_column`. A local-time column can therefore be scored before it is complete — a genuine case for a delay.
+</Note>
+
+For the full trade-off, see [Understanding dimension anomalies](/data-tests/anomaly-detection-tests/understanding-dimension-anomalies).

--- a/docs/data-tests/anomaly-detection-configuration/detection-delay.mdx
+++ b/docs/data-tests/anomaly-detection-configuration/detection-delay.mdx
@@ -80,7 +80,7 @@ A four-hour delay pushes the boundary back before midnight, costing a full day o
 </Tip>
 
 <Note>
-  The boundary comes from the dbt invocation time, which dbt reports in UTC, while buckets align to midnight in the values of your `timestamp_column`. A local-time column can therefore be scored before it is complete — a genuine case for a delay.
+  Bucket boundaries and the detection boundary are not derived the same way: buckets start at midnight of a calendar date, while the detection boundary carries the dbt invocation time, which dbt reports in UTC. If your `timestamp_column` is not stored in UTC, confirm which bucket your test actually scores — depending on your warehouse and the column's type, the newest bucket can be evaluated before it has closed in the column's own timezone. That is a real case for a delay.
 </Note>
 
 For the full trade-off, see [Understanding dimension anomalies](/data-tests/anomaly-detection-tests/understanding-dimension-anomalies).

--- a/docs/data-tests/anomaly-detection-configuration/detection-delay.mdx
+++ b/docs/data-tests/anomaly-detection-configuration/detection-delay.mdx
@@ -61,7 +61,9 @@ It does not affect the other duration parameters, like `detection_period` or `tr
 
 #### You don't need a delay to avoid testing a half-finished day
 
-Elementary only ever tests **finished time buckets**. The newest one it looks at is the last bucket that had already ended when dbt started, minus any delay. With daily buckets and dbt running at 02:00, the newest bucket tested is yesterday, midnight to midnight — today's two hours are never tested, without setting anything.
+Elementary only ever tests **finished time buckets**. The newest one it looks at is the last bucket that had already ended when dbt started, minus any delay.
+
+Your job does not need to run at midnight for this to hold. With daily buckets, the newest day tested is always yesterday, whether dbt starts at 00:30, 02:00 or 23:00 — today's partial data is never tested, without setting anything.
 
 What a delay is really for is **data that shows up late**. If yesterday's load does not finish until 04:00 but your tests run at 02:00, yesterday looks finished on the calendar but is still missing rows in the warehouse, and the test sees a drop.
 

--- a/docs/data-tests/anomaly-detection-configuration/detection-delay.mdx
+++ b/docs/data-tests/anomaly-detection-configuration/detection-delay.mdx
@@ -57,4 +57,41 @@ vars:
 #### How it works?
 
 The `detection_delay` param only works for tests that have `timestamp_column` configuration.
-It does not affect the other duration parameters, like `detection_period` or `training_period`.
+It does not affect the other duration parameters, like `detection_period` or `training_period` — it shifts the whole evaluated window back in time rather than resizing it.
+
+#### You don't need a delay to avoid partial buckets
+
+Elementary only ever evaluates **complete time buckets**. The newest bucket a test considers is the last one whose *end* falls at or before the invocation time, minus the delay. With daily buckets and dbt running at 02:00, the newest evaluated bucket runs from yesterday 00:00 to today 00:00 — today's two hours of data are never scored, with no delay configured.
+
+So a delay is not what protects you from testing a partial day. What it protects you from is **data that arrives after the bucket it belongs to has closed**: if yesterday's load only finishes at 04:00 and your tests run at 02:00, yesterday's bucket is complete by the clock but incomplete in the warehouse, and the test sees a drop.
+
+<Note>
+  The detection boundary comes from the dbt invocation time, which dbt reports in UTC, while buckets are aligned to midnight in the values of your `timestamp_column`. If that column holds local time, the newest bucket can be evaluated before it is actually complete. This is a genuine case for a delay.
+</Note>
+
+#### The delay snaps to bucket boundaries
+
+A delay smaller than one time bucket is rarely a small adjustment. With daily buckets and dbt running at 02:00:
+
+| `detection_delay` | Detection boundary | Newest evaluated bucket |
+| --- | --- | --- |
+| none | today 02:00 | **yesterday** |
+| 4 hours | yesterday 22:00 | day before yesterday |
+| 1 day | yesterday 02:00 | day before yesterday |
+
+A four-hour delay pushes the boundary back before midnight, so it costs a full day of freshness — the same as asking for a whole day. Reason about the delay in whole buckets.
+
+#### Choosing a delay
+
+A delay buys completeness and pays in detection latency. There is no setting that avoids the trade-off.
+
+- **No delay** is correct when the pipeline that populates a bucket reliably finishes before the tests run. This is the common case, and the default.
+- **A one-bucket delay** is correct when late-arriving data is normal — event data with a long ingestion tail, a source you don't control, a loader that sometimes finishes after the test. You accept finding out about yesterday tomorrow, in exchange for not being alerted by an artifact of scheduling.
+
+<Tip>
+  Before reaching for a delay, check whether a different timestamp fixes the problem outright. If `timestamp_column` is an *event* time (`occurred_at`) but rows land hours later, switch to a *load* time (`loaded_at`, `_synced_at`). Bucketing by when rows arrived removes the late-data problem instead of waiting it out, and keeps detection current.
+</Tip>
+
+<Warning>
+  A delay does not shorten the periods, it moves them. With `detection_delay: 1 day`, an incident inside the skipped bucket is caught on the *next* run, once that bucket enters the window. Make sure your delay plus your run cadence still evaluates every bucket.
+</Warning>

--- a/docs/data-tests/anomaly-detection-configuration/detection-delay.mdx
+++ b/docs/data-tests/anomaly-detection-configuration/detection-delay.mdx
@@ -57,30 +57,30 @@ vars:
 #### How it works?
 
 The `detection_delay` param only works for tests that have `timestamp_column` configuration.
-It does not affect the other duration parameters, like `detection_period` or `training_period` — it shifts the whole evaluated window back in time rather than resizing it.
+It does not affect the other duration parameters, like `detection_period` or `training_period` — it moves the whole tested window into the past instead of making it shorter.
 
-#### You don't need a delay to avoid partial buckets
+#### You don't need a delay to avoid testing a half-finished day
 
-Elementary only ever evaluates **complete time buckets** — the newest one considered is the last whose *end* falls at or before the invocation time, minus the delay. With daily buckets and dbt running at 02:00, the newest evaluated bucket runs from yesterday 00:00 to today 00:00, so today's partial data is never scored without any delay configured.
+Elementary only ever tests **finished time buckets**. The newest one it looks at is the last bucket that had already ended when dbt started, minus any delay. With daily buckets and dbt running at 02:00, the newest bucket tested is yesterday, midnight to midnight — today's two hours are never tested, without setting anything.
 
-A delay is instead for **data that arrives after its bucket has closed**: if yesterday's load finishes at 04:00 but tests run at 02:00, yesterday's bucket is complete by the clock and incomplete in the warehouse, and the test sees a drop.
+What a delay is really for is **data that shows up late**. If yesterday's load does not finish until 04:00 but your tests run at 02:00, yesterday looks finished on the calendar but is still missing rows in the warehouse, and the test sees a drop.
 
-The delay also snaps to bucket boundaries, so a sub-bucket delay is not a small adjustment. Daily buckets, dbt running at 02:00:
+A delay also only moves in whole buckets, so a small delay is not a small change. Daily buckets, dbt running at 02:00:
 
-| `detection_delay` | Detection boundary | Newest evaluated bucket |
+| `detection_delay` | Cutoff | Newest bucket tested |
 | --- | --- | --- |
 | none | today 02:00 | **yesterday** |
 | 4 hours | yesterday 22:00 | day before yesterday |
 | 1 day | yesterday 02:00 | day before yesterday |
 
-A four-hour delay pushes the boundary back before midnight, costing a full day of freshness — the same as asking for a whole day.
+A four-hour delay pushes the cutoff back past midnight, so it costs you a whole day — the same as asking for one.
 
 <Tip>
-  Before reaching for a delay, check whether a different timestamp fixes the problem outright. If `timestamp_column` is an *event* time (`occurred_at`) but rows land hours later, switch to a *load* time (`loaded_at`, `_synced_at`). Bucketing by arrival removes the late-data problem instead of waiting it out.
+  Before adding a delay, see whether a different column solves it. If `timestamp_column` is when something happened (`occurred_at`) but the rows only land hours later, switch to when it was loaded (`loaded_at`, `_synced_at`). Grouping by arrival time avoids the problem instead of waiting it out.
 </Tip>
 
 <Note>
-  Bucket boundaries and the detection boundary are not derived the same way: buckets start at midnight of a calendar date, while the detection boundary carries the dbt invocation time, which dbt reports in UTC. If your `timestamp_column` is not stored in UTC, confirm which bucket your test actually scores — depending on your warehouse and the column's type, the newest bucket can be evaluated before it has closed in the column's own timezone. That is a real case for a delay.
+  Time buckets are built from calendar dates, but the cutoff for "how recent" comes from when dbt started running, and dbt uses UTC. If your timestamp column holds local time rather than UTC, the newest day can get tested before that day has actually ended where your data lives. Check which day your test is really looking at, and add a delay if it is testing too early.
 </Note>
 
 For the full trade-off, see [Understanding dimension anomalies](/data-tests/anomaly-detection-tests/understanding-dimension-anomalies).

--- a/docs/data-tests/anomaly-detection-configuration/dimensions.mdx
+++ b/docs/data-tests/anomaly-detection-configuration/dimensions.mdx
@@ -24,6 +24,20 @@ It is best to configure low-cardinality fields as `dimensions`.
 - _Relevant tests: `dimension_anomalies`, `column_anomalies`, `all_columns_anomalies`_
 - _Configuration level: test_
 
+#### Configuring more than one dimension
+
+Multiple dimensions do not create one series per column. Elementary concatenates the columns into a single composite value, separated by `; `, and monitors each observed **combination** as one series. With `dimensions: [country, device_os]`, the monitored series are `US; ios`, `US; android`, `DE; ios`, and so on. `NULL` values are rendered as the literal string `NULL`.
+
+<Warning>
+  Series count multiplies. Two dimensions of 20 and 10 values are up to 200 series, each needing its own training history. Combinations also have lower counts than either column alone, which makes them individually noisier. If you want each field monitored independently, define a separate test per field.
+</Warning>
+
+<Note>
+  The dimension list — including its **order** — is part of the identity of the collected metrics. Editing or reordering the list means the test no longer matches its previously collected history and starts building a training set from scratch.
+</Note>
+
+For the full picture, see [Understanding dimension anomalies](/data-tests/anomaly-detection-tests/understanding-dimension-anomalies).
+
 <RequestExample>
 
 ```yml test

--- a/docs/data-tests/anomaly-detection-configuration/dimensions.mdx
+++ b/docs/data-tests/anomaly-detection-configuration/dimensions.mdx
@@ -24,16 +24,16 @@ It is best to configure low-cardinality fields as `dimensions`.
 - _Relevant tests: `dimension_anomalies`, `column_anomalies`, `all_columns_anomalies`_
 - _Configuration level: test_
 
-#### Configuring more than one dimension
+#### Listing more than one column
 
-Multiple dimensions do not create one series per column. Elementary concatenates the columns into a single composite value, separated by `; `, and monitors each observed **combination** as one series. With `dimensions: [country, device_os]`, the monitored series are `US; ios`, `US; android`, `DE; ios`, and so on. `NULL` values are rendered as the literal string `NULL`.
+Listing two columns does not test each column separately. Elementary joins them into one value with `; ` in between, then watches every **combination** it finds. With `dimensions: [country, device_os]`, what gets watched is `US; ios`, `US; android`, `DE; ios`, and so on. Empty values appear as the word `NULL`.
 
 <Warning>
-  Series count multiplies: 20 countries and 10 operating systems is up to 200 series, each needing its own training history, and each combination has lower counts than either column alone. If you want each field monitored independently, define a separate test per field.
+  Combinations multiply fast. 20 countries and 10 operating systems is up to 200 things to watch, each needing its own history, and each combination has fewer rows than either column on its own. To watch two fields separately, write two tests.
 </Warning>
 
 <Note>
-  The dimension list — including its **order** — is part of the identity of the collected metrics. Editing or reordering it means the test no longer matches its previously collected history and starts training from scratch.
+  Elementary saves the history under the exact list you configured, in the exact order. If you add a column, remove one, or just reorder them, the test can no longer find its old history and starts collecting again from scratch.
 </Note>
 
 For how to choose dimensions and read the results, see [Understanding dimension anomalies](/data-tests/anomaly-detection-tests/understanding-dimension-anomalies).

--- a/docs/data-tests/anomaly-detection-configuration/dimensions.mdx
+++ b/docs/data-tests/anomaly-detection-configuration/dimensions.mdx
@@ -29,14 +29,14 @@ It is best to configure low-cardinality fields as `dimensions`.
 Multiple dimensions do not create one series per column. Elementary concatenates the columns into a single composite value, separated by `; `, and monitors each observed **combination** as one series. With `dimensions: [country, device_os]`, the monitored series are `US; ios`, `US; android`, `DE; ios`, and so on. `NULL` values are rendered as the literal string `NULL`.
 
 <Warning>
-  Series count multiplies. Two dimensions of 20 and 10 values are up to 200 series, each needing its own training history. Combinations also have lower counts than either column alone, which makes them individually noisier. If you want each field monitored independently, define a separate test per field.
+  Series count multiplies: 20 countries and 10 operating systems is up to 200 series, each needing its own training history, and each combination has lower counts than either column alone. If you want each field monitored independently, define a separate test per field.
 </Warning>
 
 <Note>
-  The dimension list — including its **order** — is part of the identity of the collected metrics. Editing or reordering the list means the test no longer matches its previously collected history and starts building a training set from scratch.
+  The dimension list — including its **order** — is part of the identity of the collected metrics. Editing or reordering it means the test no longer matches its previously collected history and starts training from scratch.
 </Note>
 
-For the full picture, see [Understanding dimension anomalies](/data-tests/anomaly-detection-tests/understanding-dimension-anomalies).
+For how to choose dimensions and read the results, see [Understanding dimension anomalies](/data-tests/anomaly-detection-tests/understanding-dimension-anomalies).
 
 <RequestExample>
 

--- a/docs/data-tests/anomaly-detection-configuration/exclude_detection_period_from_training.mdx
+++ b/docs/data-tests/anomaly-detection-configuration/exclude_detection_period_from_training.mdx
@@ -14,9 +14,19 @@ When the detection period spans multiple values, there can be overlap between th
 
 Setting `exclude_detection_period_from_training: true` ensures that no values from the detection period are used in the training calculation, preventing this overlap and improving anomaly detection accuracy.
 
+**Why the overlap happens:**
+
+The expected range at a given time bucket is calculated from the values of that metric **up to and including that bucket**. When `detection_period` spans a single bucket this is harmless, but as soon as it spans several, earlier detection buckets feed the training statistics of the later ones.
+
 **Example use case:**
 
-When `detection_period` is set to more than 1 time bucket (e.g., `detection_period: 7 days`), the detection period overlaps with the training period. Without excluding the detection period from training, values being evaluated for anomalies are also contributing to the expected range calculation, which can mask actual anomalies and result in false negatives.
+An incident starts on Monday and continues through Wednesday, with `detection_period: 3 days`. Monday's inflated value is flagged. It then joins the training data used to evaluate Tuesday, pulling the average up and the standard deviation wider. Wednesday is evaluated against a range that the incident itself widened. A sustained incident hides its own tail — you get an alert on day one and silence afterwards, which reads like a resolved blip rather than an ongoing failure.
+
+Setting this to `true` removes every detection-period bucket from the training calculation, so all three days are judged against pre-incident history only.
+
+<Warning>
+  If your `detection_period` is longer than one time bucket, set `exclude_detection_period_from_training: true`. Leaving it off produces false negatives on exactly the multi-day incidents you most want to catch.
+</Warning>
 
 - _Default: false_
 - _Supported values: `true`, `false`_

--- a/docs/data-tests/anomaly-detection-configuration/exclude_detection_period_from_training.mdx
+++ b/docs/data-tests/anomaly-detection-configuration/exclude_detection_period_from_training.mdx
@@ -16,7 +16,9 @@ Setting `exclude_detection_period_from_training: true` ensures that no values fr
 
 **Why the overlap happens:**
 
-The expected range for a time bucket is worked out from that metric's numbers **up to and including that bucket**. That is harmless when `detection_period` covers a single bucket, but as soon as it covers several, the earlier detection buckets become part of what the later ones are compared against.
+The two periods always overlap. This is not something you can avoid by picking different period lengths: the expected range for a time bucket is worked out from that metric's numbers **up to and including that bucket**, so the buckets being tested are also part of what they are tested against.
+
+That is harmless when `detection_period` covers a single bucket. As soon as it covers several, the earlier detection buckets become part of what the later ones are compared against — and with the default 2-day detection period and daily buckets, it already covers two.
 
 **Example use case:**
 

--- a/docs/data-tests/anomaly-detection-configuration/exclude_detection_period_from_training.mdx
+++ b/docs/data-tests/anomaly-detection-configuration/exclude_detection_period_from_training.mdx
@@ -16,16 +16,16 @@ Setting `exclude_detection_period_from_training: true` ensures that no values fr
 
 **Why the overlap happens:**
 
-The expected range at a given time bucket is calculated from the values of that metric **up to and including that bucket**. When `detection_period` spans a single bucket this is harmless, but as soon as it spans several, earlier detection buckets feed the training statistics of the later ones.
+The expected range for a time bucket is worked out from that metric's numbers **up to and including that bucket**. That is harmless when `detection_period` covers a single bucket, but as soon as it covers several, the earlier detection buckets become part of what the later ones are compared against.
 
 **Example use case:**
 
-An incident starts on Monday and continues through Wednesday, with `detection_period: 3 days`. Monday's inflated value is flagged. It then joins the training data used to evaluate Tuesday, pulling the average up and the standard deviation wider. Wednesday is evaluated against a range that the incident itself widened. A sustained incident hides its own tail — you get an alert on day one and silence afterwards, which reads like a resolved blip rather than an ongoing failure.
+Say something breaks on Monday and stays broken through Wednesday, with `detection_period: 3 days`. Monday gets flagged. Monday's bad number then becomes part of what Tuesday is compared against, pulling the average up and widening the range. By Wednesday the test is comparing against a range the problem itself stretched. A long problem covers its own tracks — you get one alert, then silence that looks like it was fixed.
 
-Setting this to `true` removes every detection-period bucket from the training calculation, so all three days are judged against pre-incident history only.
+Setting this to `true` leaves every detection period bucket out of that calculation, so all three days are compared against history from before the problem started.
 
 <Warning>
-  If your `detection_period` is longer than one time bucket, set `exclude_detection_period_from_training: true`. Leaving it off produces false negatives on exactly the multi-day incidents you most want to catch.
+  If your `detection_period` is longer than one time bucket, set `exclude_detection_period_from_training: true`. Leaving it off means missing exactly the multi-day problems you most want to catch.
 </Warning>
 
 - _Default: false_

--- a/docs/data-tests/anomaly-detection-tests/dimension-anomalies.mdx
+++ b/docs/data-tests/anomaly-detection-tests/dimension-anomalies.mdx
@@ -18,10 +18,10 @@ It is best to configure it on low-cardinality fields.
 
 If `timestamp_column` is configured, the distribution is collected per `time_bucket`. If not, it counts the total rows per dimension.
 
-Every distinct dimension value is monitored as its own series, with its own training set and expected range. A value that drops to zero is flagged even if the table's total row count is unchanged.
+Each value is compared against its own past, with its own expected range. So a value that drops to zero gets caught even when the table's total row count barely changes.
 
 <Card horizontal="true" title="Understanding dimension anomalies" icon="book-open" href="/data-tests/anomaly-detection-tests/understanding-dimension-anomalies">
-  How multiple dimensions combine, how to reason about `detection_delay`, and the training/detection overlap that causes false negatives.
+  What happens when you list more than one column, how to think about `detection_delay`, and why a long detection period can hide problems.
 </Card>
 
 ### Test configuration

--- a/docs/data-tests/anomaly-detection-tests/dimension-anomalies.mdx
+++ b/docs/data-tests/anomaly-detection-tests/dimension-anomalies.mdx
@@ -18,6 +18,12 @@ It is best to configure it on low-cardinality fields.
 
 If `timestamp_column` is configured, the distribution is collected per `time_bucket`. If not, it counts the total rows per dimension.
 
+Every distinct dimension value is monitored as its own series, with its own training set and expected range. A value that drops to zero is flagged even if the table's total row count is unchanged.
+
+<Card horizontal="true" title="Understanding dimension anomalies" icon="book-open" href="/data-tests/anomaly-detection-tests/understanding-dimension-anomalies">
+  How multiple dimensions combine, how to reason about `detection_delay`, and the training/detection overlap that causes false negatives.
+</Card>
+
 ### Test configuration
 
 _Required configuration: `dimensions`_

--- a/docs/data-tests/anomaly-detection-tests/understanding-dimension-anomalies.mdx
+++ b/docs/data-tests/anomaly-detection-tests/understanding-dimension-anomalies.mdx
@@ -50,19 +50,23 @@ Listing two columns does not test each column separately. Elementary joins them 
 
 ## A long detection period can hide problems
 
-The expected range for a bucket is worked out from that value's numbers **up to and including that bucket**. That is fine when [`detection_period`](/data-tests/anomaly-detection-configuration/detection-period) covers a single bucket. It works against you when it covers several.
+The training period and the detection period **always overlap**. This is not a mistake you can avoid by picking different period lengths: the expected range for a bucket is worked out from that value's numbers **up to and including that bucket**, so the days being tested are also part of what they are tested against.
+
+That is harmless when [`detection_period`](/data-tests/anomaly-detection-configuration/detection-period) covers a single bucket. It works against you when it covers several — which, with the default 2-day detection period and daily buckets, it already does.
 
 Say something breaks on Monday and stays broken through Wednesday, with `detection_period: 3 days`. Monday gets flagged. Monday's bad number then becomes part of what Tuesday is compared against, pulling the average up and widening the range. By Wednesday the test is comparing against a range the problem itself stretched. **A long problem covers its own tracks** — you get one alert, then silence that looks like it was fixed.
 
 <Warning>
-  If `detection_period` is longer than one time bucket, set [`exclude_detection_period_from_training`](/data-tests/anomaly-detection-configuration/exclude_detection_period_from_training) to `true`.
+  If `detection_period` is longer than one time bucket, set [`exclude_detection_period_from_training`](/data-tests/anomaly-detection-configuration/exclude_detection_period_from_training) to `true`. On the defaults — 2-day detection period, daily buckets — that means most tests.
 </Warning>
 
 Two related limits. A value with only one past data point cannot be checked at all, so the default 14-day [`training_period`](/data-tests/anomaly-detection-configuration/training-period) means 14 buckets *for each value* — not much for values that only show up now and then. And [`seasonality`](/data-tests/anomaly-detection-configuration/seasonality) splits each value again by day of week, so every value needs far more history.
 
 ## How to think about `detection_delay`
 
-[`detection_delay`](/data-tests/anomaly-detection-configuration/detection-delay) moves the whole tested window further into the past. It is tempting to always set a one-day delay so the test never looks at a half-finished day — but **Elementary only ever tests finished buckets**. With daily buckets and dbt running at 02:00, the newest bucket tested is yesterday, midnight to midnight. Today's two hours are never tested, without setting anything.
+[`detection_delay`](/data-tests/anomaly-detection-configuration/detection-delay) moves the whole tested window further into the past. It is tempting to always set a one-day delay so the test never looks at a half-finished day — but **Elementary only ever tests finished buckets**, so you don't need a delay for that.
+
+Your job does not need to run at midnight for this to hold. With daily buckets, the newest day tested is always yesterday, whether dbt starts at 00:30, 02:00 or 23:00. Today's partial data is never tested, without setting anything.
 
 What a delay is really for is **data that shows up late**. If yesterday's load does not finish until 04:00 but your tests run at 02:00, yesterday looks finished on the calendar but is still missing rows in the warehouse, and every value looks like it dropped.
 

--- a/docs/data-tests/anomaly-detection-tests/understanding-dimension-anomalies.mdx
+++ b/docs/data-tests/anomaly-detection-tests/understanding-dimension-anomalies.mdx
@@ -7,13 +7,13 @@ import AiGenerateTest from '/snippets/ai-generate-test.mdx';
 
 <AiGenerateTest />
 
-`dimension_anomalies` monitors the **distribution** of values in a field over time, not the size of the table. It catches what volume tests structurally cannot see: one country stops reporting, a payment provider drops to zero, a new enum value appears upstream — all while the total row count stays flat.
+`dimension_anomalies` watches how your rows split across the values of a field, rather than how big the table is. It catches problems a volume test misses: one country stops sending data, a payment provider drops to zero, an unexpected new value shows up — all while the total row count barely moves.
 
-For the parameter list, see [dimension_anomalies](/data-tests/anomaly-detection-tests/dimension-anomalies). This page covers the decisions that don't exist in the other anomaly tests.
+For the list of settings, see [dimension_anomalies](/data-tests/anomaly-detection-tests/dimension-anomalies). This page covers the choices that only come up with this test.
 
-## One independent test per dimension value
+## Every value is checked on its own
 
-The test counts rows grouped by your `dimensions`, per [time bucket](/data-tests/anomaly-detection-configuration/time-bucket). Every distinct dimension value becomes its own series, with its own training set and expected range.
+The test counts rows for each value of your `dimensions`, in each [time bucket](/data-tests/anomaly-detection-configuration/time-bucket). Each value is then compared against its own past, with its own expected range.
 
 | `bucket_end` | `dimension_value` | `metric_value` |
 | --- | --- | --- |
@@ -22,71 +22,71 @@ The test counts rows grouped by your `dimensions`, per [time bucket](/data-tests
 | 2026-03-02 | `US` | 47,880 |
 | 2026-03-02 | `JP` | 0 |
 
-`JP` dropping to zero is scored only against `JP`'s own history, so it is flagged even though the table's total barely moved. That is the point of the test.
+`JP` falling to zero is compared only to `JP`'s own history, so it gets caught even though the table total hardly changed. That is what this test is for.
 
-The cost is that **noise scales with cardinality**. 500 values is 500 chances per run for a false positive, and the low-volume values are the noisiest: a series that normally sits at 5 rows a day has a large relative standard deviation and drifts in and out of range on its own. Prefer a handful of stable values, and scope with [`where_expression`](/data-tests/anomaly-detection-configuration/where-expression).
+The trade-off is that **more values means more noise**. With 500 values, every run is 500 chances for a false alarm. Small values are the worst offenders: something that averages 5 rows a day swings a lot in percentage terms, so it drifts in and out of range on its own. Stick to fields with a few stable values, and use [`where_expression`](/data-tests/anomaly-detection-configuration/where-expression) to leave out the rest.
 
 <Tip>
-  This test monitors **row count** per group. For a *column* metric — null rate, average, uniqueness — segmented per group, use [`column_anomalies`](/data-tests/anomaly-detection-tests/column-anomalies) with [`dimensions`](/data-tests/anomaly-detection-configuration/dimensions).
+  This test counts **rows** per value. To track something about a column instead — null rate, average, uniqueness — split by value, use [`column_anomalies`](/data-tests/anomaly-detection-tests/column-anomalies) with [`dimensions`](/data-tests/anomaly-detection-configuration/dimensions).
 </Tip>
 
-## Multiple dimensions monitor combinations
+## Listing two columns watches combinations
 
-Multiple dimensions do **not** create one test per column. Elementary concatenates them into a single composite value separated by `; `, and monitors each observed **combination** as one series. With `dimensions: [country, device_os]` the series are `US; ios`, `US; android`, `DE; ios`, and so on. `NULL` becomes the literal string `NULL`, so a spike in `US; NULL` is a real signal about missing `device_os`.
+Listing two columns does not test each column separately. Elementary joins them into one value with `; ` in between, then watches every combination it finds. With `dimensions: [country, device_os]`, what gets watched is `US; ios`, `US; android`, `DE; ios`, and so on. Empty values appear as the word `NULL`, so a jump in `US; NULL` is a real signal that `device_os` has gone missing.
 
 <Warning>
-  Series count multiplies: 20 countries and 10 operating systems is up to 200 series, each needing its own history, and each combination has lower counts than either column alone. Adding a second dimension monitors the *interaction* — it is not a shortcut for monitoring two fields. For that, define one test per field.
+  Combinations multiply fast. 20 countries and 10 operating systems is up to 200 things to watch, each needing its own history. Each combination also has fewer rows than either column on its own, which makes it noisier. Only list two columns when you want to watch the combination. To watch two fields, write two tests.
 </Warning>
 
 <Note>
-  The dimension list, **including its order**, is part of the identity of the collected metrics. Editing or reordering it means the test no longer matches its history and starts training from scratch. Treat it as creating a new test.
+  Elementary saves the history under the exact list you configured, in the exact order. If you add a column, remove one, or just reorder them, the test can no longer find its old history and starts collecting again from scratch. Changing this list is really creating a new test.
 </Note>
 
-## New and disappearing values
+## New and missing values
 
-- **A value disappears.** Once Elementary has seen a value, it writes an explicit `0` for buckets where the value has no rows. This is what makes disappearance detectable.
-- **A value appears.** A never-seen value gets no backfilled zeros — its series starts at first appearance, and with no history there is no expected range. **A new value cannot raise an anomaly on the run it first appears.** To catch unexpected categories, add an `accepted_values` test.
-- **A value stays gone.** A value whose entire history inside the window is zero drops out of tracking, so retired values stop alerting.
+- **A value goes missing.** Once Elementary has seen a value, it records a `0` for buckets where that value has no rows. This is what lets it spot a value that disappears.
+- **A new value shows up.** A value Elementary has never seen has no past to compare against, so **it cannot be flagged on the run where it first appears**. To catch unexpected new values, add an `accepted_values` test.
+- **A value stays gone.** Once a value has been at zero for the whole period, Elementary stops watching it, so retired values do not keep alerting.
 
-## The detection period overlaps the training period
+## A long detection period can hide problems
 
-The expected range at a bucket is calculated from that series' values **up to and including that bucket**. Harmless when [`detection_period`](/data-tests/anomaly-detection-configuration/detection-period) is a single bucket, costly beyond that.
+The expected range for a bucket is worked out from that value's numbers **up to and including that bucket**. That is fine when [`detection_period`](/data-tests/anomaly-detection-configuration/detection-period) covers a single bucket. It works against you when it covers several.
 
-An incident starts Monday and runs through Wednesday, with `detection_period: 3 days`. Monday is flagged, then joins the training data used to judge Tuesday — pulling the average up and the standard deviation wider. Wednesday is measured against a range the incident itself widened. **A sustained incident hides its own tail**: one alert, then silence that reads like recovery.
+Say something breaks on Monday and stays broken through Wednesday, with `detection_period: 3 days`. Monday gets flagged. Monday's bad number then becomes part of what Tuesday is compared against, pulling the average up and widening the range. By Wednesday the test is comparing against a range the problem itself stretched. **A long problem covers its own tracks** — you get one alert, then silence that looks like it was fixed.
 
 <Warning>
   If `detection_period` is longer than one time bucket, set [`exclude_detection_period_from_training`](/data-tests/anomaly-detection-configuration/exclude_detection_period_from_training) to `true`.
 </Warning>
 
-Two related constraints: a series with a single training value gets no score at all, so the default 14-day [`training_period`](/data-tests/anomaly-detection-configuration/training-period) is 14 buckets *per dimension value* — thin for values that appear sporadically. And [`seasonality`](/data-tests/anomaly-detection-configuration/seasonality) splits each series again by weekday, multiplying the history every value needs.
+Two related limits. A value with only one past data point cannot be checked at all, so the default 14-day [`training_period`](/data-tests/anomaly-detection-configuration/training-period) means 14 buckets *for each value* — not much for values that only show up now and then. And [`seasonality`](/data-tests/anomaly-detection-configuration/seasonality) splits each value again by day of week, so every value needs far more history.
 
 ## How to think about `detection_delay`
 
-[`detection_delay`](/data-tests/anomaly-detection-configuration/detection-delay) shifts the evaluated window back in time. The instinct is to always set a one-day delay so the test never scores a partial day — but **Elementary only ever evaluates complete time buckets**. With daily buckets and dbt running at 02:00, the newest scored bucket runs from yesterday 00:00 to today 00:00; today's two hours are never scored, with no delay configured.
+[`detection_delay`](/data-tests/anomaly-detection-configuration/detection-delay) moves the whole tested window further into the past. It is tempting to always set a one-day delay so the test never looks at a half-finished day — but **Elementary only ever tests finished buckets**. With daily buckets and dbt running at 02:00, the newest bucket tested is yesterday, midnight to midnight. Today's two hours are never tested, without setting anything.
 
-What a delay is for is **data that arrives after its bucket has closed**. If yesterday's load finishes at 04:00 and tests run at 02:00, yesterday's bucket is complete by the clock but incomplete in the warehouse, and every value looks like a drop.
+What a delay is really for is **data that shows up late**. If yesterday's load does not finish until 04:00 but your tests run at 02:00, yesterday looks finished on the calendar but is still missing rows in the warehouse, and every value looks like it dropped.
 
-It also snaps to bucket boundaries, so a sub-bucket delay is not a small adjustment. Daily buckets, dbt running at 02:00:
+A delay also only moves in whole buckets, so a small delay is not a small change. Daily buckets, dbt running at 02:00:
 
-| `detection_delay` | Detection boundary | Newest evaluated bucket |
+| `detection_delay` | Cutoff | Newest bucket tested |
 | --- | --- | --- |
 | none | today 02:00 | **yesterday** |
 | 4 hours | yesterday 22:00 | day before yesterday |
 | 1 day | yesterday 02:00 | day before yesterday |
 
-A four-hour delay pushes the boundary back before midnight and costs a full day of freshness, the same as asking for a whole day. So reason in whole buckets: no delay when the load reliably finishes before the tests run (the common case, and the default), one bucket when late-arriving data is normal and you accept hearing about yesterday tomorrow.
+A four-hour delay pushes the cutoff back past midnight, so it costs you a whole day — the same as asking for one. So think in whole days: no delay when your data reliably lands before the tests run (the usual case, and the default), one day when late data is normal and you are fine hearing about yesterday tomorrow.
 
 <Tip>
-  First check whether a different timestamp removes the problem outright. If `timestamp_column` is an *event* time (`occurred_at`) but rows land hours later, switch to a *load* time (`loaded_at`). Bucketing by arrival keeps detection current instead of waiting late data out.
+  Before adding a delay, see whether a different column solves it. If `timestamp_column` is when something happened (`occurred_at`) but the rows only land hours later, switch to when it was loaded (`loaded_at`). Grouping by arrival time avoids the problem instead of waiting it out.
 </Tip>
 
 <Note>
-  Bucket boundaries and the detection boundary are not derived the same way: buckets start at midnight of a calendar date, while the detection boundary carries the dbt invocation time, which dbt reports in UTC. If your `timestamp_column` is not stored in UTC, confirm which bucket your test actually scores — depending on your warehouse and the column's type, the newest bucket can be evaluated before it has closed in the column's own timezone. That is a real case for a delay.
+  Time buckets are built from calendar dates, but the cutoff for "how recent" comes from when dbt started running, and dbt uses UTC. If your timestamp column holds local time rather than UTC, the newest day can get tested before that day has actually ended where your data lives. Check which day your test is really looking at, and add a delay if it is testing too early.
 </Note>
 
-## Without a `timestamp_column`
+## With no `timestamp_column`
 
-The test counts rows per value across the whole table and stores one point per run. Training is built from **previous runs**, so the default 14-day period needs roughly 14 runs on separate days, and `time_bucket`, `detection_delay` and the period parameters have no buckets to act on. Use this mode for dimension tables and reference data. For anything append-only, configure a `timestamp_column`.
+The test counts rows per value across the whole table and saves one number per run. Its history is built from **past runs**, so a 14-day training period needs roughly 14 runs on different days. `time_bucket`, `detection_delay` and the period settings have no buckets to work with. Use this for dimension tables and reference data. If rows are only ever added, set a `timestamp_column`.
 
 ## Reading a failure
 
@@ -95,7 +95,7 @@ The test counts rows per value across the whole table and stores one point per r
 US; ios (0.0, avg 48120.4), DE; android (91204.0, avg 3410.2), JP; ios (0.0, avg 96.7)
 ```
 
-- **The failure count is anomalous bucket/value pairs**, not affected values — one value anomalous across three buckets counts as three failures.
-- **Stored results include each affected value's full series**, not only the anomalous buckets, so the report and alert graph show the anomaly in context.
+- **The failure count counts buckets, not values.** One value that looks wrong across three buckets counts as three failures.
+- **The results include each affected value's whole history**, not just the bad buckets, so the report and the alert graph can show the problem in context.
 
-To inspect collected metrics and scores directly, see the [anomaly tests troubleshooting guide](/data-tests/anomaly-detection-tests/Anomaly-troubleshooting-guide).
+To look at the collected numbers and scores yourself, see the [anomaly tests troubleshooting guide](/data-tests/anomaly-detection-tests/Anomaly-troubleshooting-guide).

--- a/docs/data-tests/anomaly-detection-tests/understanding-dimension-anomalies.mdx
+++ b/docs/data-tests/anomaly-detection-tests/understanding-dimension-anomalies.mdx
@@ -7,121 +7,66 @@ import AiGenerateTest from '/snippets/ai-generate-test.mdx';
 
 <AiGenerateTest />
 
-`dimension_anomalies` monitors the **distribution** of values in a field over time, not the size of the table. It catches problems that volume tests structurally cannot see: one country stops reporting, a payment provider drops to zero, a new enum value appears from an upstream schema change — all while the total row count stays flat.
+`dimension_anomalies` monitors the **distribution** of values in a field over time, not the size of the table. It catches what volume tests structurally cannot see: one country stops reporting, a payment provider drops to zero, a new enum value appears upstream — all while the total row count stays flat.
 
-That extra power comes with configuration decisions that don't exist in the other anomaly tests. This page explains what the test does per dimension value, how multiple dimensions combine, and how to reason about the delay and period parameters. For the parameter list itself, see [dimension_anomalies](/data-tests/anomaly-detection-tests/dimension-anomalies).
+For the parameter list, see [dimension_anomalies](/data-tests/anomaly-detection-tests/dimension-anomalies). This page covers the decisions that don't exist in the other anomaly tests.
 
 ## One independent test per dimension value
 
-The test counts rows grouped by your `dimensions`, per [time bucket](/data-tests/anomaly-detection-configuration/time-bucket). Every distinct dimension value becomes its **own metric series with its own training set, its own expected range, and its own anomaly score**.
-
-Given `dimensions: [country]` on a daily bucket:
+The test counts rows grouped by your `dimensions`, per [time bucket](/data-tests/anomaly-detection-configuration/time-bucket). Every distinct dimension value becomes its own series, with its own training set and expected range.
 
 | `bucket_end` | `dimension_value` | `metric_value` |
 | --- | --- | --- |
 | 2026-03-01 | `US` | 48,120 |
-| 2026-03-01 | `DE` | 3,301 |
 | 2026-03-01 | `JP` | 96 |
 | 2026-03-02 | `US` | 47,880 |
-| 2026-03-02 | `DE` | 3,410 |
 | 2026-03-02 | `JP` | 0 |
 
-`JP` dropping to zero is evaluated only against `JP`'s own history. It is flagged even though the table's total row count barely moved — which is exactly the point of the test.
+`JP` dropping to zero is scored only against `JP`'s own history, so it is flagged even though the table's total barely moved. That is the point of the test.
 
-The practical consequence is that **noise scales with the number of dimension values**. A dimension with 500 values is 500 chances per run to produce a false positive, and the small-volume values are the noisiest: a series that normally sits at 5 rows a day has a large relative standard deviation, so it flips in and out of the expected range on its own. Prefer fields with a handful of stable values, and use [`where_expression`](/data-tests/anomaly-detection-configuration/where-expression) to scope the test to the values you actually care about.
+The cost is that **noise scales with cardinality**. 500 values is 500 chances per run for a false positive, and the low-volume values are the noisiest: a series that normally sits at 5 rows a day has a large relative standard deviation and drifts in and out of range on its own. Prefer a handful of stable values, and scope with [`where_expression`](/data-tests/anomaly-detection-configuration/where-expression).
 
 <Tip>
-  `dimension_anomalies` monitors **row count** per group. If you want a *column* metric — null rate, average, uniqueness — segmented per group, use [`column_anomalies`](/data-tests/anomaly-detection-tests/column-anomalies) with the [`dimensions`](/data-tests/anomaly-detection-configuration/dimensions) parameter instead.
+  This test monitors **row count** per group. For a *column* metric — null rate, average, uniqueness — segmented per group, use [`column_anomalies`](/data-tests/anomaly-detection-tests/column-anomalies) with [`dimensions`](/data-tests/anomaly-detection-configuration/dimensions).
 </Tip>
 
-## What happens with multiple dimensions
+## Multiple dimensions monitor combinations
 
-Multiple dimensions do **not** create one test per column. Elementary concatenates the columns into a single composite value, separated by `; `, and monitors each observed **combination** as one series.
-
-With this configuration:
-
-```yaml
-models:
-  - name: login_events
-    config:
-      elementary:
-        timestamp_column: loaded_at
-    data_tests:
-      - elementary.dimension_anomalies:
-          arguments:
-            dimensions:
-              - country
-              - device_os
-```
-
-the monitored series are `US; ios`, `US; android`, `DE; ios`, and so on. `NULL` values are rendered as the literal string `NULL`, so `US; NULL` is a legitimate series and a spike in it is a real signal about missing `device_os`.
+Multiple dimensions do **not** create one test per column. Elementary concatenates them into a single composite value separated by `; `, and monitors each observed **combination** as one series. With `dimensions: [country, device_os]` the series are `US; ios`, `US; android`, `DE; ios`, and so on. `NULL` becomes the literal string `NULL`, so a spike in `US; NULL` is a real signal about missing `device_os`.
 
 <Warning>
-  Series count multiplies. Two dimensions of 20 and 10 values are up to 200 series, each needing its own training history and its own row per bucket in the metrics table. Combinations also have lower counts than either column alone, which makes them individually noisier. Adding a second dimension is a decision to monitor the *interaction*, not a shortcut for monitoring two fields.
+  Series count multiplies: 20 countries and 10 operating systems is up to 200 series, each needing its own history, and each combination has lower counts than either column alone. Adding a second dimension monitors the *interaction* — it is not a shortcut for monitoring two fields. For that, define one test per field.
 </Warning>
 
-If you want each field monitored independently, define **separate tests**:
-
-```yaml
-data_tests:
-  - elementary.dimension_anomalies:
-      arguments:
-        dimensions:
-          - country
-  - elementary.dimension_anomalies:
-      arguments:
-        dimensions:
-          - device_os
-```
-
-This gives you 30 series instead of 200, and an alert names the field that broke rather than a combination you have to decompose.
-
 <Note>
-  The dimension list is part of the identity of the collected metrics — including its **order**. Editing the list, or reordering it, means the test no longer matches its previously collected history and starts building a training set from scratch. Treat a change to `dimensions` as creating a new test, not tuning an existing one.
+  The dimension list, **including its order**, is part of the identity of the collected metrics. Editing or reordering it means the test no longer matches its history and starts training from scratch. Treat it as creating a new test.
 </Note>
 
-## How the history of a dimension value behaves
+## New and disappearing values
 
-Dimension values come and go, and the test handles the two directions asymmetrically.
+- **A value disappears.** Once Elementary has seen a value, it writes an explicit `0` for buckets where the value has no rows. This is what makes disappearance detectable.
+- **A value appears.** A never-seen value gets no backfilled zeros — its series starts at first appearance, and with no history there is no expected range. **A new value cannot raise an anomaly on the run it first appears.** To catch unexpected categories, add an `accepted_values` test.
+- **A value stays gone.** A value whose entire history inside the window is zero drops out of tracking, so retired values stop alerting.
 
-- **A value disappears.** Once Elementary has seen a dimension value, it writes an explicit `0` for buckets where the value has no rows. This is what makes disappearance detectable: the series drops to zero and is scored against its own history.
-- **A value appears.** A value that has never been seen has no backfilled zeros — its series simply starts at first appearance. With no history there is no expected range, so **a brand new dimension value does not raise an anomaly on the run it first appears**. It becomes monitorable once enough buckets accumulate.
-- **A value stays gone.** A value whose entire history inside the training window is zero is dropped from tracking, so a retired value stops generating alerts once it ages out of the window.
+## The detection period overlaps the training period
 
-<Note>
-  This means the test detects *new* values only indirectly — by the effect they have on the values that lost volume to them. If detecting unexpected new categories is the goal, pair this test with an [`accepted_values`](https://docs.getdbt.com/reference/resource-properties/data-tests) test on the same column.
-</Note>
+The expected range at a bucket is calculated from that series' values **up to and including that bucket**. Harmless when [`detection_period`](/data-tests/anomaly-detection-configuration/detection-period) is a single bucket, costly beyond that.
 
-## Training period, detection period, and the overlap between them
-
-For each series, the expected range at a given bucket is calculated from that series' values **up to and including that bucket**, within the [`training_period`](/data-tests/anomaly-detection-configuration/training-period). Buckets inside the [`detection_period`](/data-tests/anomaly-detection-configuration/detection-period) are the ones eligible to be flagged.
-
-Since the training window runs up to the bucket being evaluated, the two periods overlap by default. That overlap is harmless when `detection_period` is a single bucket, but it works against you as soon as it spans several:
-
-An incident starts on Monday and continues through Wednesday, with `detection_period: 3 days`. Monday's inflated value is flagged. It then joins the training data used to evaluate Tuesday, pulling the average up and the standard deviation wider. Wednesday is evaluated against a range that the incident itself widened. **A sustained incident hides its own tail** — you get an alert on day one and silence afterwards, which reads like a resolved blip rather than an ongoing failure.
-
-Set [`exclude_detection_period_from_training`](/data-tests/anomaly-detection-configuration/exclude_detection_period_from_training) to `true` to remove every detection-period bucket from the training calculation, so all three days are judged against pre-incident history only.
+An incident starts Monday and runs through Wednesday, with `detection_period: 3 days`. Monday is flagged, then joins the training data used to judge Tuesday — pulling the average up and the standard deviation wider. Wednesday is measured against a range the incident itself widened. **A sustained incident hides its own tail**: one alert, then silence that reads like recovery.
 
 <Warning>
-  If your `detection_period` is longer than one time bucket, set `exclude_detection_period_from_training: true`. Leaving it off produces false negatives on exactly the multi-day incidents you most want to catch.
+  If `detection_period` is longer than one time bucket, set [`exclude_detection_period_from_training`](/data-tests/anomaly-detection-configuration/exclude_detection_period_from_training) to `true`.
 </Warning>
 
-Two more things worth knowing about the training set:
-
-- **Every series needs its own history.** A series with a single training value gets no score at all. With `dimensions`, the default 14-day `training_period` is 14 daily buckets *per dimension value* — fine for values present every day, thin for values that appear sporadically.
-- **[Seasonality](/data-tests/anomaly-detection-configuration/seasonality) multiplies the requirement.** `seasonality: day_of_week` splits each series again by weekday, so a dimension value is compared only to the same weekday. Elementary extends the training period to compensate, but combining seasonality with many dimension values needs substantially more history before the test is useful.
+Two related constraints: a series with a single training value gets no score at all, so the default 14-day [`training_period`](/data-tests/anomaly-detection-configuration/training-period) is 14 buckets *per dimension value* — thin for values that appear sporadically. And [`seasonality`](/data-tests/anomaly-detection-configuration/seasonality) splits each series again by weekday, multiplying the history every value needs.
 
 ## How to think about `detection_delay`
 
-[`detection_delay`](/data-tests/anomaly-detection-configuration/detection-delay) shifts the whole evaluated window back in time. The instinct is to always set a one-day delay so the test never scores a partial day — but that isn't necessary, because **Elementary only ever evaluates complete time buckets**.
+[`detection_delay`](/data-tests/anomaly-detection-configuration/detection-delay) shifts the evaluated window back in time. The instinct is to always set a one-day delay so the test never scores a partial day — but **Elementary only ever evaluates complete time buckets**. With daily buckets and dbt running at 02:00, the newest scored bucket runs from yesterday 00:00 to today 00:00; today's two hours are never scored, with no delay configured.
 
-The newest bucket the test considers is the last one whose *end* falls at or before the invocation time (minus the delay). With daily buckets and dbt running at 02:00, the newest evaluated bucket runs from yesterday 00:00 to today 00:00, and today's two hours of data are never scored. No delay required.
+What a delay is for is **data that arrives after its bucket has closed**. If yesterday's load finishes at 04:00 and tests run at 02:00, yesterday's bucket is complete by the clock but incomplete in the warehouse, and every value looks like a drop.
 
-What the delay is actually for is **data that arrives after the bucket it belongs to has closed**. If yesterday's load only finishes at 04:00 and your tests run at 02:00, yesterday's bucket is complete by the clock but incomplete in the warehouse, and every dimension value looks like a drop.
-
-### The delay snaps to bucket boundaries
-
-A delay smaller than one bucket is rarely a small adjustment. Daily buckets, dbt running at 02:00:
+It also snaps to bucket boundaries, so a sub-bucket delay is not a small adjustment. Daily buckets, dbt running at 02:00:
 
 | `detection_delay` | Detection boundary | Newest evaluated bucket |
 | --- | --- | --- |
@@ -129,69 +74,28 @@ A delay smaller than one bucket is rarely a small adjustment. Daily buckets, dbt
 | 4 hours | yesterday 22:00 | day before yesterday |
 | 1 day | yesterday 02:00 | day before yesterday |
 
-A four-hour delay pushes the boundary back before midnight, so it costs a full day of freshness — the same as asking for a whole day. Any delay is worth reasoning about in whole buckets.
-
-### Choosing a delay
-
-The trade-off is real and there is no setting that avoids it: a delay buys completeness and pays in detection latency.
-
-- **No delay** is correct when the pipeline that populates a bucket reliably finishes before the tests run. This is the common case, and it is the default for a reason.
-- **A one-bucket delay** is correct when late-arriving data is normal — event data with a long ingestion tail, a source you don't control, a loader that sometimes finishes after the test. You accept finding out about yesterday tomorrow, in exchange for not being paged every morning by an artifact of scheduling.
+A four-hour delay pushes the boundary back before midnight and costs a full day of freshness, the same as asking for a whole day. So reason in whole buckets: no delay when the load reliably finishes before the tests run (the common case, and the default), one bucket when late-arriving data is normal and you accept hearing about yesterday tomorrow.
 
 <Tip>
-  Before reaching for a delay, check whether a different timestamp fixes the problem outright. If `timestamp_column` is an *event* time (`occurred_at`) but rows land hours later, switch to a *load* time (`loaded_at`, `_synced_at`). Bucketing by when rows arrived removes the late-data problem instead of waiting it out, and keeps detection current.
+  First check whether a different timestamp removes the problem outright. If `timestamp_column` is an *event* time (`occurred_at`) but rows land hours later, switch to a *load* time (`loaded_at`). Bucketing by arrival keeps detection current instead of waiting late data out.
 </Tip>
 
 <Note>
-  The detection boundary comes from the dbt invocation time, which dbt reports in UTC, while buckets are aligned to midnight in the values of your `timestamp_column`. If that column holds local time, the newest bucket can be evaluated before it is actually complete. This is a genuine case for a delay.
+  The boundary comes from the dbt invocation time, which dbt reports in UTC, while buckets align to midnight in the values of your `timestamp_column`. A local-time column can therefore be scored before it is complete — a genuine case for a delay.
 </Note>
-
-<Warning>
-  A delay does not shorten the periods, it moves them. With `detection_delay: 1 day`, an incident inside the skipped bucket is not caught late — it is caught on the *next* run, once that bucket enters the window. Make sure your delay plus your run cadence still evaluates every bucket.
-</Warning>
 
 ## Without a `timestamp_column`
 
-If no `timestamp_column` is configured, the test counts rows per dimension value across the whole table and stores one point per run. There are no time buckets: the training set is built from **previous runs**, so the default 14-day training period means roughly 14 runs on separate days before the test has a full training set. `time_bucket`, `detection_delay`, and the period parameters have no bucketing to act on.
-
-Use this mode for dimension tables and slowly changing reference data, where "how many rows does each category have right now" is the meaningful question. For anything append-only, configure a `timestamp_column`.
+The test counts rows per value across the whole table and stores one point per run. Training is built from **previous runs**, so the default 14-day period needs roughly 14 runs on separate days, and `time_bucket`, `detection_delay` and the period parameters have no buckets to act on. Use this mode for dimension tables and reference data. For anything append-only, configure a `timestamp_column`.
 
 ## Reading a failure
-
-The failure description names the affected values, with the observed metric and the training average:
 
 ```
 3 anomalous dimension values for dimension country; device_os:
 US; ios (0.0, avg 48120.4), DE; android (91204.0, avg 3410.2), JP; ios (0.0, avg 96.7)
 ```
 
-Two details in the results are specific to this test:
+- **The failure count is anomalous bucket/value pairs**, not affected values — one value anomalous across three buckets counts as three failures.
+- **Stored results include each affected value's full series**, not only the anomalous buckets, so the report and alert graph show the anomaly in context.
 
-- **The failure count is the number of anomalous bucket/value pairs**, not the number of affected dimension values. One value anomalous across three buckets counts as three failures.
-- **The stored results include the full series for every affected dimension value**, not just the anomalous buckets. This is deliberate: it lets the report and the alert graph show the anomaly in the context of that value's normal behavior.
-
-For queries to inspect collected metrics and scores directly, see the [anomaly tests troubleshooting guide](/data-tests/anomaly-detection-tests/Anomaly-troubleshooting-guide).
-
-## Configuration checklist
-
-<AccordionGroup>
-  <Accordion title="Rolling out a new dimension test">
-    1. Pick a **low-cardinality, stable** field. Check `count(distinct ...)` first.
-    2. Use one test per field unless you specifically want to monitor the interaction.
-    3. Scope with [`where_expression`](/data-tests/anomaly-detection-configuration/where-expression) to drop values you don't care about.
-    4. Configure a [`timestamp_column`](/data-tests/anomaly-detection-configuration/timestamp-column) that reflects when rows *arrived*, unless the model is a dimension table.
-    5. Start with `severity: warn` and let the training set build before promoting to `error`.
-  </Accordion>
-  <Accordion title="Tuning a noisy dimension test">
-    - Raise [`anomaly_sensitivity`](/data-tests/anomaly-detection-configuration/anomaly-sensitivity), or set [`ignore_small_changes`](/data-tests/anomaly-detection-configuration/ignore_small_changes) so small absolute moves in low-volume values are ignored.
-    - Set [`anomaly_direction`](/data-tests/anomaly-detection-configuration/anomaly-direction) to `drop` if only disappearing data matters.
-    - Increase [`training_period`](/data-tests/anomaly-detection-configuration/training-period) to widen the expected range with a larger sample.
-    - Filter out the long tail of rare values with [`where_expression`](/data-tests/anomaly-detection-configuration/where-expression), or use a coarser grouping expression.
-  </Accordion>
-  <Accordion title="Tuning a test that misses incidents">
-    - Set [`exclude_detection_period_from_training`](/data-tests/anomaly-detection-configuration/exclude_detection_period_from_training) to `true` if `detection_period` spans more than one bucket.
-    - Lower [`anomaly_sensitivity`](/data-tests/anomaly-detection-configuration/anomaly-sensitivity).
-    - Use a smaller [`time_bucket`](/data-tests/anomaly-detection-configuration/time-bucket) so a partial-day outage isn't averaged away inside a daily count.
-    - Check that the delay isn't larger than it needs to be, and that the values you expected to be monitored actually have enough history.
-  </Accordion>
-</AccordionGroup>
+To inspect collected metrics and scores directly, see the [anomaly tests troubleshooting guide](/data-tests/anomaly-detection-tests/Anomaly-troubleshooting-guide).

--- a/docs/data-tests/anomaly-detection-tests/understanding-dimension-anomalies.mdx
+++ b/docs/data-tests/anomaly-detection-tests/understanding-dimension-anomalies.mdx
@@ -1,0 +1,197 @@
+---
+title: "Understanding dimension anomalies"
+sidebarTitle: "Understanding dimension anomalies"
+---
+
+import AiGenerateTest from '/snippets/ai-generate-test.mdx';
+
+<AiGenerateTest />
+
+`dimension_anomalies` monitors the **distribution** of values in a field over time, not the size of the table. It catches problems that volume tests structurally cannot see: one country stops reporting, a payment provider drops to zero, a new enum value appears from an upstream schema change — all while the total row count stays flat.
+
+That extra power comes with configuration decisions that don't exist in the other anomaly tests. This page explains what the test does per dimension value, how multiple dimensions combine, and how to reason about the delay and period parameters. For the parameter list itself, see [dimension_anomalies](/data-tests/anomaly-detection-tests/dimension-anomalies).
+
+## One independent test per dimension value
+
+The test counts rows grouped by your `dimensions`, per [time bucket](/data-tests/anomaly-detection-configuration/time-bucket). Every distinct dimension value becomes its **own metric series with its own training set, its own expected range, and its own anomaly score**.
+
+Given `dimensions: [country]` on a daily bucket:
+
+| `bucket_end` | `dimension_value` | `metric_value` |
+| --- | --- | --- |
+| 2026-03-01 | `US` | 48,120 |
+| 2026-03-01 | `DE` | 3,301 |
+| 2026-03-01 | `JP` | 96 |
+| 2026-03-02 | `US` | 47,880 |
+| 2026-03-02 | `DE` | 3,410 |
+| 2026-03-02 | `JP` | 0 |
+
+`JP` dropping to zero is evaluated only against `JP`'s own history. It is flagged even though the table's total row count barely moved — which is exactly the point of the test.
+
+The practical consequence is that **noise scales with the number of dimension values**. A dimension with 500 values is 500 chances per run to produce a false positive, and the small-volume values are the noisiest: a series that normally sits at 5 rows a day has a large relative standard deviation, so it flips in and out of the expected range on its own. Prefer fields with a handful of stable values, and use [`where_expression`](/data-tests/anomaly-detection-configuration/where-expression) to scope the test to the values you actually care about.
+
+<Tip>
+  `dimension_anomalies` monitors **row count** per group. If you want a *column* metric — null rate, average, uniqueness — segmented per group, use [`column_anomalies`](/data-tests/anomaly-detection-tests/column-anomalies) with the [`dimensions`](/data-tests/anomaly-detection-configuration/dimensions) parameter instead.
+</Tip>
+
+## What happens with multiple dimensions
+
+Multiple dimensions do **not** create one test per column. Elementary concatenates the columns into a single composite value, separated by `; `, and monitors each observed **combination** as one series.
+
+With this configuration:
+
+```yaml
+models:
+  - name: login_events
+    config:
+      elementary:
+        timestamp_column: loaded_at
+    data_tests:
+      - elementary.dimension_anomalies:
+          arguments:
+            dimensions:
+              - country
+              - device_os
+```
+
+the monitored series are `US; ios`, `US; android`, `DE; ios`, and so on. `NULL` values are rendered as the literal string `NULL`, so `US; NULL` is a legitimate series and a spike in it is a real signal about missing `device_os`.
+
+<Warning>
+  Series count multiplies. Two dimensions of 20 and 10 values are up to 200 series, each needing its own training history and its own row per bucket in the metrics table. Combinations also have lower counts than either column alone, which makes them individually noisier. Adding a second dimension is a decision to monitor the *interaction*, not a shortcut for monitoring two fields.
+</Warning>
+
+If you want each field monitored independently, define **separate tests**:
+
+```yaml
+data_tests:
+  - elementary.dimension_anomalies:
+      arguments:
+        dimensions:
+          - country
+  - elementary.dimension_anomalies:
+      arguments:
+        dimensions:
+          - device_os
+```
+
+This gives you 30 series instead of 200, and an alert names the field that broke rather than a combination you have to decompose.
+
+<Note>
+  The dimension list is part of the identity of the collected metrics — including its **order**. Editing the list, or reordering it, means the test no longer matches its previously collected history and starts building a training set from scratch. Treat a change to `dimensions` as creating a new test, not tuning an existing one.
+</Note>
+
+## How the history of a dimension value behaves
+
+Dimension values come and go, and the test handles the two directions asymmetrically.
+
+- **A value disappears.** Once Elementary has seen a dimension value, it writes an explicit `0` for buckets where the value has no rows. This is what makes disappearance detectable: the series drops to zero and is scored against its own history.
+- **A value appears.** A value that has never been seen has no backfilled zeros — its series simply starts at first appearance. With no history there is no expected range, so **a brand new dimension value does not raise an anomaly on the run it first appears**. It becomes monitorable once enough buckets accumulate.
+- **A value stays gone.** A value whose entire history inside the training window is zero is dropped from tracking, so a retired value stops generating alerts once it ages out of the window.
+
+<Note>
+  This means the test detects *new* values only indirectly — by the effect they have on the values that lost volume to them. If detecting unexpected new categories is the goal, pair this test with an [`accepted_values`](https://docs.getdbt.com/reference/resource-properties/data-tests) test on the same column.
+</Note>
+
+## Training period, detection period, and the overlap between them
+
+For each series, the expected range at a given bucket is calculated from that series' values **up to and including that bucket**, within the [`training_period`](/data-tests/anomaly-detection-configuration/training-period). Buckets inside the [`detection_period`](/data-tests/anomaly-detection-configuration/detection-period) are the ones eligible to be flagged.
+
+Since the training window runs up to the bucket being evaluated, the two periods overlap by default. That overlap is harmless when `detection_period` is a single bucket, but it works against you as soon as it spans several:
+
+An incident starts on Monday and continues through Wednesday, with `detection_period: 3 days`. Monday's inflated value is flagged. It then joins the training data used to evaluate Tuesday, pulling the average up and the standard deviation wider. Wednesday is evaluated against a range that the incident itself widened. **A sustained incident hides its own tail** — you get an alert on day one and silence afterwards, which reads like a resolved blip rather than an ongoing failure.
+
+Set [`exclude_detection_period_from_training`](/data-tests/anomaly-detection-configuration/exclude_detection_period_from_training) to `true` to remove every detection-period bucket from the training calculation, so all three days are judged against pre-incident history only.
+
+<Warning>
+  If your `detection_period` is longer than one time bucket, set `exclude_detection_period_from_training: true`. Leaving it off produces false negatives on exactly the multi-day incidents you most want to catch.
+</Warning>
+
+Two more things worth knowing about the training set:
+
+- **Every series needs its own history.** A series with a single training value gets no score at all. With `dimensions`, the default 14-day `training_period` is 14 daily buckets *per dimension value* — fine for values present every day, thin for values that appear sporadically.
+- **[Seasonality](/data-tests/anomaly-detection-configuration/seasonality) multiplies the requirement.** `seasonality: day_of_week` splits each series again by weekday, so a dimension value is compared only to the same weekday. Elementary extends the training period to compensate, but combining seasonality with many dimension values needs substantially more history before the test is useful.
+
+## How to think about `detection_delay`
+
+[`detection_delay`](/data-tests/anomaly-detection-configuration/detection-delay) shifts the whole evaluated window back in time. The instinct is to always set a one-day delay so the test never scores a partial day — but that isn't necessary, because **Elementary only ever evaluates complete time buckets**.
+
+The newest bucket the test considers is the last one whose *end* falls at or before the invocation time (minus the delay). With daily buckets and dbt running at 02:00, the newest evaluated bucket runs from yesterday 00:00 to today 00:00, and today's two hours of data are never scored. No delay required.
+
+What the delay is actually for is **data that arrives after the bucket it belongs to has closed**. If yesterday's load only finishes at 04:00 and your tests run at 02:00, yesterday's bucket is complete by the clock but incomplete in the warehouse, and every dimension value looks like a drop.
+
+### The delay snaps to bucket boundaries
+
+A delay smaller than one bucket is rarely a small adjustment. Daily buckets, dbt running at 02:00:
+
+| `detection_delay` | Detection boundary | Newest evaluated bucket |
+| --- | --- | --- |
+| none | today 02:00 | **yesterday** |
+| 4 hours | yesterday 22:00 | day before yesterday |
+| 1 day | yesterday 02:00 | day before yesterday |
+
+A four-hour delay pushes the boundary back before midnight, so it costs a full day of freshness — the same as asking for a whole day. Any delay is worth reasoning about in whole buckets.
+
+### Choosing a delay
+
+The trade-off is real and there is no setting that avoids it: a delay buys completeness and pays in detection latency.
+
+- **No delay** is correct when the pipeline that populates a bucket reliably finishes before the tests run. This is the common case, and it is the default for a reason.
+- **A one-bucket delay** is correct when late-arriving data is normal — event data with a long ingestion tail, a source you don't control, a loader that sometimes finishes after the test. You accept finding out about yesterday tomorrow, in exchange for not being paged every morning by an artifact of scheduling.
+
+<Tip>
+  Before reaching for a delay, check whether a different timestamp fixes the problem outright. If `timestamp_column` is an *event* time (`occurred_at`) but rows land hours later, switch to a *load* time (`loaded_at`, `_synced_at`). Bucketing by when rows arrived removes the late-data problem instead of waiting it out, and keeps detection current.
+</Tip>
+
+<Note>
+  The detection boundary comes from the dbt invocation time, which dbt reports in UTC, while buckets are aligned to midnight in the values of your `timestamp_column`. If that column holds local time, the newest bucket can be evaluated before it is actually complete. This is a genuine case for a delay.
+</Note>
+
+<Warning>
+  A delay does not shorten the periods, it moves them. With `detection_delay: 1 day`, an incident inside the skipped bucket is not caught late — it is caught on the *next* run, once that bucket enters the window. Make sure your delay plus your run cadence still evaluates every bucket.
+</Warning>
+
+## Without a `timestamp_column`
+
+If no `timestamp_column` is configured, the test counts rows per dimension value across the whole table and stores one point per run. There are no time buckets: the training set is built from **previous runs**, so the default 14-day training period means roughly 14 runs on separate days before the test has a full training set. `time_bucket`, `detection_delay`, and the period parameters have no bucketing to act on.
+
+Use this mode for dimension tables and slowly changing reference data, where "how many rows does each category have right now" is the meaningful question. For anything append-only, configure a `timestamp_column`.
+
+## Reading a failure
+
+The failure description names the affected values, with the observed metric and the training average:
+
+```
+3 anomalous dimension values for dimension country; device_os:
+US; ios (0.0, avg 48120.4), DE; android (91204.0, avg 3410.2), JP; ios (0.0, avg 96.7)
+```
+
+Two details in the results are specific to this test:
+
+- **The failure count is the number of anomalous bucket/value pairs**, not the number of affected dimension values. One value anomalous across three buckets counts as three failures.
+- **The stored results include the full series for every affected dimension value**, not just the anomalous buckets. This is deliberate: it lets the report and the alert graph show the anomaly in the context of that value's normal behavior.
+
+For queries to inspect collected metrics and scores directly, see the [anomaly tests troubleshooting guide](/data-tests/anomaly-detection-tests/Anomaly-troubleshooting-guide).
+
+## Configuration checklist
+
+<AccordionGroup>
+  <Accordion title="Rolling out a new dimension test">
+    1. Pick a **low-cardinality, stable** field. Check `count(distinct ...)` first.
+    2. Use one test per field unless you specifically want to monitor the interaction.
+    3. Scope with [`where_expression`](/data-tests/anomaly-detection-configuration/where-expression) to drop values you don't care about.
+    4. Configure a [`timestamp_column`](/data-tests/anomaly-detection-configuration/timestamp-column) that reflects when rows *arrived*, unless the model is a dimension table.
+    5. Start with `severity: warn` and let the training set build before promoting to `error`.
+  </Accordion>
+  <Accordion title="Tuning a noisy dimension test">
+    - Raise [`anomaly_sensitivity`](/data-tests/anomaly-detection-configuration/anomaly-sensitivity), or set [`ignore_small_changes`](/data-tests/anomaly-detection-configuration/ignore_small_changes) so small absolute moves in low-volume values are ignored.
+    - Set [`anomaly_direction`](/data-tests/anomaly-detection-configuration/anomaly-direction) to `drop` if only disappearing data matters.
+    - Increase [`training_period`](/data-tests/anomaly-detection-configuration/training-period) to widen the expected range with a larger sample.
+    - Filter out the long tail of rare values with [`where_expression`](/data-tests/anomaly-detection-configuration/where-expression), or use a coarser grouping expression.
+  </Accordion>
+  <Accordion title="Tuning a test that misses incidents">
+    - Set [`exclude_detection_period_from_training`](/data-tests/anomaly-detection-configuration/exclude_detection_period_from_training) to `true` if `detection_period` spans more than one bucket.
+    - Lower [`anomaly_sensitivity`](/data-tests/anomaly-detection-configuration/anomaly-sensitivity).
+    - Use a smaller [`time_bucket`](/data-tests/anomaly-detection-configuration/time-bucket) so a partial-day outage isn't averaged away inside a daily count.
+    - Check that the delay isn't larger than it needs to be, and that the values you expected to be monitored actually have enough history.
+  </Accordion>
+</AccordionGroup>

--- a/docs/data-tests/anomaly-detection-tests/understanding-dimension-anomalies.mdx
+++ b/docs/data-tests/anomaly-detection-tests/understanding-dimension-anomalies.mdx
@@ -81,7 +81,7 @@ A four-hour delay pushes the boundary back before midnight and costs a full day 
 </Tip>
 
 <Note>
-  The boundary comes from the dbt invocation time, which dbt reports in UTC, while buckets align to midnight in the values of your `timestamp_column`. A local-time column can therefore be scored before it is complete — a genuine case for a delay.
+  Bucket boundaries and the detection boundary are not derived the same way: buckets start at midnight of a calendar date, while the detection boundary carries the dbt invocation time, which dbt reports in UTC. If your `timestamp_column` is not stored in UTC, confirm which bucket your test actually scores — depending on your warehouse and the column's type, the newest bucket can be evaluated before it has closed in the column's own timezone. That is a real case for a delay.
 </Note>
 
 ## Without a `timestamp_column`

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -417,6 +417,7 @@
               "data-tests/anomaly-detection-tests/freshness-anomalies",
               "data-tests/anomaly-detection-tests/event-freshness-anomalies",
               "data-tests/anomaly-detection-tests/dimension-anomalies",
+              "data-tests/anomaly-detection-tests/understanding-dimension-anomalies",
               "data-tests/anomaly-detection-tests/all-columns-anomalies",
               "data-tests/anomaly-detection-tests/column-anomalies",
               "data-tests/anomaly-detection-tests/Anomaly-troubleshooting-guide"


### PR DESCRIPTION
Adds a conceptual guide for `dimension_anomalies` — the test with the most configuration nuance and the sparsest docs. Written to be sendable to a team member who needs to understand the test, not just look up a parameter.

Behaviour was verified against the macros in `dbt-data-reliability`, because two of the three areas below have answers that are non-obvious from the reference pages.

## What it covers

**Multiple dimensions produce one composite series per observed combination, not one series per column.** Columns are concatenated with `; ` (NULLs rendered as the literal `NULL`), so `[country, device_os]` monitors `US; ios`, `US; android`, … Series count multiplies, and combinations are individually noisier than either column alone. Also documented: the dimension list — *including its order* — is part of the metric identity, so editing or reordering it orphans the collected history and restarts the training set.

**`detection_delay` is not needed to avoid partial buckets.** Only complete time buckets are ever evaluated: the newest bucket is the last one whose end falls at or before the invocation time. With daily buckets and a 02:00 run, the newest scored bucket is yesterday 00:00→today 00:00, and today's partial data is never scored. A delay exists for data arriving *after* its bucket closed. It also snaps to bucket boundaries — a 4-hour delay on a 02:00 run costs a full day, same as asking for one. The case where a delay genuinely is needed: the detection boundary comes from the dbt invocation time (UTC) while buckets align to midnight in the `timestamp_column`'s own frame, so a local-time column can be scored before it is complete.

**Training/detection overlap is self-masking, not just imprecise.** The expected range at each bucket is a cumulative window over that series up to *and including* that bucket. With a multi-bucket `detection_period`, Monday's anomaly joins the training data used to judge Tuesday, widening the range Wednesday is measured against — a sustained incident hides its own tail, giving one alert then silence that reads like recovery. Hence the flat recommendation: `detection_period` longer than one bucket ⇒ set `exclude_detection_period_from_training: true`.

Also covered: dimension value lifecycle (previously-seen values get an explicit `0` for empty buckets, which is what makes disappearance detectable; never-seen values get no backfill, so a new value cannot alert on first appearance), the seasonality interaction, the no-`timestamp_column` mode, and how to read a failure (the failure count is anomalous bucket/value pairs, while stored results deliberately include each affected value's full series for graph context).

## Files

- `data-tests/anomaly-detection-tests/understanding-dimension-anomalies.mdx` — new page
- `data-tests/anomaly-detection-tests/dimension-anomalies.mdx` — series-per-value note and a card link to the guide
- `data-tests/anomaly-detection-configuration/dimensions.mdx` — multi-dimension behaviour
- `data-tests/anomaly-detection-configuration/detection-delay.mdx` — complete buckets, boundary snapping, how to choose
- `data-tests/anomaly-detection-configuration/exclude_detection_period_from_training.mdx` — why the overlap happens
- `docs.json` — nav entry

The reference pages repeat the guidance inline rather than only linking out, since `skills.md` asks for pages to be self-contained enough for Kapa to answer from a single page.

## Checks

JSON parses, every internal link and nav target resolves to a real file, MDX tags and fences balanced. `mintlify dev` was not run — the CLI is not installed locally, so a preview check before merge would be worthwhile.

## Note for a follow-up

`docs/skills.md` instructs `git checkout -b docs/<feature-name>`, which git cannot push while a branch named `docs` exists (`directory file conflict`). Hence the flat branch name here. Worth fixing in the guide separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)