### PR TITLE
docs: remove Start Free with Cloud hero button

### DIFF
--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -28,9 +28,6 @@ icon: "house"
               >
                 Setup OSS
               </a>
-              <a href="/cloud/quickstart" className="home__hero-btn home__hero-btn--secondary">
-                Start Free with Cloud
-              </a>
             </div>
           </div>
           <div className="home__hero-image-block">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -687,7 +687,7 @@ h1, h2, h3, h4, h5, h6 {
   flex-direction: row;
   gap: 24px;
   margin-top: 8px;
-  justify-content: center;
+  justify-content: flex-start;
   width: 100%;
 }
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -770,6 +770,10 @@ h1, h2, h3, h4, h5, h6 {
     align-items: center;
     text-align: center;
   }
+
+  .home__hero-buttons {
+    justify-content: center;
+  }
 }
 
 @media (max-width: 700px) {


### PR DESCRIPTION
Removes the "Start Free with Cloud" button from the homepage hero