### PR TITLE
docs: add Elementary Public API (beta) reference

### DIFF
--- a/docs/api-reference/beta/openapi.json
+++ b/docs/api-reference/beta/openapi.json
@@ -3272,7 +3272,7 @@
   ],
   "servers": [
     {
-      "url": "https://app.elementary-data.com/api"
+      "url": "https://prod.api.elementary-data.com"
     }
   ],
   "tags": [

--- a/docs/api-reference/beta/openapi.json
+++ b/docs/api-reference/beta/openapi.json
@@ -1,0 +1,3300 @@
+{
+  "components": {
+    "schemas": {
+      "ApiError": {
+        "properties": {
+          "code": {
+            "description": "Stable code identifying the type of error.",
+            "title": "Code",
+            "type": "string"
+          },
+          "message": {
+            "description": "Human-readable explanation of the error.",
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"],
+        "title": "ApiError",
+        "type": "object"
+      },
+      "ApiErrorResponse": {
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/ApiError",
+            "description": "Structured details about the error."
+          }
+        },
+        "required": ["error"],
+        "title": "ApiErrorResponse",
+        "type": "object"
+      },
+      "Asset": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the asset was created in the source platform, when available.",
+            "title": "Created At"
+          },
+          "deleted_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Soft-delete timestamp. Present only in the `deleted_since` feed.",
+            "title": "Deleted At"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Description from the source platform.",
+            "title": "Description"
+          },
+          "id": {
+            "description": "Unique asset identifier.",
+            "title": "Id",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Extensible enum. High-level asset category; picks the typed endpoint that exposes this asset's extra fields (`/assets/tables` for `table`, `/assets/bi` for `bi`). New values may be added over time \u2014 treat any unrecognized value as `other` and do not hard-fail.",
+            "examples": ["table", "bi", "semantic", "etl", "other"],
+            "title": "Kind",
+            "type": "string"
+          },
+          "name": {
+            "description": "Asset name.",
+            "title": "Name",
+            "type": "string"
+          },
+          "owners": {
+            "default": [],
+            "description": "Owners assigned to the asset.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Owners",
+            "type": "array"
+          },
+          "parent_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ID of the parent asset (e.g. a BI dashboard containing this page).",
+            "title": "Parent Id"
+          },
+          "path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Logical path of the asset in its project tree.",
+            "title": "Path"
+          },
+          "source_type": {
+            "description": "Extensible enum. Integration that synced this asset. New values may be added over time.",
+            "examples": ["dbt", "looker", "sigma", "fivetran", "tableau"],
+            "title": "Source Type",
+            "type": "string"
+          },
+          "synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When Elementary last synced this asset. Use with `synced_since` for incremental reads.",
+            "title": "Synced At"
+          },
+          "tags": {
+            "default": [],
+            "description": "Tags assigned to the asset.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the asset was updated in the source platform, when available.",
+            "title": "Updated At"
+          }
+        },
+        "required": ["id", "name", "kind", "source_type"],
+        "title": "Asset",
+        "type": "object"
+      },
+      "AssetLineage": {
+        "properties": {
+          "downstream_asset_id": {
+            "description": "Identifier of the downstream asset receiving data from upstream.",
+            "title": "Downstream Asset Id",
+            "type": "string"
+          },
+          "upstream_asset_id": {
+            "description": "Identifier of the upstream asset; data flows from upstream to downstream.",
+            "title": "Upstream Asset Id",
+            "type": "string"
+          }
+        },
+        "required": ["upstream_asset_id", "downstream_asset_id"],
+        "title": "AssetLineage",
+        "type": "object"
+      },
+      "BiAsset": {
+        "properties": {
+          "bi_platform": {
+            "description": "Extensible enum. BI platform name. New values may be added over time.",
+            "examples": ["looker", "sigma", "tableau", "powerbi"],
+            "title": "Bi Platform",
+            "type": "string"
+          },
+          "bi_type": {
+            "description": "Extensible enum. BI-specific asset type. New values may be added over time.",
+            "examples": ["dashboard", "explore", "look", "report"],
+            "title": "Bi Type",
+            "type": "string"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the asset was created in the source platform, when available.",
+            "title": "Created At"
+          },
+          "deleted_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Soft-delete timestamp. Present only in the `deleted_since` feed.",
+            "title": "Deleted At"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Description from the source platform.",
+            "title": "Description"
+          },
+          "id": {
+            "description": "Unique asset identifier.",
+            "title": "Id",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Extensible enum. High-level asset category; picks the typed endpoint that exposes this asset's extra fields (`/assets/tables` for `table`, `/assets/bi` for `bi`). New values may be added over time \u2014 treat any unrecognized value as `other` and do not hard-fail.",
+            "examples": ["table", "bi", "semantic", "etl", "other"],
+            "title": "Kind",
+            "type": "string"
+          },
+          "name": {
+            "description": "Asset name.",
+            "title": "Name",
+            "type": "string"
+          },
+          "owners": {
+            "default": [],
+            "description": "Owners assigned to the asset.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Owners",
+            "type": "array"
+          },
+          "parent_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ID of the parent asset (e.g. a BI dashboard containing this page).",
+            "title": "Parent Id"
+          },
+          "path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Logical path of the asset in its project tree.",
+            "title": "Path"
+          },
+          "source_type": {
+            "description": "Extensible enum. Integration that synced this asset. New values may be added over time.",
+            "examples": ["dbt", "looker", "sigma", "fivetran", "tableau"],
+            "title": "Source Type",
+            "type": "string"
+          },
+          "synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When Elementary last synced this asset. Use with `synced_since` for incremental reads.",
+            "title": "Synced At"
+          },
+          "tags": {
+            "default": [],
+            "description": "Tags assigned to the asset.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the asset was updated in the source platform, when available.",
+            "title": "Updated At"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "URL to the asset in its source platform.",
+            "title": "Url"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "kind",
+          "source_type",
+          "bi_platform",
+          "bi_type"
+        ],
+        "title": "BiAsset",
+        "type": "object"
+      },
+      "Column": {
+        "properties": {
+          "asset_id": {
+            "description": "ID of the asset this column belongs to.",
+            "title": "Asset Id",
+            "type": "string"
+          },
+          "data_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Data type reported by the source platform.",
+            "title": "Data Type"
+          },
+          "deleted_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Soft-delete timestamp. Present only in the `deleted_since` feed.",
+            "title": "Deleted At"
+          },
+          "id": {
+            "description": "Unique column identifier.",
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "description": "Column name.",
+            "title": "Name",
+            "type": "string"
+          },
+          "synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When Elementary last synced this column. Use with `synced_since` for incremental reads.",
+            "title": "Synced At"
+          }
+        },
+        "required": ["id", "name", "asset_id"],
+        "title": "Column",
+        "type": "object"
+      },
+      "ColumnLineage": {
+        "properties": {
+          "downstream_column_id": {
+            "description": "Identifier of the downstream column receiving data from upstream.",
+            "title": "Downstream Column Id",
+            "type": "string"
+          },
+          "upstream_column_id": {
+            "description": "Identifier of the upstream column; data flows from upstream to downstream.",
+            "title": "Upstream Column Id",
+            "type": "string"
+          }
+        },
+        "required": ["upstream_column_id", "downstream_column_id"],
+        "title": "ColumnLineage",
+        "type": "object"
+      },
+      "Direction": {
+        "enum": ["asc", "desc"],
+        "title": "Direction",
+        "type": "string"
+      },
+      "Environment": {
+        "properties": {
+          "cron": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Sync schedule as a cron expression, if configured.",
+            "title": "Cron"
+          },
+          "id": {
+            "description": "Use as `env_id` in all environment-scoped endpoints.",
+            "title": "Id",
+            "type": "string"
+          },
+          "last_sync_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Extensible enum. Status of the environment's most recent sync. New values may be added over time.",
+            "examples": ["success", "running", "error"],
+            "title": "Last Sync Status"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When Elementary last synced the environment.",
+            "title": "Last Synced At"
+          },
+          "name": {
+            "description": "Environment name.",
+            "title": "Name",
+            "type": "string"
+          },
+          "warehouse_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Extensible enum. Warehouse the environment reads from. New values may be added over time.",
+            "examples": [
+              "snowflake",
+              "bigquery",
+              "databricks",
+              "redshift",
+              "postgres"
+            ],
+            "title": "Warehouse Type"
+          }
+        },
+        "required": ["id", "name"],
+        "title": "Environment",
+        "type": "object"
+      },
+      "OrderBy": {
+        "enum": ["id", "synced_at"],
+        "title": "OrderBy",
+        "type": "string"
+      },
+      "PaginatedResponse_AssetLineage_": {
+        "properties": {
+          "has_more": {
+            "default": false,
+            "description": "The only signal to continue pagination; a short page may still have more items because permission filtering can trim rows.",
+            "title": "Has More",
+            "type": "boolean"
+          },
+          "items": {
+            "description": "Objects returned in the current page.",
+            "items": {
+              "$ref": "#/components/schemas/AssetLineage"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Opaque cursor for the next page, valid only with identical query parameters.",
+            "title": "Next Cursor"
+          }
+        },
+        "required": ["items"],
+        "title": "PaginatedResponse[AssetLineage]",
+        "type": "object"
+      },
+      "PaginatedResponse_Asset_": {
+        "properties": {
+          "has_more": {
+            "default": false,
+            "description": "The only signal to continue pagination; a short page may still have more items because permission filtering can trim rows.",
+            "title": "Has More",
+            "type": "boolean"
+          },
+          "items": {
+            "description": "Objects returned in the current page.",
+            "items": {
+              "$ref": "#/components/schemas/Asset"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Opaque cursor for the next page, valid only with identical query parameters.",
+            "title": "Next Cursor"
+          }
+        },
+        "required": ["items"],
+        "title": "PaginatedResponse[Asset]",
+        "type": "object"
+      },
+      "PaginatedResponse_BiAsset_": {
+        "properties": {
+          "has_more": {
+            "default": false,
+            "description": "The only signal to continue pagination; a short page may still have more items because permission filtering can trim rows.",
+            "title": "Has More",
+            "type": "boolean"
+          },
+          "items": {
+            "description": "Objects returned in the current page.",
+            "items": {
+              "$ref": "#/components/schemas/BiAsset"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Opaque cursor for the next page, valid only with identical query parameters.",
+            "title": "Next Cursor"
+          }
+        },
+        "required": ["items"],
+        "title": "PaginatedResponse[BiAsset]",
+        "type": "object"
+      },
+      "PaginatedResponse_ColumnLineage_": {
+        "properties": {
+          "has_more": {
+            "default": false,
+            "description": "The only signal to continue pagination; a short page may still have more items because permission filtering can trim rows.",
+            "title": "Has More",
+            "type": "boolean"
+          },
+          "items": {
+            "description": "Objects returned in the current page.",
+            "items": {
+              "$ref": "#/components/schemas/ColumnLineage"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Opaque cursor for the next page, valid only with identical query parameters.",
+            "title": "Next Cursor"
+          }
+        },
+        "required": ["items"],
+        "title": "PaginatedResponse[ColumnLineage]",
+        "type": "object"
+      },
+      "PaginatedResponse_Column_": {
+        "properties": {
+          "has_more": {
+            "default": false,
+            "description": "The only signal to continue pagination; a short page may still have more items because permission filtering can trim rows.",
+            "title": "Has More",
+            "type": "boolean"
+          },
+          "items": {
+            "description": "Objects returned in the current page.",
+            "items": {
+              "$ref": "#/components/schemas/Column"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Opaque cursor for the next page, valid only with identical query parameters.",
+            "title": "Next Cursor"
+          }
+        },
+        "required": ["items"],
+        "title": "PaginatedResponse[Column]",
+        "type": "object"
+      },
+      "PaginatedResponse_TableAsset_": {
+        "properties": {
+          "has_more": {
+            "default": false,
+            "description": "The only signal to continue pagination; a short page may still have more items because permission filtering can trim rows.",
+            "title": "Has More",
+            "type": "boolean"
+          },
+          "items": {
+            "description": "Objects returned in the current page.",
+            "items": {
+              "$ref": "#/components/schemas/TableAsset"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Opaque cursor for the next page, valid only with identical query parameters.",
+            "title": "Next Cursor"
+          }
+        },
+        "required": ["items"],
+        "title": "PaginatedResponse[TableAsset]",
+        "type": "object"
+      },
+      "TableAsset": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the asset was created in the source platform, when available.",
+            "title": "Created At"
+          },
+          "data_platform": {
+            "description": "Extensible enum. Data platform name. New values may be added over time.",
+            "examples": [
+              "snowflake",
+              "bigquery",
+              "databricks",
+              "redshift",
+              "postgres"
+            ],
+            "title": "Data Platform",
+            "type": "string"
+          },
+          "db_name": {
+            "description": "Database (catalog) name.",
+            "title": "Db Name",
+            "type": "string"
+          },
+          "deleted_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Soft-delete timestamp. Present only in the `deleted_since` feed.",
+            "title": "Deleted At"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Description from the source platform.",
+            "title": "Description"
+          },
+          "id": {
+            "description": "Unique asset identifier.",
+            "title": "Id",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Extensible enum. High-level asset category; picks the typed endpoint that exposes this asset's extra fields (`/assets/tables` for `table`, `/assets/bi` for `bi`). New values may be added over time \u2014 treat any unrecognized value as `other` and do not hard-fail.",
+            "examples": ["table", "bi", "semantic", "etl", "other"],
+            "title": "Kind",
+            "type": "string"
+          },
+          "materialization": {
+            "description": "Extensible enum. Materialization strategy. New values may be added over time.",
+            "examples": ["table", "view", "incremental", "ephemeral"],
+            "title": "Materialization",
+            "type": "string"
+          },
+          "name": {
+            "description": "Asset name.",
+            "title": "Name",
+            "type": "string"
+          },
+          "owners": {
+            "default": [],
+            "description": "Owners assigned to the asset.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Owners",
+            "type": "array"
+          },
+          "parent_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ID of the parent asset (e.g. a BI dashboard containing this page).",
+            "title": "Parent Id"
+          },
+          "path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Logical path of the asset in its project tree.",
+            "title": "Path"
+          },
+          "schema_name": {
+            "description": "Schema name.",
+            "title": "Schema Name",
+            "type": "string"
+          },
+          "source_type": {
+            "description": "Extensible enum. Integration that synced this asset. New values may be added over time.",
+            "examples": ["dbt", "looker", "sigma", "fivetran", "tableau"],
+            "title": "Source Type",
+            "type": "string"
+          },
+          "synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When Elementary last synced this asset. Use with `synced_since` for incremental reads.",
+            "title": "Synced At"
+          },
+          "table_name": {
+            "description": "Table or view name.",
+            "title": "Table Name",
+            "type": "string"
+          },
+          "tags": {
+            "default": [],
+            "description": "Tags assigned to the asset.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the asset was updated in the source platform, when available.",
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "kind",
+          "source_type",
+          "data_platform",
+          "db_name",
+          "schema_name",
+          "table_name",
+          "materialization"
+        ],
+        "title": "TableAsset",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "description": "Personal or account token.",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "description": "The Elementary Public API is a REST interface for programmatically reading\nElementary's assets, columns, and lineage for one environment.\n\n**Authentication.** Send a bearer token (personal or account token) in the\n`Authorization` header. The token resolves to an account; results are scoped to\nthe environments that token may view.\n\n**Environment scope.** Every resource lives under `/{env_id}`. Call\n`GET /environments` first to discover the ids you can access.\n\n**Pagination.** List endpoints are keyset-paginated: pass `limit` (default 500,\nmax 2000) and follow `next_cursor` until `has_more` is `false`. Cursors are opaque\nand bound to the filters that produced them \u2014 reusing a cursor with different\nfilters returns `400`.\n\n**Incremental sync.** Every dataset supports a full scan (default). Assets and\ncolumns also expose two incremental feeds: `synced_since` (upserts) and\n`deleted_since` (soft-delete tombstones).\n\n**Rate limiting.** Requests are rate-limited per account; responses carry\n`RateLimit-*` headers and `429` responses include `Retry-After`.\n\n_Beta: the shape may change while we co-design with early adopters._\n",
+    "title": "Elementary Public API",
+    "version": "beta"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/public/beta/environments": {
+      "get": {
+        "description": "Lists the environments the token can access. Each `id` is an `env_id` for the other endpoints. Call this first.",
+        "operationId": "list_environments_public_beta_environments_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Environment"
+                  },
+                  "title": "Response List Environments Public Beta Environments Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid cursor or request parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication is required."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The token does not have permission to access the resource."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "RateLimit-Limit": {
+                "description": "Maximum requests allowed in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Reset": {
+                "description": "Seconds until the current rate-limit window resets.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "An unexpected server error occurred."
+          }
+        },
+        "summary": "List environments",
+        "tags": ["Environments"]
+      }
+    },
+    "/public/beta/{env_id}/asset-lineage": {
+      "get": {
+        "description": "Lists asset-to-asset lineage edges. Full scan only. Edges are returned as-is, including edges to and from ephemeral (CTE-only) dbt models; those assets are also returned by the assets endpoints.",
+        "operationId": "list_asset_lineage_public_beta__env_id__asset_lineage_get",
+        "parameters": [
+          {
+            "description": "Environment identifier that scopes the request.",
+            "in": "path",
+            "name": "env_id",
+            "required": true,
+            "schema": {
+              "description": "Environment identifier that scopes the request.",
+              "title": "Env Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Opaque cursor from a previous response's `next_cursor`. Reuse it only with the identical query parameters that produced it.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opaque cursor from a previous response's `next_cursor`. Reuse it only with the identical query parameters that produced it.",
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Maximum items to return per page (1-2000).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 500,
+              "description": "Maximum items to return per page (1-2000).",
+              "maximum": 2000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Return only edges touching these asset ids.",
+            "in": "query",
+            "name": "asset_ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only edges touching these asset ids.",
+              "title": "Asset Ids"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_AssetLineage_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid cursor or request parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication is required."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The token does not have permission to access the resource."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "RateLimit-Limit": {
+                "description": "Maximum requests allowed in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Reset": {
+                "description": "Seconds until the current rate-limit window resets.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "An unexpected server error occurred."
+          }
+        },
+        "summary": "List asset lineage edges",
+        "tags": ["Asset lineage"]
+      }
+    },
+    "/public/beta/{env_id}/assets": {
+      "get": {
+        "description": "Lists lineage assets of every kind (tables, BI assets, semantic models, \u2026) with their common fields. Use `kind` to enrich a row from the typed endpoints (`/assets/tables`, `/assets/bi`). Full scan by default; pass `synced_since` for the upserts feed or `deleted_since` for the tombstones feed (mutually exclusive).",
+        "operationId": "list_assets_public_beta__env_id__assets_get",
+        "parameters": [
+          {
+            "description": "Environment identifier that scopes the request.",
+            "in": "path",
+            "name": "env_id",
+            "required": true,
+            "schema": {
+              "description": "Environment identifier that scopes the request.",
+              "title": "Env Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only assets with these ids.",
+            "in": "query",
+            "name": "ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only assets with these ids.",
+              "title": "Ids"
+            }
+          },
+          {
+            "description": "Return only assets from these source types (e.g. `dbt`, `fivetran`, `looker`).",
+            "in": "query",
+            "name": "source_types",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only assets from these source types (e.g. `dbt`, `fivetran`, `looker`).",
+              "title": "Source Types"
+            }
+          },
+          {
+            "description": "Return only assets tagged with any of these tags.",
+            "in": "query",
+            "name": "tags",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only assets tagged with any of these tags.",
+              "title": "Tags"
+            }
+          },
+          {
+            "description": "Upserts feed: assets whose `synced_at` >= this time (inclusive). Orders by `synced_at`.",
+            "in": "query",
+            "name": "synced_since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Upserts feed: assets whose `synced_at` >= this time (inclusive). Orders by `synced_at`.",
+              "title": "Synced Since"
+            }
+          },
+          {
+            "description": "Tombstones feed: assets whose `deleted_at` >= this time (inclusive). Orders by `deleted_at`.",
+            "in": "query",
+            "name": "deleted_since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Tombstones feed: assets whose `deleted_at` >= this time (inclusive). Orders by `deleted_at`.",
+              "title": "Deleted Since"
+            }
+          },
+          {
+            "description": "Opaque cursor from a previous response's `next_cursor`. Reuse it only with the identical query parameters that produced it.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opaque cursor from a previous response's `next_cursor`. Reuse it only with the identical query parameters that produced it.",
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Maximum items to return per page (1-2000).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 500,
+              "description": "Maximum items to return per page (1-2000).",
+              "maximum": 2000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort field for a full scan. Ignored when `synced_since`/`deleted_since` is set (those feeds always order by their own cursor).",
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrderBy",
+              "default": "id",
+              "description": "Sort field for a full scan. Ignored when `synced_since`/`deleted_since` is set (those feeds always order by their own cursor)."
+            }
+          },
+          {
+            "description": "Sort direction for `order_by`.",
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Direction",
+              "default": "asc",
+              "description": "Sort direction for `order_by`."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_Asset_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid cursor or request parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication is required."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The token does not have permission to access the resource."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "RateLimit-Limit": {
+                "description": "Maximum requests allowed in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Reset": {
+                "description": "Seconds until the current rate-limit window resets.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "An unexpected server error occurred."
+          }
+        },
+        "summary": "List assets",
+        "tags": ["Assets"]
+      }
+    },
+    "/public/beta/{env_id}/assets/bi": {
+      "get": {
+        "description": "Lists BI assets with their BI-specific fields (`bi_platform`, `bi_type`, `url`). Full scan by default; supports the `synced_since` / `deleted_since` feeds.",
+        "operationId": "list_bi_assets_public_beta__env_id__assets_bi_get",
+        "parameters": [
+          {
+            "description": "Environment identifier that scopes the request.",
+            "in": "path",
+            "name": "env_id",
+            "required": true,
+            "schema": {
+              "description": "Environment identifier that scopes the request.",
+              "title": "Env Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only BI assets with these ids.",
+            "in": "query",
+            "name": "ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only BI assets with these ids.",
+              "title": "Ids"
+            }
+          },
+          {
+            "description": "Return only BI assets from these source types (e.g. `looker`, `sigma`).",
+            "in": "query",
+            "name": "source_types",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only BI assets from these source types (e.g. `looker`, `sigma`).",
+              "title": "Source Types"
+            }
+          },
+          {
+            "description": "Return only BI assets tagged with any of these tags.",
+            "in": "query",
+            "name": "tags",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only BI assets tagged with any of these tags.",
+              "title": "Tags"
+            }
+          },
+          {
+            "description": "Return only BI assets on these platforms (e.g. `looker`, `sigma`, `tableau`).",
+            "in": "query",
+            "name": "bi_platforms",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only BI assets on these platforms (e.g. `looker`, `sigma`, `tableau`).",
+              "title": "Bi Platforms"
+            }
+          },
+          {
+            "description": "Upserts feed: assets whose `synced_at` >= this time (inclusive). Orders by `synced_at`.",
+            "in": "query",
+            "name": "synced_since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Upserts feed: assets whose `synced_at` >= this time (inclusive). Orders by `synced_at`.",
+              "title": "Synced Since"
+            }
+          },
+          {
+            "description": "Tombstones feed: assets whose `deleted_at` >= this time (inclusive). Orders by `deleted_at`.",
+            "in": "query",
+            "name": "deleted_since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Tombstones feed: assets whose `deleted_at` >= this time (inclusive). Orders by `deleted_at`.",
+              "title": "Deleted Since"
+            }
+          },
+          {
+            "description": "Opaque cursor from a previous response's `next_cursor`. Reuse it only with the identical query parameters that produced it.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opaque cursor from a previous response's `next_cursor`. Reuse it only with the identical query parameters that produced it.",
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Maximum items to return per page (1-2000).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 500,
+              "description": "Maximum items to return per page (1-2000).",
+              "maximum": 2000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort field for a full scan. Ignored when `synced_since`/`deleted_since` is set (those feeds always order by their own cursor).",
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrderBy",
+              "default": "id",
+              "description": "Sort field for a full scan. Ignored when `synced_since`/`deleted_since` is set (those feeds always order by their own cursor)."
+            }
+          },
+          {
+            "description": "Sort direction for `order_by`.",
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Direction",
+              "default": "asc",
+              "description": "Sort direction for `order_by`."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_BiAsset_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid cursor or request parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication is required."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The token does not have permission to access the resource."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "RateLimit-Limit": {
+                "description": "Maximum requests allowed in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Reset": {
+                "description": "Seconds until the current rate-limit window resets.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "An unexpected server error occurred."
+          }
+        },
+        "summary": "List BI assets",
+        "tags": ["Assets"]
+      }
+    },
+    "/public/beta/{env_id}/assets/bi/{asset_id}": {
+      "get": {
+        "description": "Fetches a single BI asset by id. Returns 404 if it doesn't exist in this environment or isn't a BI asset.",
+        "operationId": "get_bi_asset_public_beta__env_id__assets_bi__asset_id__get",
+        "parameters": [
+          {
+            "description": "Asset identifier.",
+            "in": "path",
+            "name": "asset_id",
+            "required": true,
+            "schema": {
+              "description": "Asset identifier.",
+              "title": "Asset Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Environment identifier that scopes the request.",
+            "in": "path",
+            "name": "env_id",
+            "required": true,
+            "schema": {
+              "description": "Environment identifier that scopes the request.",
+              "title": "Env Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BiAsset"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid cursor or request parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication is required."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The token does not have permission to access the resource."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "RateLimit-Limit": {
+                "description": "Maximum requests allowed in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Reset": {
+                "description": "Seconds until the current rate-limit window resets.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "An unexpected server error occurred."
+          }
+        },
+        "summary": "Get a BI asset",
+        "tags": ["Assets"]
+      }
+    },
+    "/public/beta/{env_id}/assets/tables": {
+      "get": {
+        "description": "Lists warehouse table assets with their warehouse-specific fields (`data_platform`, `db_name`, `schema_name`, `table_name`, `materialization`). Full scan by default; supports the `synced_since` / `deleted_since` feeds.",
+        "operationId": "list_table_assets_public_beta__env_id__assets_tables_get",
+        "parameters": [
+          {
+            "description": "Environment identifier that scopes the request.",
+            "in": "path",
+            "name": "env_id",
+            "required": true,
+            "schema": {
+              "description": "Environment identifier that scopes the request.",
+              "title": "Env Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only table assets with these ids.",
+            "in": "query",
+            "name": "ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only table assets with these ids.",
+              "title": "Ids"
+            }
+          },
+          {
+            "description": "Return only table assets from these source types (e.g. `dbt`, `fivetran`).",
+            "in": "query",
+            "name": "source_types",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only table assets from these source types (e.g. `dbt`, `fivetran`).",
+              "title": "Source Types"
+            }
+          },
+          {
+            "description": "Return only table assets tagged with any of these tags.",
+            "in": "query",
+            "name": "tags",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only table assets tagged with any of these tags.",
+              "title": "Tags"
+            }
+          },
+          {
+            "description": "Return only table assets in these databases.",
+            "in": "query",
+            "name": "db_names",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only table assets in these databases.",
+              "title": "Db Names"
+            }
+          },
+          {
+            "description": "Return only table assets in these schemas.",
+            "in": "query",
+            "name": "schema_names",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only table assets in these schemas.",
+              "title": "Schema Names"
+            }
+          },
+          {
+            "description": "Return only table assets with these materializations (e.g. `table`, `view`, `incremental`).",
+            "in": "query",
+            "name": "materializations",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only table assets with these materializations (e.g. `table`, `view`, `incremental`).",
+              "title": "Materializations"
+            }
+          },
+          {
+            "description": "Upserts feed: assets whose `synced_at` >= this time (inclusive). Orders by `synced_at`.",
+            "in": "query",
+            "name": "synced_since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Upserts feed: assets whose `synced_at` >= this time (inclusive). Orders by `synced_at`.",
+              "title": "Synced Since"
+            }
+          },
+          {
+            "description": "Tombstones feed: assets whose `deleted_at` >= this time (inclusive). Orders by `deleted_at`.",
+            "in": "query",
+            "name": "deleted_since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Tombstones feed: assets whose `deleted_at` >= this time (inclusive). Orders by `deleted_at`.",
+              "title": "Deleted Since"
+            }
+          },
+          {
+            "description": "Opaque cursor from a previous response's `next_cursor`. Reuse it only with the identical query parameters that produced it.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opaque cursor from a previous response's `next_cursor`. Reuse it only with the identical query parameters that produced it.",
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Maximum items to return per page (1-2000).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 500,
+              "description": "Maximum items to return per page (1-2000).",
+              "maximum": 2000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort field for a full scan. Ignored when `synced_since`/`deleted_since` is set (those feeds always order by their own cursor).",
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrderBy",
+              "default": "id",
+              "description": "Sort field for a full scan. Ignored when `synced_since`/`deleted_since` is set (those feeds always order by their own cursor)."
+            }
+          },
+          {
+            "description": "Sort direction for `order_by`.",
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Direction",
+              "default": "asc",
+              "description": "Sort direction for `order_by`."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_TableAsset_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid cursor or request parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication is required."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The token does not have permission to access the resource."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "RateLimit-Limit": {
+                "description": "Maximum requests allowed in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Reset": {
+                "description": "Seconds until the current rate-limit window resets.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "An unexpected server error occurred."
+          }
+        },
+        "summary": "List table assets",
+        "tags": ["Assets"]
+      }
+    },
+    "/public/beta/{env_id}/assets/tables/{asset_id}": {
+      "get": {
+        "description": "Fetches a single table asset by id. Returns 404 if it doesn't exist in this environment or isn't a table asset.",
+        "operationId": "get_table_asset_public_beta__env_id__assets_tables__asset_id__get",
+        "parameters": [
+          {
+            "description": "Asset identifier.",
+            "in": "path",
+            "name": "asset_id",
+            "required": true,
+            "schema": {
+              "description": "Asset identifier.",
+              "title": "Asset Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Environment identifier that scopes the request.",
+            "in": "path",
+            "name": "env_id",
+            "required": true,
+            "schema": {
+              "description": "Environment identifier that scopes the request.",
+              "title": "Env Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TableAsset"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid cursor or request parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication is required."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The token does not have permission to access the resource."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "RateLimit-Limit": {
+                "description": "Maximum requests allowed in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Reset": {
+                "description": "Seconds until the current rate-limit window resets.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "An unexpected server error occurred."
+          }
+        },
+        "summary": "Get a table asset",
+        "tags": ["Assets"]
+      }
+    },
+    "/public/beta/{env_id}/assets/{asset_id}": {
+      "get": {
+        "description": "Fetches a single asset (common fields) by id. Returns 404 if it doesn't exist in this environment.",
+        "operationId": "get_asset_public_beta__env_id__assets__asset_id__get",
+        "parameters": [
+          {
+            "description": "Asset identifier.",
+            "in": "path",
+            "name": "asset_id",
+            "required": true,
+            "schema": {
+              "description": "Asset identifier.",
+              "title": "Asset Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Environment identifier that scopes the request.",
+            "in": "path",
+            "name": "env_id",
+            "required": true,
+            "schema": {
+              "description": "Environment identifier that scopes the request.",
+              "title": "Env Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid cursor or request parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication is required."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The token does not have permission to access the resource."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "RateLimit-Limit": {
+                "description": "Maximum requests allowed in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Reset": {
+                "description": "Seconds until the current rate-limit window resets.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "An unexpected server error occurred."
+          }
+        },
+        "summary": "Get an asset",
+        "tags": ["Assets"]
+      }
+    },
+    "/public/beta/{env_id}/column-lineage": {
+      "get": {
+        "description": "Lists column-to-column lineage edges, one record per edge (mirroring the asset-lineage shape). Full scan by default; the `synced_since` / `deleted_since` feeds filter on the downstream column's timestamps.",
+        "operationId": "list_column_lineage_public_beta__env_id__column_lineage_get",
+        "parameters": [
+          {
+            "description": "Environment identifier that scopes the request.",
+            "in": "path",
+            "name": "env_id",
+            "required": true,
+            "schema": {
+              "description": "Environment identifier that scopes the request.",
+              "title": "Env Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only edges whose downstream column is in this set.",
+            "in": "query",
+            "name": "column_ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only edges whose downstream column is in this set.",
+              "title": "Column Ids"
+            }
+          },
+          {
+            "description": "Return only edges whose downstream column belongs to these asset ids.",
+            "in": "query",
+            "name": "asset_ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only edges whose downstream column belongs to these asset ids.",
+              "title": "Asset Ids"
+            }
+          },
+          {
+            "description": "Upserts feed: edges whose downstream column `synced_at` >= this time (inclusive). Orders by `synced_at`.",
+            "in": "query",
+            "name": "synced_since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Upserts feed: edges whose downstream column `synced_at` >= this time (inclusive). Orders by `synced_at`.",
+              "title": "Synced Since"
+            }
+          },
+          {
+            "description": "Tombstones feed: edges whose downstream column `deleted_at` >= this time (inclusive). Orders by `deleted_at`.",
+            "in": "query",
+            "name": "deleted_since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Tombstones feed: edges whose downstream column `deleted_at` >= this time (inclusive). Orders by `deleted_at`.",
+              "title": "Deleted Since"
+            }
+          },
+          {
+            "description": "Opaque cursor from a previous response's `next_cursor`. Reuse it only with the identical query parameters that produced it.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opaque cursor from a previous response's `next_cursor`. Reuse it only with the identical query parameters that produced it.",
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Maximum items to return per page (1-2000).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 500,
+              "description": "Maximum items to return per page (1-2000).",
+              "maximum": 2000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort field for a full scan. Ignored when `synced_since`/`deleted_since` is set (those feeds always order by their own cursor).",
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrderBy",
+              "default": "id",
+              "description": "Sort field for a full scan. Ignored when `synced_since`/`deleted_since` is set (those feeds always order by their own cursor)."
+            }
+          },
+          {
+            "description": "Sort direction for `order_by`.",
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Direction",
+              "default": "asc",
+              "description": "Sort direction for `order_by`."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_ColumnLineage_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid cursor or request parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication is required."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The token does not have permission to access the resource."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "RateLimit-Limit": {
+                "description": "Maximum requests allowed in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Reset": {
+                "description": "Seconds until the current rate-limit window resets.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "An unexpected server error occurred."
+          }
+        },
+        "summary": "List column lineage",
+        "tags": ["Column lineage"]
+      }
+    },
+    "/public/beta/{env_id}/columns": {
+      "get": {
+        "description": "Lists asset columns. Full scan by default; pass `synced_since` for the upserts feed or `deleted_since` for the tombstones feed.",
+        "operationId": "list_columns_public_beta__env_id__columns_get",
+        "parameters": [
+          {
+            "description": "Environment identifier that scopes the request.",
+            "in": "path",
+            "name": "env_id",
+            "required": true,
+            "schema": {
+              "description": "Environment identifier that scopes the request.",
+              "title": "Env Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only columns with these ids.",
+            "in": "query",
+            "name": "ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only columns with these ids.",
+              "title": "Ids"
+            }
+          },
+          {
+            "description": "Return only columns belonging to these asset ids.",
+            "in": "query",
+            "name": "asset_ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only columns belonging to these asset ids.",
+              "title": "Asset Ids"
+            }
+          },
+          {
+            "description": "Return only columns with these data types.",
+            "in": "query",
+            "name": "data_types",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only columns with these data types.",
+              "title": "Data Types"
+            }
+          },
+          {
+            "description": "Upserts feed: columns whose `synced_at` >= this time (inclusive). Orders by `synced_at`.",
+            "in": "query",
+            "name": "synced_since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Upserts feed: columns whose `synced_at` >= this time (inclusive). Orders by `synced_at`.",
+              "title": "Synced Since"
+            }
+          },
+          {
+            "description": "Tombstones feed: columns whose `deleted_at` >= this time (inclusive). Orders by `deleted_at`.",
+            "in": "query",
+            "name": "deleted_since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Tombstones feed: columns whose `deleted_at` >= this time (inclusive). Orders by `deleted_at`.",
+              "title": "Deleted Since"
+            }
+          },
+          {
+            "description": "Opaque cursor from a previous response's `next_cursor`. Reuse it only with the identical query parameters that produced it.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opaque cursor from a previous response's `next_cursor`. Reuse it only with the identical query parameters that produced it.",
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Maximum items to return per page (1-2000).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 500,
+              "description": "Maximum items to return per page (1-2000).",
+              "maximum": 2000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort field for a full scan. Ignored when `synced_since`/`deleted_since` is set (those feeds always order by their own cursor).",
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrderBy",
+              "default": "id",
+              "description": "Sort field for a full scan. Ignored when `synced_since`/`deleted_since` is set (those feeds always order by their own cursor)."
+            }
+          },
+          {
+            "description": "Sort direction for `order_by`.",
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Direction",
+              "default": "asc",
+              "description": "Sort direction for `order_by`."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_Column_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid cursor or request parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication is required."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The token does not have permission to access the resource."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "RateLimit-Limit": {
+                "description": "Maximum requests allowed in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Reset": {
+                "description": "Seconds until the current rate-limit window resets.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "An unexpected server error occurred."
+          }
+        },
+        "summary": "List columns",
+        "tags": ["Columns"]
+      }
+    },
+    "/public/beta/{env_id}/columns/{column_id}": {
+      "get": {
+        "description": "Fetches a single column by id. Returns 404 if it doesn't exist in this environment.",
+        "operationId": "get_column_public_beta__env_id__columns__column_id__get",
+        "parameters": [
+          {
+            "description": "Column identifier.",
+            "in": "path",
+            "name": "column_id",
+            "required": true,
+            "schema": {
+              "description": "Column identifier.",
+              "title": "Column Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Environment identifier that scopes the request.",
+            "in": "path",
+            "name": "env_id",
+            "required": true,
+            "schema": {
+              "description": "Environment identifier that scopes the request.",
+              "title": "Env Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Column"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid cursor or request parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication is required."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The token does not have permission to access the resource."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "RateLimit-Limit": {
+                "description": "Maximum requests allowed in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining in the current window.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "RateLimit-Reset": {
+                "description": "Seconds until the current rate-limit window resets.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "An unexpected server error occurred."
+          }
+        },
+        "summary": "Get a column",
+        "tags": ["Columns"]
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "servers": [
+    {
+      "url": "https://app.elementary-data.com/api"
+    }
+  ],
+  "tags": [
+    {
+      "description": "Discover accessible environments.",
+      "name": "Environments"
+    },
+    {
+      "description": "Lineage assets \u2014 tables, views, BI assets.",
+      "name": "Assets"
+    },
+    {
+      "description": "Columns of assets.",
+      "name": "Columns"
+    },
+    {
+      "description": "Asset-to-asset lineage edges.",
+      "name": "Asset lineage"
+    },
+    {
+      "description": "Column-level lineage edges.",
+      "name": "Column lineage"
+    }
+  ]
+}

--- a/docs/api/authentication.mdx
+++ b/docs/api/authentication.mdx
@@ -1,0 +1,67 @@
+---
+title: 'Authentication'
+description: 'Authenticate with a bearer token and scope requests to an environment.'
+---
+
+## Bearer token
+
+Send your token in the `Authorization` header on every request:
+
+```bash
+curl -H "Authorization: Bearer $ELEMENTARY_TOKEN" \
+  https://app.elementary-data.com/api/public/beta/environments
+```
+
+Both **personal tokens** and **account tokens** are accepted. The token resolves
+to an account, and requests are limited to the environments that token may view.
+
+## Environment scope
+
+Every resource except `GET /environments` is nested under an environment:
+
+```
+/public/beta/{env_id}/assets
+```
+
+Call `GET /environments` first to discover the ids you can access. Passing an
+`env_id` you don't have access to returns `403`.
+
+## Visibility & permissions
+
+Access is governed by your token's role at three levels:
+
+1. **Environment access** — the token must be able to view the environment (as
+   returned by `GET /environments`). Otherwise every request under that
+   `env_id` returns `403`.
+2. **Resource scope** — the asset, column, and lineage endpoints require the
+   _assets_ view scope. A role that can reach the environment but isn't granted
+   the assets resource returns `403`.
+3. **Per-asset access** — see below.
+
+If your token's role is restricted to a subset of an environment's assets
+(resource-group permissions), the API only ever returns the assets — and the
+columns and lineage edges derived from them — that you're allowed to see:
+
+- **List endpoints** silently omit assets you can't view. Asset-lineage edges
+  are returned only when **both** of their endpoints are visible to you; an
+  edge that touches a restricted asset is dropped entirely.
+- Column-lineage edges are returned only when the downstream column's asset is
+  visible to you. A returned edge's `upstream_column_id` may reference a
+  restricted upstream asset; only the id is exposed, not its metadata.
+- **Get-one endpoints** (`/assets/{id}`, `/columns/{id}`)
+  return `404` for an object you can't view — the same response as a nonexistent
+  object, so the API never discloses that a restricted asset exists.
+
+Because filtering is applied per page after rows are read, a page may contain
+fewer than `limit` items while `has_more` is still `true`. Always iterate on
+`has_more`, not on item count — see [Pagination](/api/pagination).
+
+## Errors
+
+| Status | Code                | Meaning                                      |
+| ------ | ------------------- | -------------------------------------------- |
+| `401`  | `unauthenticated`   | Missing or invalid token                     |
+| `403`  | `permission_denied` | Token can't access the requested environment |
+| `404`  | `not_found`         | Environment or object doesn't exist          |
+
+See [Errors](/api/errors) for the full error contract.

--- a/docs/api/authentication.mdx
+++ b/docs/api/authentication.mdx
@@ -15,6 +15,32 @@ curl -H "Authorization: Bearer $ELEMENTARY_TOKEN" \
 Both **personal tokens** and **account tokens** are accepted. The token resolves
 to an account, and requests are limited to the environments that token may view.
 
+## Creating a token
+
+Generate a token in the Elementary app, then send it as the bearer token shown
+above. The token is displayed **only once** — copy it and store it securely.
+
+<CardGroup cols={2}>
+  <Card title="Personal token" icon="user" href="https://app.elementary-data.com/settings/user-tokens">
+    **User → Personal Tokens.** User-scoped: inherits your own workspace
+    permissions, so it can read exactly the environments and assets you can.
+    Best for personal scripts and exploration.
+  </Card>
+  <Card title="Account token" icon="building" href="https://app.elementary-data.com/settings/account-tokens">
+    **Account → Account Tokens.** Account-scoped with "Can View" permissions and
+    not tied to a single user. Best for shared services, CI, and integrations.
+    Creating one requires the *Manage account tokens* permission.
+  </Card>
+</CardGroup>
+
+In either case, click **Generate token** and copy the value into the
+`Authorization: Bearer` header.
+
+<Warning>
+  Treat tokens like passwords: never share or commit them, rotate them
+  regularly, and revoke a token immediately if it may have been exposed.
+</Warning>
+
 ## Environment scope
 
 Every resource except `GET /environments` is nested under an environment:

--- a/docs/api/authentication.mdx
+++ b/docs/api/authentication.mdx
@@ -9,7 +9,7 @@ Send your token in the `Authorization` header on every request:
 
 ```bash
 curl -H "Authorization: Bearer $ELEMENTARY_TOKEN" \
-  https://app.elementary-data.com/api/public/beta/environments
+  https://prod.api.elementary-data.com/public/beta/environments
 ```
 
 Both **personal tokens** and **account tokens** are accepted. The token resolves

--- a/docs/api/authentication.mdx
+++ b/docs/api/authentication.mdx
@@ -36,6 +36,19 @@ above. The token is displayed **only once** — copy it and store it securely.
 In either case, click **Generate token** and copy the value into the
 `Authorization: Bearer` header.
 
+### Which token should I use?
+
+Both work identically on the wire — the difference is what the token is tied to:
+
+- Use a **personal token** for interactive work: notebooks, one-off scripts, and
+  local exploration. Its access mirrors yours and is revoked automatically when
+  your own access changes, so it's convenient but tied to your account lifecycle
+  (a token stops working if you leave the workspace or lose a permission).
+- Use an **account token** for anything long-lived or shared: CI jobs, backend
+  services, and third-party integrations. It isn't attached to a person, so it
+  keeps working through team changes and offboarding — which also makes it the
+  token you must rotate and guard most carefully.
+
 <Warning>
   Treat tokens like passwords: never share or commit them, rotate them
   regularly, and revoke a token immediately if it may have been exposed.

--- a/docs/api/errors.mdx
+++ b/docs/api/errors.mdx
@@ -1,0 +1,67 @@
+---
+title: 'Errors'
+description: 'The error envelope, error codes, and how to handle them.'
+---
+
+Every failing request returns a standard HTTP status code and a JSON body with a
+single `error` object:
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Asset 'model.shop.orders' not found."
+  }
+}
+```
+
+| Field     | Description                                                              |
+| --------- | ------------------------------------------------------------------------ |
+| `code`    | Stable, machine-readable identifier. Branch on this, never on `message`. |
+| `message` | Human-readable explanation, intended for logs and debugging.             |
+
+`message` wording may change at any time; `code` values are part of the API
+contract and only change with a new API version. Treat an unrecognized `code` as
+a generic failure of its HTTP status class rather than failing hard.
+
+## Error codes
+
+| Code                | Status       | When it happens                                                                                                               |
+| ------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| `invalid_request`   | `400`, `422` | A parameter is missing, malformed, out of range (e.g. `limit` above 2000), or two mutually exclusive filters were combined.   |
+| `invalid_cursor`    | `400`        | The `cursor` is not a cursor this API issued, or it is reused with different query parameters than the ones that produced it. |
+| `unauthenticated`   | `401`        | The `Authorization` header is missing, malformed, or the token is invalid or revoked.                                         |
+| `permission_denied` | `403`        | The token is valid but not allowed to read the requested environment or object.                                              |
+| `not_found`         | `404`        | The environment or object id doesn't exist — or exists but isn't visible to this token.                                       |
+| `rate_limited`      | `429`        | The account exceeded its request limit. See [Rate limits](/api/rate-limits).                                                  |
+| `internal_error`    | `5xx`        | Something failed on our side. The request was not necessarily rejected — retry it.                                            |
+
+<Note>
+  `404` is also returned instead of `403` for objects a token can't see, so that
+  the API doesn't reveal whether an id exists. A `404` on an id you expect to
+  exist usually means the token's permissions don't cover it.
+</Note>
+
+## Handling errors
+
+- **`400` / `422`** — the request is wrong; fix it and don't retry as-is. On
+  `invalid_cursor`, drop the cursor and restart the iteration from the first
+  page with the same filters.
+- **`401` / `403`** — check the token and its permissions; retrying won't help.
+- **`429`** — back off for at least the `Retry-After` seconds returned with the
+  response before retrying.
+- **`5xx`** — retry with exponential backoff and jitter. Feed requests are
+  idempotent, so replaying a page is safe.
+
+```python
+response = requests.get(url, headers=headers, params=params)
+
+if response.status_code >= 400:
+    error = response.json()["error"]
+    if error["code"] == "invalid_cursor":
+        params.pop("cursor", None)  # restart the iteration
+    elif error["code"] == "rate_limited":
+        time.sleep(int(response.headers.get("Retry-After", 5)))
+    else:
+        raise RuntimeError(f"{error['code']}: {error['message']}")
+```

--- a/docs/api/incremental-sync.mdx
+++ b/docs/api/incremental-sync.mdx
@@ -1,0 +1,82 @@
+---
+title: 'Incremental sync'
+description: 'Full scans plus incremental upsert and delete feeds.'
+---
+
+Every dataset can be read two ways: a **full scan** (default) and, where
+supported, **incremental feeds** that return only what changed.
+
+## Full scan
+
+With no incremental filter, a list endpoint returns every current object,
+paginated by cursor. Use this for the initial load or a periodic full refresh.
+
+```
+GET /{env_id}/assets?limit=500
+```
+
+## Incremental feeds
+
+Assets, columns, and column lineage expose two separate feeds so upserts and
+deletes stay clean and each can use its own index:
+
+| Filter          | Returns                                           | Use for   |
+| --------------- | ------------------------------------------------- | --------- |
+| `synced_since`  | Objects created or updated at/after the timestamp | Upserts   |
+| `deleted_since` | Soft-delete tombstones at/after the timestamp     | Deletions |
+
+```bash
+# New/changed assets since your last sync
+curl -H "Authorization: Bearer $ELEMENTARY_TOKEN" \
+  "$BASE/$ENV_ID/assets?synced_since=2026-08-01T00:00:00Z&limit=500"
+
+# Assets deleted since your last sync
+curl -H "Authorization: Bearer $ELEMENTARY_TOKEN" \
+  "$BASE/$ENV_ID/assets?deleted_since=2026-08-01T00:00:00Z&limit=500"
+```
+
+Timestamps are UTC ISO-8601.
+
+## Recommended loop
+
+1. Store the wall-clock time `T` when you start a sync.
+2. Re-query from a small safety overlap behind the previous watermark (for
+   example, `synced_since=<previous T - overlap>`). This covers clock skew and
+   commits that were in flight when the previous sync ran.
+3. Page the `synced_since` feed to upsert changed objects and the
+   `deleted_since` feed to remove tombstoned objects.
+4. After both feeds complete, persist `T` as the new watermark for the next run.
+
+<Note>
+  Drain each dataset once, then stay incremental. A full `column-lineage` scan
+  is significantly more expensive per page than the other feeds — its edges are
+  derived from each column's stored dependencies, so a full scan reads every
+  column in the environment — while `synced_since` and `deleted_since` reads are
+  index-backed and stay fast as the environment grows. Persist `next_cursor` and
+  the sync timestamp so a scheduled job resumes incrementally instead of
+  re-running the initial snapshot on every run.
+</Note>
+
+<Note>
+  Feeds are **at-least-once**: an object may reappear across runs or in the
+  safety overlap. Upserts and tombstones are keyed by `id`, so re-applying
+  overlapping rows is idempotent.
+</Note>
+
+## Support matrix
+
+| Dataset        | Full scan | Incremental                          |
+| -------------- | --------- | ------------------------------------ |
+| Assets         | ✅        | ✅ (`synced_since`, `deleted_since`) |
+| Columns        | ✅        | ✅ (`synced_since`, `deleted_since`) |
+| Asset lineage  | ✅        | Full replace                         |
+| Column lineage | ✅        | ✅ (`synced_since`, `deleted_since`) |
+
+<Note>
+  Column lineage is returned one record per edge, but edges do not have their
+  own timestamps. The incremental filters use the downstream column's
+  timestamps. When a downstream column appears in the upserts feed, replace all
+  of its edges rather than merging them. An edge removed while its downstream
+  column still exists has no individual tombstone; a downstream column tombstone
+  in `deleted_since` removes all of its edges.
+</Note>

--- a/docs/api/introduction.mdx
+++ b/docs/api/introduction.mdx
@@ -20,7 +20,7 @@ environment. Use it to sync your data catalog and lineage into your own systems
 ## Base URL
 
 ```
-https://app.elementary-data.com/api/public/beta
+https://prod.api.elementary-data.com/public/beta
 ```
 
 ## Quickstart
@@ -35,7 +35,7 @@ See [Authentication](/api/authentication).
 
 ```bash
 curl -H "Authorization: Bearer $ELEMENTARY_TOKEN" \
-  "https://app.elementary-data.com/api/public/beta/environments"
+  "https://prod.api.elementary-data.com/public/beta/environments"
 ```
 
 Each returned `id` is an `env_id` you use in every other endpoint.
@@ -45,7 +45,7 @@ Each returned `id` is an `env_id` you use in every other endpoint.
 <Step title="List assets">
 ```bash
 curl -H "Authorization: Bearer $ELEMENTARY_TOKEN" \
-  "https://app.elementary-data.com/api/public/beta/$ENV_ID/assets?limit=500"
+  "https://prod.api.elementary-data.com/public/beta/$ENV_ID/assets?limit=500"
 ```
 Follow `next_cursor` until `has_more` is `false` — see [Pagination](/api/pagination).
 </Step>

--- a/docs/api/introduction.mdx
+++ b/docs/api/introduction.mdx
@@ -1,0 +1,115 @@
+---
+title: 'Introduction'
+description: "Read Elementary's assets, columns, and lineage over a REST API."
+---
+
+The **Elementary Public API** is a REST interface for programmatically reading
+the assets, columns, and lineage Elementary tracks for one
+environment. Use it to sync your data catalog and lineage into your own systems
+(a warehouse, a BI tool, a data catalog, an internal service).
+
+<Note>
+  The API is in **beta**. The shape may change while we co-design it with early
+  adopters. Endpoints live under `/public/beta`.
+</Note>
+
+## Base URL
+
+```
+https://app.elementary-data.com/api/public/beta
+```
+
+## Quickstart
+
+<Steps>
+<Step title="Get a token">
+Create a personal or account token in Elementary and send it as a bearer token.
+See [Authentication](/api/authentication).
+</Step>
+
+<Step title="Discover your environments">
+
+```bash
+curl -H "Authorization: Bearer $ELEMENTARY_TOKEN" \
+  "https://app.elementary-data.com/api/public/beta/environments"
+```
+
+Each returned `id` is an `env_id` you use in every other endpoint.
+
+</Step>
+
+<Step title="List assets">
+```bash
+curl -H "Authorization: Bearer $ELEMENTARY_TOKEN" \
+  "https://app.elementary-data.com/api/public/beta/$ENV_ID/assets?limit=500"
+```
+Follow `next_cursor` until `has_more` is `false` — see [Pagination](/api/pagination).
+</Step>
+</Steps>
+
+## What you can read
+
+| Resource       | Endpoint                       | Notes                                    |
+| -------------- | ------------------------------ | ---------------------------------------- |
+| Environments   | `GET /environments`            | Account-scoped discovery                 |
+| Assets         | `GET /{env_id}/assets`         | Every asset, common fields + `kind`      |
+| Table assets   | `GET /{env_id}/assets/tables`  | Table assets + warehouse-specific fields |
+| BI assets      | `GET /{env_id}/assets/bi`      | BI assets + BI-specific fields           |
+| Columns        | `GET /{env_id}/columns`        | Columns of assets                        |
+| Asset lineage  | `GET /{env_id}/asset-lineage`  | Asset-to-asset edges                     |
+| Column lineage | `GET /{env_id}/column-lineage` | Column-to-column edges                   |
+
+Every list endpoint supports a full scan and keyset pagination; assets and
+columns also expose incremental feeds — see [Incremental sync](/api/incremental-sync).
+
+## Assets: one base endpoint, plus typed endpoints
+
+Elementary tracks assets of several kinds — warehouse tables and views, BI
+dashboards and explores, semantic models, and more. They share a common set of
+fields but each kind also has its own attributes, so the API splits them:
+
+- **`GET /assets`** returns **every** asset of every kind with the **common
+  fields** (`id`, `name`, `source_type`, `tags`, `owners`, timestamps, …) plus a
+  `kind` discriminator. This is the complete list of lineage nodes: every asset
+  id referenced by asset lineage or column lineage appears here, so you can
+  resolve any edge endpoint to a node.
+- **`GET /assets/tables`** and **`GET /assets/bi`** return the same assets
+  narrowed to a single kind, with that kind's extra fields fully populated —
+  warehouse coordinates (`db_name`, `schema_name`, `table_name`,
+  `materialization`) for tables, and `bi_platform` / `bi_type` / `url` for BI
+  assets. Kind-specific filters live here too (e.g. `db_names` on
+  `/assets/tables`, `bi_platforms` on `/assets/bi`).
+
+**Why the split?** A single asset shape would leave most fields null on any given
+row (a BI dashboard has no `db_name`; a table has no `bi_platform`). Keeping the
+common fields on `/assets` gives you a clean node list for building the lineage
+graph, while the typed endpoints give each kind a tight, fully-populated shape.
+A typical flow: page `/assets` to build the graph, then enrich the kinds you
+care about via the typed endpoints — use the `kind` field to decide which one.
+
+The full endpoint and schema reference is generated from the API and lives under
+**API Reference**.
+
+## Forward compatibility
+
+Some string fields are **extensible enums**: they carry a value from a small,
+known set today (e.g. `kind`, `source_type`, `data_platform`, `materialization`,
+`bi_platform`, `bi_type`, `warehouse_type`, `last_sync_status`), but that set
+grows as Elementary adds integrations and asset types. In the schema these
+fields are typed as plain strings with an `Extensible enum.` note and their
+currently-known values listed under `examples` — they are **not** a closed
+enum.
+
+To stay compatible as the API evolves, build your integration so that:
+
+- **Unknown values never break you.** Treat any value you don't recognize as a
+  safe fallback (for `kind`, use `other`) rather than failing. New values can
+  appear in a normal, non-breaking release.
+- **New fields are ignored, not rejected.** We may add fields to a response;
+  don't configure your parser to reject unknown properties.
+- **You iterate on `has_more`, not item counts** (see [Pagination](/api/pagination)).
+
+Our side of the contract: we add enum values and fields additively without a
+version bump, and never silently change the meaning of an existing value.
+**Removing or renaming** a field or a known value is a breaking change and would
+ship under a new API version, not under `beta`.

--- a/docs/api/introduction.mdx
+++ b/docs/api/introduction.mdx
@@ -8,10 +8,14 @@ the assets, columns, and lineage Elementary tracks for one
 environment. Use it to sync your data catalog and lineage into your own systems
 (a warehouse, a BI tool, a data catalog, an internal service).
 
-<Note>
-  The API is in **beta**. The shape may change while we co-design it with early
-  adopters. Endpoints live under `/public/beta`.
-</Note>
+<Warning>
+  This API is in **active development (beta)** and is **not intended for
+  production use**. The interface can change — including **breaking changes** —
+  while we co-design it with early adopters, and availability, stability, and
+  support are not guaranteed. Endpoints live under `/public/beta`; wait for a
+  stable `v1` before depending on it in production. See
+  [Versioning](/api/versioning).
+</Warning>
 
 ## Base URL
 

--- a/docs/api/pagination.mdx
+++ b/docs/api/pagination.mdx
@@ -1,0 +1,65 @@
+---
+title: 'Pagination'
+description: 'Keyset pagination with opaque cursors across every list endpoint.'
+---
+
+All list endpoints use **keyset (cursor) pagination**. Each page reads live
+data, not a snapshot: concurrent writes can cause rows to shift between pages.
+For a consistent view, rerun the full scan after writes settle.
+
+## Request
+
+```
+GET /{env_id}/assets?limit=500
+```
+
+| Parameter   | Default | Notes                                                  |
+| ----------- | ------- | ------------------------------------------------------ |
+| `limit`     | `500`   | Items per page. Min `1`, max `2000`.                   |
+| `cursor`    | —       | Opaque token from a previous response's `next_cursor`. |
+| `order_by`  | `id`    | Sort key for full scans.                               |
+| `direction` | `asc`   | `asc` or `desc`.                                       |
+
+## Response envelope
+
+```json
+{
+  "items": [{ "id": "...", "...": "..." }],
+  "next_cursor": "eyJ...",
+  "has_more": true
+}
+```
+
+## Iterating
+
+Follow `next_cursor` until `has_more` is `false`:
+
+```bash
+cursor=""
+while : ; do
+  resp=$(curl -s -H "Authorization: Bearer $ELEMENTARY_TOKEN" \
+    "$BASE/$ENV_ID/assets?limit=500&cursor=$cursor")
+  echo "$resp" | jq '.items[]'
+  more=$(echo "$resp" | jq -r '.has_more')
+  [ "$more" = "true" ] || break
+  cursor=$(echo "$resp" | jq -r '.next_cursor')
+done
+```
+
+## Cursor rules
+
+- **Opaque.** The cursor is an encoded token — don't parse or construct it.
+- **Bound to filters.** A cursor is tied to the exact filter and sort context
+  that produced it. Reusing a cursor with a different filter set returns `400`
+  with the `invalid_cursor` code. Start a new iteration if you change filters.
+- **Deterministic order.** Ordering includes `id` as a tiebreaker, so a cursor
+  advances predictably when timestamps collide. It does not freeze the dataset
+  while you page through it.
+
+## Pages can be under-filled
+
+Never treat a short page as the end of the data. A page can hold fewer than
+`limit` items — even zero — while `has_more` is still `true`. This happens when
+asset-level permissions trim rows after a page is read (see
+[Visibility & permissions](/api/authentication)). Stop only when `has_more` is
+`false`.

--- a/docs/api/rate-limits.mdx
+++ b/docs/api/rate-limits.mdx
@@ -1,0 +1,36 @@
+---
+title: 'Rate limits'
+description: 'Per-account limits, standard headers, and how to back off.'
+---
+
+Requests are rate-limited **per account** (across all of that account's tokens).
+
+## Headers
+
+Every response carries the current window state:
+
+| Header                | Meaning                             |
+| --------------------- | ----------------------------------- |
+| `RateLimit-Limit`     | Max requests allowed in the window  |
+| `RateLimit-Remaining` | Requests left in the current window |
+| `RateLimit-Reset`     | Seconds until the window resets     |
+
+## When you're limited
+
+Exceeding the limit returns `429 Too Many Requests` with a `Retry-After` header
+(seconds to wait) and the standard error envelope with the `rate_limited` code:
+
+```http
+HTTP/1.1 429 Too Many Requests
+Retry-After: 12
+
+{
+  "error": {
+    "code": "rate_limited",
+    "message": "Rate limit exceeded: 120 requests per minute."
+  }
+}
+```
+
+Back off for at least `Retry-After` seconds before retrying. A client that reads
+`RateLimit-Remaining` and paces itself will rarely hit `429`.

--- a/docs/api/reference/asset-lineage/list-asset-lineage-edges.mdx
+++ b/docs/api/reference/asset-lineage/list-asset-lineage-edges.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /public/beta/{env_id}/asset-lineage
+openapi: api-reference/beta/openapi.json get /public/beta/{env_id}/asset-lineage
 ---

--- a/docs/api/reference/asset-lineage/list-asset-lineage-edges.mdx
+++ b/docs/api/reference/asset-lineage/list-asset-lineage-edges.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /public/beta/{env_id}/asset-lineage
+---

--- a/docs/api/reference/assets/get-a-bi-asset.mdx
+++ b/docs/api/reference/assets/get-a-bi-asset.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /public/beta/{env_id}/assets/bi/{asset_id}
+openapi: api-reference/beta/openapi.json get /public/beta/{env_id}/assets/bi/{asset_id}
 ---

--- a/docs/api/reference/assets/get-a-bi-asset.mdx
+++ b/docs/api/reference/assets/get-a-bi-asset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /public/beta/{env_id}/assets/bi/{asset_id}
+---

--- a/docs/api/reference/assets/get-a-table-asset.mdx
+++ b/docs/api/reference/assets/get-a-table-asset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /public/beta/{env_id}/assets/tables/{asset_id}
+---

--- a/docs/api/reference/assets/get-a-table-asset.mdx
+++ b/docs/api/reference/assets/get-a-table-asset.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /public/beta/{env_id}/assets/tables/{asset_id}
+openapi: api-reference/beta/openapi.json get /public/beta/{env_id}/assets/tables/{asset_id}
 ---

--- a/docs/api/reference/assets/get-an-asset.mdx
+++ b/docs/api/reference/assets/get-an-asset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /public/beta/{env_id}/assets/{asset_id}
+---

--- a/docs/api/reference/assets/get-an-asset.mdx
+++ b/docs/api/reference/assets/get-an-asset.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /public/beta/{env_id}/assets/{asset_id}
+openapi: api-reference/beta/openapi.json get /public/beta/{env_id}/assets/{asset_id}
 ---

--- a/docs/api/reference/assets/list-assets.mdx
+++ b/docs/api/reference/assets/list-assets.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /public/beta/{env_id}/assets
+---

--- a/docs/api/reference/assets/list-assets.mdx
+++ b/docs/api/reference/assets/list-assets.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /public/beta/{env_id}/assets
+openapi: api-reference/beta/openapi.json get /public/beta/{env_id}/assets
 ---

--- a/docs/api/reference/assets/list-bi-assets.mdx
+++ b/docs/api/reference/assets/list-bi-assets.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /public/beta/{env_id}/assets/bi
+---

--- a/docs/api/reference/assets/list-bi-assets.mdx
+++ b/docs/api/reference/assets/list-bi-assets.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /public/beta/{env_id}/assets/bi
+openapi: api-reference/beta/openapi.json get /public/beta/{env_id}/assets/bi
 ---

--- a/docs/api/reference/assets/list-table-assets.mdx
+++ b/docs/api/reference/assets/list-table-assets.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /public/beta/{env_id}/assets/tables
+openapi: api-reference/beta/openapi.json get /public/beta/{env_id}/assets/tables
 ---

--- a/docs/api/reference/assets/list-table-assets.mdx
+++ b/docs/api/reference/assets/list-table-assets.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /public/beta/{env_id}/assets/tables
+---

--- a/docs/api/reference/column-lineage/list-column-lineage.mdx
+++ b/docs/api/reference/column-lineage/list-column-lineage.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /public/beta/{env_id}/column-lineage
+---

--- a/docs/api/reference/column-lineage/list-column-lineage.mdx
+++ b/docs/api/reference/column-lineage/list-column-lineage.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /public/beta/{env_id}/column-lineage
+openapi: api-reference/beta/openapi.json get /public/beta/{env_id}/column-lineage
 ---

--- a/docs/api/reference/columns/get-a-column.mdx
+++ b/docs/api/reference/columns/get-a-column.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /public/beta/{env_id}/columns/{column_id}
+---

--- a/docs/api/reference/columns/get-a-column.mdx
+++ b/docs/api/reference/columns/get-a-column.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /public/beta/{env_id}/columns/{column_id}
+openapi: api-reference/beta/openapi.json get /public/beta/{env_id}/columns/{column_id}
 ---

--- a/docs/api/reference/columns/list-columns.mdx
+++ b/docs/api/reference/columns/list-columns.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /public/beta/{env_id}/columns
+---

--- a/docs/api/reference/columns/list-columns.mdx
+++ b/docs/api/reference/columns/list-columns.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /public/beta/{env_id}/columns
+openapi: api-reference/beta/openapi.json get /public/beta/{env_id}/columns
 ---

--- a/docs/api/reference/environments/list-environments.mdx
+++ b/docs/api/reference/environments/list-environments.mdx
@@ -1,0 +1,3 @@
+---
+openapi: api-reference/beta/openapi.json get /public/beta/environments
+---

--- a/docs/api/versioning.mdx
+++ b/docs/api/versioning.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Versioning'
+description: 'How the beta channel evolves into a stable v1.'
+---
+
+The API uses a **staged versioning** strategy.
+
+## `beta` — today
+
+```
+/public/beta/...
+```
+
+`beta` is a rolling channel that always points at the latest not-yet-official
+version. While in beta we co-design the API with early adopters, so **breaking
+changes can happen** on this path. We'll flag them in advance to active users.
+
+## `v1` — at GA
+
+When the surface stabilizes, we promote it to a stable version:
+
+```
+/public/v1/...
+```
+
+From `v1` onward we follow an **additive-compatibility** contract: we may add
+fields and endpoints, but we won't remove or repurpose existing ones without a
+new major version.
+
+## Recommendation
+
+Build against `beta` today to get the features early, but pin to `v1` once it
+ships if you need long-term stability guarantees.

--- a/docs/api/versioning.mdx
+++ b/docs/api/versioning.mdx
@@ -29,5 +29,7 @@ new major version.
 
 ## Recommendation
 
-Build against `beta` today to get the features early, but pin to `v1` once it
-ships if you need long-term stability guarantees.
+Use `beta` to explore, integrate early, and send us feedback — but treat it as
+**pre-production**: it isn't intended for production workloads, and breaking
+changes can land without a version bump. If you need long-term stability
+guarantees, wait for `v1` and pin to it once it ships.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -503,6 +503,55 @@
         ]
       },
       {
+        "tab": "API Reference",
+        "openapi": "api-reference/beta/openapi.json",
+        "groups": [
+          {
+            "group": "Guides",
+            "pages": [
+              "api/introduction",
+              "api/authentication",
+              "api/pagination",
+              "api/incremental-sync",
+              "api/rate-limits",
+              "api/errors",
+              "api/versioning"
+            ]
+          },
+          {
+            "group": "Endpoints",
+            "pages": [
+              {
+                "group": "Environments",
+                "pages": [
+                  "api/reference/environments/list-environments"
+                ]
+              },
+              {
+                "group": "Assets",
+                "pages": [
+                  "api/reference/assets/list-assets",
+                  "api/reference/assets/get-an-asset",
+                  "api/reference/assets/list-table-assets",
+                  "api/reference/assets/get-a-table-asset",
+                  "api/reference/assets/list-bi-assets",
+                  "api/reference/assets/get-a-bi-asset",
+                  "api/reference/asset-lineage/list-asset-lineage-edges"
+                ]
+              },
+              {
+                "group": "Columns",
+                "pages": [
+                  "api/reference/columns/list-columns",
+                  "api/reference/columns/get-a-column",
+                  "api/reference/column-lineage/list-column-lineage"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
         "tab": "Elementary OSS",
         "groups": [
           {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -504,7 +504,6 @@
       },
       {
         "tab": "API Reference",
-        "openapi": "api-reference/beta/openapi.json",
         "groups": [
           {
             "group": "Guides",


### PR DESCRIPTION
## Summary

Adds an **API Reference** tab to the docs site for the beta **Elementary Public API**, rendered from a committed OpenAPI snapshot.

- **Guides** (`docs/api/*.mdx`): introduction, authentication, pagination, incremental sync, rate limits, errors, versioning.
- **Endpoints** (`docs/api/reference/**`, bound to `docs/api-reference/beta/openapi.json`):
  - Environments — list
  - Assets — list/get, typed table + BI endpoints, asset lineage edges
  - Columns — list/get, column lineage edges
- **Nav** (`docs/docs.json`): one new tab inserted between *Python SDK* and *Elementary OSS* (49-line insertion, no other changes). Branding (pink `#FF20B8`, `mint` theme) is inherited automatically.

## How it was produced

The OpenAPI snapshot is a **one-time manual copy** from `elementary-internal`, generated by `apps/api/scripts/generate_external_openapi.py`. Verified byte-identical to a fresh regeneration from the API branch tip (11 operations, title "Elementary Public API", version "beta").

## Follow-up (not in this PR)

Automate keeping the snapshot fresh: an `elementary-internal` CI job regenerates `openapi.json` and opens a cross-repo bot PR into this repo, gated on the beta API deploy so beta docs go live only when the API ships. Until then the snapshot must be regenerated manually when the beta surface changes (a `--check` drift guard already exists on the API side).

## Validation

- `mint openapi-check` / pre-commit **Mintlify validate**: spec valid ✔
- All 11 endpoint stubs resolve to real spec operations (no missing/orphans) ✔
- `docs.json` parses; tab order correct ✔

## Test plan

- [ ] `cd docs && mint dev` — confirm the *API Reference* tab renders, guides load, and endpoint pages populate (not just titles)
- [ ] Confirm no new broken links (`mint broken-links`)

Made with [Cursor](https://cursor.com)