### PR TITLE
docs: clarify how the time settings relate, fix anomaly_direction, link volume_threshold

### DIFF
--- a/docs/data-tests/anomaly-detection-configuration/anomaly-direction.mdx
+++ b/docs/data-tests/anomaly-detection-configuration/anomaly-direction.mdx
@@ -16,6 +16,12 @@ For some data monitors, you might only want to flag anomalies if they are above 
 For example - when monitoring for freshness, we only want to detect data delays and not data that is “early”.
 The anomaly_direction configuration is used to configure the direction of the expected range, and can be set to both, spike or drop.
 
+<Note>
+  This setting does not change how the expected range is calculated. The average and standard deviation are taken over every bucket in the training period, whichever direction you choose, and `anomaly_direction` only decides which side of the range raises an alert.
+
+  So `drop` does not mean "the standard deviation of drops only". A table that has never dropped still varies from bucket to bucket, and that variation is what a real drop gets measured against.
+</Note>
+
 - _Default: `both`_
 - _Supported values: `both`, `spike`, `drop`_
 - _Relevant tests: All anomaly detection tests_

--- a/docs/data-tests/anomaly-detection-tests/volume-anomalies.mdx
+++ b/docs/data-tests/anomaly-detection-tests/volume-anomalies.mdx
@@ -21,6 +21,10 @@ and compares it to the row count of the previous time buckets.
 **The test will only run on completed time buckets**, so if you run it with daily buckets in the middle of today, the test would only count yesterday as a complete bucket.
 If there were any anomalies during the detection period, the test will fail.
 
+<Tip>
+  If you already know the acceptable range, for example "alert me if this table shrinks by more than 10 percent", use [`volume_threshold`](/data-tests/volume-threshold) instead. It compares the newest completed bucket against the previous one using explicit percentage thresholds rather than a z score, and has separate warn and error levels.
+</Tip>
+
 ### Test configuration
 
 No mandatory configuration, however it is highly recommended to configure a `timestamp_column`.

--- a/docs/data-tests/how-anomaly-detection-works.mdx
+++ b/docs/data-tests/how-anomaly-detection-works.mdx
@@ -25,6 +25,32 @@ On each test elementary package executes the relevant monitors, and searches for
 
 To learn more, refer to [core concepts](/data-tests/how-anomaly-detection-works).
 
+## How the three time settings relate
+
+`time_bucket`, `training_period` and `detection_period` all take a `period` and a `count`, which makes them look like alternatives. They are not. One sets the resolution and the other two set the extent.
+
+- [`time_bucket`](/data-tests/anomaly-detection-configuration/time-bucket) is the **resolution**: how wide each data point is. Daily by default.
+- [`training_period`](/data-tests/anomaly-detection-configuration/training-period) is the **extent**: how far back data is collected. 14 days by default.
+- [`detection_period`](/data-tests/anomaly-detection-configuration/detection-period) is how much of the newest end of that data can be flagged. 2 days by default.
+
+Your number of data points is the extent divided by the resolution. On the defaults that is 14 days of daily buckets, so 14 points, with the newest 2 eligible to fail and the older 12 serving only as baseline.
+
+Changing the resolution changes how many points you get without changing how far back you look:
+
+| `time_bucket` | `training_period` | Data points |
+| --- | --- | --- |
+| 1 day | 14 days | 14 |
+| 4 hours | 14 days | 84 |
+| 1 week | 14 days | 2 |
+
+<Warning>
+  That last row is a real risk. Widening the time bucket without also raising the training period leaves too few points to detect anything. If you move to weekly buckets, raise `training_period` to match.
+</Warning>
+
+<Note>
+  The two periods are nested, not sequential. `training_period` is the whole window, and `detection_period` is carved out of the end of it, so `training_period: 14 days` with `detection_period: 2 days` is 14 days of data in total and not 16. Raising `detection_period` shrinks your baseline instead of extending the window.
+</Note>
+
 ## What does it mean when a test fails?
 
 When a test fail, it means that an anomaly was detected on this metric and dataset. To learn more, refer to [anomaly detection method](/data-tests/data-anomaly-detection).

--- a/docs/data-tests/how-anomaly-detection-works.mdx
+++ b/docs/data-tests/how-anomaly-detection-works.mdx
@@ -27,15 +27,15 @@ To learn more, refer to [core concepts](/data-tests/how-anomaly-detection-works)
 
 ## How the three time settings relate
 
