### PR TITLE
fix: interpret naive detected_at as UTC + tz-aware fallback in alert groups

### DIFF
--- a/elementary/monitor/alerts/alert.py
+++ b/elementary/monitor/alerts/alert.py
@@ -58,7 +58,11 @@ class AlertModel:
         self.detected_at = None
         if detected_at is not None:
             try:
-                self.detected_at_utc = detected_at
+                # detected_at is stored in UTC, so a naive datetime must be
+                # interpreted as UTC rather than as the machine's local time.
+                if detected_at.tzinfo is None:
+                    detected_at = detected_at.replace(tzinfo=tz.tzutc())
+                self.detected_at_utc = detected_at.astimezone(tz.tzutc())
                 self.detected_at = detected_at.astimezone(
                     tz.gettz(timezone) if timezone else tz.tzlocal()
                 )

--- a/elementary/monitor/alerts/alerts_groups/base_alerts_group.py
+++ b/elementary/monitor/alerts/alerts_groups/base_alerts_group.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Dict, List, Optional, Sequence
 
+from dateutil import tz
+
 from elementary.monitor.alerts.alert import AlertModel
 
 
@@ -20,7 +22,10 @@ class BaseAlertsGroup(ABC):
 
     @property
     def detected_at(self) -> datetime:
-        return min(alert.detected_at or datetime.max for alert in self.alerts)
+        return min(
+            alert.detected_at or datetime.max.replace(tzinfo=tz.tzutc())
+            for alert in self.alerts
+        )
 
     @property
     @abstractmethod

--- a/tests/unit/monitor/alerts/test_alert_models.py
+++ b/tests/unit/monitor/alerts/test_alert_models.py
@@ -1,9 +1,22 @@
+import time
+from datetime import datetime
+
 import pytest
+from dateutil import tz
 
 from elementary.monitor.alerts.alert import AlertModel
 from elementary.monitor.alerts.model_alert import ModelAlertModel
 from elementary.monitor.alerts.source_freshness_alert import SourceFreshnessAlertModel
 from elementary.monitor.alerts.test_alert import TestAlertModel
