### PR TITLE
docs(api): clarify synced_at semantics (1970-01-01 sentinel)

### DIFF
--- a/docs/api/incremental-sync.mdx
+++ b/docs/api/incremental-sync.mdx
@@ -37,6 +37,17 @@ curl -H "Authorization: Bearer $ELEMENTARY_TOKEN" \
 
 Timestamps are UTC ISO-8601.
 
+<Note>
+  **What `synced_at` means.** `synced_at` marks when an object was **created or
+  last changed** in Elementary — not when it was last *seen*. Unchanged objects
+  keep their existing `synced_at`, and some objects that predate this field may
+  show a `1970-01-01T00:00:00` placeholder. This is expected and safe for
+  incremental loading: every object is returned by the initial full scan
+  (regardless of `synced_at`), and any later change gives it a fresh `synced_at`,
+  so it reappears in the `synced_since` feed. Treat `synced_at` as a change
+  marker for driving upserts, not as an absolute "last refreshed" timestamp.
+</Note>
+
 ## Recommended loop
 
 1. Store the wall-clock time `T` when you start a sync.


### PR DESCRIPTION
## Summary

Adds a note to the **Incremental sync** guide clarifying what `synced_at` means, after smoke-testing the beta surfaced `synced_at: "1970-01-01T00:00:00"` on a subset of columns.

- `synced_at` marks **created / last-changed**, not last-seen.
- Unchanged objects keep their existing value; some pre-existing rows carry a `1970-01-01` epoch placeholder.
- This is **safe for incremental**: every object is returned by the initial full scan regardless of `synced_at`, and any later change re-emits it in the `synced_since` feed.
- Guidance: treat `synced_at` as a change marker for upserts, not an absolute freshness signal.

Addresses [APP-1550](https://linear.app/elementary/issue/APP-1550). The matching OpenAPI field descriptions (`synced_at` on assets/columns) are sharpened in `elementary-internal` (spec source of truth) and reach the published snapshot via the cross-repo sync ([APP-1546](https://linear.app/elementary/issue/APP-1546)).

## Test plan

- [x] `mint dev` renders `/api/incremental-sync` (HTTP 200) with the new note.
- [x] Mintlify validation passes.

Made with [Cursor](https://cursor.com)