-`time_bucket`, `training_period` and `detection_period` all take a `period` and a `count`, which makes them look like alternatives. They are not. One sets the resolution and the other two set the extent.
+`time_bucket`, `training_period` and `detection_period` all take a `period` and a `count`, which makes them look like alternatives. They are not. One sets how wide each data point is, and the other two set how far back you look.
 
-- [`time_bucket`](/data-tests/anomaly-detection-configuration/time-bucket) is the **resolution**: how wide each data point is. Daily by default.
-- [`training_period`](/data-tests/anomaly-detection-configuration/training-period) is the **extent**: how far back data is collected. 14 days by default.
-- [`detection_period`](/data-tests/anomaly-detection-configuration/detection-period) is how much of the newest end of that data can be flagged. 2 days by default.
+- [`time_bucket`](/data-tests/anomaly-detection-configuration/time-bucket) is **how wide each data point is**. One day by default.
+- [`training_period`](/data-tests/anomaly-detection-configuration/training-period) is **how far back data is collected**. 14 days by default.
+- [`detection_period`](/data-tests/anomaly-detection-configuration/detection-period) is **how much of the newest end can be flagged**. 2 days by default.
 
-Your number of data points is the extent divided by the resolution. On the defaults that is 14 days of daily buckets, so 14 points, with the newest 2 eligible to fail and the older 12 serving only as baseline.
+Your number of data points is the training period divided by the bucket size. On the defaults that is 14 days of daily buckets, so 14 points, with the newest 2 eligible to fail and the older 12 serving only as baseline.
 
-Changing the resolution changes how many points you get without changing how far back you look:
+Wider buckets give you fewer data points, without changing how far back you look:
 
 | `time_bucket` | `training_period` | Data points |
 | --- | --- | --- |


### PR DESCRIPTION
Follow up to #2319. Three gaps surfaced by customer questions in the thread that prompted that PR, all confirmed against the package source.

## 1. Nothing explained how the three time settings relate

`time_bucket`, `training_period` and `detection_period` all take a `period` and a `count`, so they read as alternatives to each other. Each has a good reference page, but the relationship between them was documented nowhere. Two readers hit this in one thread.

Added to `how-anomaly-detection-works.mdx`:

* `time_bucket` is the resolution, the two periods are the extent, and your point count is extent divided by resolution
* A table showing that the same 14 day training period gives 14, 84 or 2 points depending on the bucket
* A warning that widening the bucket without raising the training period leaves too few points to detect anything (weekly buckets on the default training period gives 2)
* A note that the periods nest rather than add, so 14 days training with 2 days detection is 14 days of data and not 16, and raising `detection_period` shrinks the baseline instead of extending the window

## 2. `anomaly_direction` described behaviour it does not have

The page said the setting configures "the direction of the expected range", which reads as though the baseline is calculated differently per direction. It is not. `anomaly_direction` appears nowhere in the query that computes the average, standard deviation or training size. It only appears in the final pass condition.

A customer inferred from that sentence that `drop` might mean "the standard deviation of drops only", and reasoned that this would break for a table that has never dropped. Reasonable inference, wrong behaviour. Added a note stating that the baseline is identical for all three values, and that a table which has never dropped still varies bucket to bucket.

## 3. `volume_threshold` was unreachable

The only reference to `data-tests/volume-threshold` anywhere in the docs was its own nav entry in `docs.json`. Nothing linked to it, including `volume_anomalies`, which is the page someone lands on when they want exactly this. The result was a customer asking us to build a test that already ships.

Added a tip on `volume_anomalies` pointing to it for the "alert me if this shrinks by more than N percent" case.

## Deliberately not included

* The em dashes in the pages from #2319. There are 342 across 81 existing pages, so normalizing only mine would make them inconsistent with the corpus. Worth a separate mechanical pass if wanted.
* The ceiling on attainable z scores when the tested value sits inside its own training set, roughly `(n-1)/sqrt(n)`, which means 10 or fewer training points can never produce an anomaly at the default sensitivity. Verified numerically and it explains a class of tests that never fire, but it is too dense for these pages. Better as a support note.

## Checks

`docs.json` parses, every internal link and nav target resolves, MDX tags and fences balanced. `mintlify dev` not run, the CLI is not installed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)