+
+
+@pytest.fixture
+def tokyo_local_timezone(monkeypatch):
+    monkeypatch.setenv("TZ", "Asia/Tokyo")
+    time.tzset()
+    yield
+    monkeypatch.undo()
+    time.tzset()
 
 
 def _make_test_alert(
@@ -95,3 +108,75 @@ class TestSourceFreshnessAlertModel:
     def test_concise_name_is_source_dot_identifier(self) -> None:
         alert = _make_source_freshness_alert(source_name="raw", identifier="orders")
         assert alert.concise_name == "raw.orders"
+
+
+class TestAlertModelDetectedAtTimezone:
+    """detected_at is stored in UTC (naive) in the alerts table and must be
+    interpreted as UTC, not as the machine's local time."""
+
+    def test_naive_detected_at_is_converted_to_given_timezone(
+        self, tokyo_local_timezone
+    ) -> None:
+        alert = AlertModel(
+            id="id",
+            alert_class_id="acid",
+            detected_at=datetime(2026, 7, 22, 9, 8, 22),
+            timezone="Asia/Tokyo",
+        )
+        assert alert.detected_at == datetime(
+            2026, 7, 22, 18, 8, 22, tzinfo=tz.gettz("Asia/Tokyo")
+        )
+        assert alert.detected_at_str == "2026-07-22 18:08:22 JST"
+
+    def test_naive_detected_at_is_converted_to_local_timezone_by_default(
+        self, tokyo_local_timezone
+    ) -> None:
+        alert = AlertModel(
+            id="id",
+            alert_class_id="acid",
+            detected_at=datetime(2026, 7, 22, 9, 8, 22),
+        )
+        assert alert.detected_at_str == "2026-07-22 18:08:22 JST"
+
+    def test_naive_detected_at_utc_is_utc_aware(self, tokyo_local_timezone) -> None:
+        alert = AlertModel(
+            id="id",
+            alert_class_id="acid",
+            detected_at=datetime(2026, 7, 22, 9, 8, 22),
+            timezone="Asia/Tokyo",
+        )
+        assert alert.detected_at_utc == datetime(
+            2026, 7, 22, 9, 8, 22, tzinfo=tz.tzutc()
+        )
+
+    def test_aware_detected_at_keeps_working(self, tokyo_local_timezone) -> None:
+        alert = AlertModel(
+            id="id",
+            alert_class_id="acid",
+            detected_at=datetime(2026, 7, 22, 9, 8, 22, tzinfo=tz.tzutc()),
+            timezone="Asia/Tokyo",
+        )
+        assert alert.detected_at_str == "2026-07-22 18:08:22 JST"
+
+    def test_source_freshness_result_description_uses_consistent_timezone(
+        self, tokyo_local_timezone
+    ) -> None:
+        alert = SourceFreshnessAlertModel(
+            id="id",
+            source_name="my_source",
+            identifier="my_table",
+            original_status="fail",
+            path="models/src.yml",
+            error=None,
+            alert_class_id="acid",
+            source_freshness_execution_id="sfeid",
+            detected_at=datetime(2026, 7, 22, 9, 8, 22),
+            max_loaded_at=datetime(2026, 7, 21, 8, 55, 10),
+            max_loaded_at_time_ago_in_s=87101.8,
+            timezone="Asia/Tokyo",
+        )
+        assert alert.result_description == (
+            "When the test ran at 2026-07-22 18:08:22 JST, "
+            "the most recent record found in the table was 1 day 0h 11m 41s earlier "
+            "(2026-07-21 17:55:10 JST)."
+        )

--- a/tests/unit/monitor/alerts/test_alert_models.py
+++ b/tests/unit/monitor/alerts/test_alert_models.py
@@ -1,10 +1,12 @@
 import time
 from datetime import datetime
+from typing import Optional
 
 import pytest
 from dateutil import tz
 
 from elementary.monitor.alerts.alert import AlertModel
+from elementary.monitor.alerts.alerts_groups import AlertsGroup
 from elementary.monitor.alerts.model_alert import ModelAlertModel
 from elementary.monitor.alerts.source_freshness_alert import SourceFreshnessAlertModel
 from elementary.monitor.alerts.test_alert import TestAlertModel
@@ -20,7 +22,9 @@ def tokyo_local_timezone(monkeypatch):
 
 
 def _make_test_alert(
-    test_sub_type: str = "generic", test_short_name: str = "my_test"
+    test_sub_type: str = "generic",
+    test_short_name: str = "my_test",
+    detected_at: Optional[datetime] = None,
 ) -> TestAlertModel:
     return TestAlertModel(
         id="id",
@@ -32,6 +36,7 @@ def _make_test_alert(
         test_sub_type=test_sub_type,
         test_short_name=test_short_name,
         alert_class_id="acid",
+        detected_at=detected_at,
     )
 
 
@@ -180,3 +185,11 @@ class TestAlertModelDetectedAtTimezone:
             "the most recent record found in the table was 1 day 0h 11m 41s earlier "
             "(2026-07-21 17:55:10 JST)."
         )
+
+    def test_alerts_group_detected_at_with_missing_timestamp(
+        self, tokyo_local_timezone
+    ) -> None:
+        with_time = _make_test_alert(detected_at=datetime(2026, 7, 22, 9, 8, 22))
+        without_time = _make_test_alert()
+        group = AlertsGroup(alerts=[with_time, without_time])
+        assert group.detected_at == with_time.detected_at


### PR DESCRIPTION
## Summary

Supersedes #2305 (by @hiromi-dev, commit preserved with original authorship) and #2341 — both fix #2304. Pushing to the fork branch of #2305 was not possible from this session, so this PR carries that commit plus one follow-up addressing the CodeRabbit finding on #2305.

- `AlertModel.__init__` (from #2305): naive `detected_at` (stored as UTC in the alerts table) gets `tzinfo=UTC` attached before `astimezone()`, instead of being interpreted as local host time. `detected_at_utc` is now always tz-aware UTC.
- `BaseAlertsGroup.detected_at`: the `None` fallback is now tz-aware so a group mixing a real timestamp with a missing one no longer raises `TypeError: can't compare offset-naive and offset-aware datetimes`:
  ```diff
  -min(alert.detected_at or datetime.max for alert in self.alerts)
  +min(alert.detected_at or datetime.max.replace(tzinfo=tz.tzutc()) for alert in self.alerts)
  ```
  This was a pre-existing latent bug (`astimezone()` already returned aware datetimes), not a regression from #2305; fixed here since the same PR is touching this path. Regression test added (`test_alerts_group_detected_at_with_missing_timestamp`).


Link to Devin session: https://app.devin.ai/sessions/b00625736a91440886fe65d392bfda17
Open in Devin Desktop: https://app.devin.ai/desktop/session/b00625736a91440886fe65d392bfda17?variant=devin
Requested by: @haritamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Alert timestamps without an explicit timezone are now consistently interpreted as UTC.
  - Timezone-aware timestamps continue to be normalized correctly to UTC.
  - Alerts without detection timestamps now use timezone-consistent fallback handling.
  - Alert freshness descriptions and displayed times are more reliable across different local timezones.

- **Tests**
  - Added coverage for timezone conversion, timestamp preservation, and alerts without detection times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->