### PR TITLE
docs: BigQuery nested STRUCT support in anomaly tests

### DIFF
--- a/docs/data-tests/anomaly-detection-tests/all-columns-anomalies.mdx
+++ b/docs/data-tests/anomaly-detection-tests/all-columns-anomalies.mdx
@@ -18,6 +18,10 @@ Specific monitors are detailed in the table below and can be configured using th
 The test checks the data type of each column and only executes monitors that are relevant to it.
 You can use `column_anomalies` param to override the default monitors, and `exclude_prefix` / `exclude_regexp` to exclude columns from the test.
 
+<Note>
+  **BigQuery: nested STRUCT fields.** `all_columns_anomalies` monitors top-level columns and does not automatically expand nested STRUCT fields. To monitor a nested field, add a [`column_anomalies`](/data-tests/anomaly-detection-tests/column-anomalies) test that references it by its dotted path, for example `user.address.city`. Fields under a `REPEATED` (array) ancestor are not supported.
+</Note>
+
 <ColumnMetrics />
 
 ### Test configuration

--- a/docs/data-tests/anomaly-detection-tests/column-anomalies.mdx
+++ b/docs/data-tests/anomaly-detection-tests/column-anomalies.mdx
@@ -5,6 +5,7 @@ sidebarTitle: "Column anomalies"
 
 import AiGenerateTest from '/snippets/ai-generate-test.mdx';
 import ColumnMetrics from '/snippets/column-metrics.mdx';
+import BigQueryNestedStruct from '/snippets/data-tests/bigquery-nested-struct-anomalies.mdx';
 
 
 <AiGenerateTest />
@@ -15,6 +16,8 @@ Executes column level monitors and anomaly detection on the column.
 Specific monitors are detailed in the table below and can be configured using the `columns_anomalies` configuration.
 
 The test checks the data type of the column and only executes monitors that are relevant to it.
+
+<BigQueryNestedStruct />
 
 <ColumnMetrics />
 

--- a/docs/data-tests/anomaly-detection-tests/dimension-anomalies.mdx
+++ b/docs/data-tests/anomaly-detection-tests/dimension-anomalies.mdx
@@ -4,6 +4,7 @@ title: "dimension_anomalies"
 ---
 
 import AiGenerateTest from '/snippets/ai-generate-test.mdx';
+import BigQueryNestedStruct from '/snippets/data-tests/bigquery-nested-struct-anomalies.mdx';
 
 
 <AiGenerateTest />
@@ -12,6 +13,8 @@ import AiGenerateTest from '/snippets/ai-generate-test.mdx';
 `elementary.dimension_anomalies`
 
 The test counts rows grouped by given `dimensions` (columns/expressions).
+
+<BigQueryNestedStruct />
 
 This test practically monitors the frequency of values in the configured dimension over time, and alerts on unexpected changes in the distribution.
 It is best to configure it on low-cardinality fields.

--- a/docs/snippets/data-tests/bigquery-nested-struct-anomalies.mdx
+++ b/docs/snippets/data-tests/bigquery-nested-struct-anomalies.mdx
@@ -1,0 +1,5 @@
+<Note>
+  **BigQuery: nested STRUCT fields.** On BigQuery you can reference nested STRUCT leaf fields by their dotted path, for example `user.address.city`, wherever you name a column or dimension in this test. There is no need to flatten them into their own columns first, and the full dotted path is preserved in alerts.
+
+  Fields under a `REPEATED` (array) ancestor are not supported.
+</Note>


### PR DESCRIPTION
## What

Documents BigQuery nested STRUCT support in anomaly tests, shipped in dbt package v0.26.0 ([#1012](https://github.com/elementary-data/dbt-data-reliability/pull/1012)).

`column_anomalies` and `dimension_anomalies` can now reference nested STRUCT leaf fields by dotted path on BigQuery (e.g. `user.address.city`) instead of only top-level columns. The dotted path is preserved in alerts. Fields under a REPEATED (array) ancestor are not supported. `all_columns_anomalies` does not auto-expand nested STRUCTs.

## Changes

- **New snippet** `snippets/data-tests/bigquery-nested-struct-anomalies.mdx` — shared `<Note>` describing the capability + the array limitation.
- **`column-anomalies.mdx`** and **`dimension-anomalies.mdx`** — render the shared snippet.
- **`all-columns-anomalies.mdx`** — tailored note (does not auto-expand nested STRUCTs; points users to a `column_anomalies` test on the nested field).

Edits to existing pages only — no `docs.json` nav or features-card change.

## Checks

- `mintlify broken-links` passes (no broken links).

## For reviewer

- Confirm the recommended path for monitoring a nested field under `all_columns_anomalies` (a `column_anomalies` test on the dotted field vs. an explicit `column_name` argument). The note currently recommends the former.

🤖 Generated with [Claude Code](https://claude.com/claude-code)