### PR TITLE
docs: nest Understanding dimension anomalies under a Dimension anomalies group

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -418,8 +418,13 @@
               "data-tests/anomaly-detection-tests/volume-anomalies",
               "data-tests/anomaly-detection-tests/freshness-anomalies",
               "data-tests/anomaly-detection-tests/event-freshness-anomalies",
-              "data-tests/anomaly-detection-tests/dimension-anomalies",
-              "data-tests/anomaly-detection-tests/understanding-dimension-anomalies",
+              {
+                "group": "Dimension anomalies",
+                "pages": [
+                  "data-tests/anomaly-detection-tests/dimension-anomalies",
+                  "data-tests/anomaly-detection-tests/understanding-dimension-anomalies"
+                ]
+              },
               "data-tests/anomaly-detection-tests/all-columns-anomalies",
               "data-tests/anomaly-detection-tests/column-anomalies",
               "data-tests/anomaly-detection-tests/Anomaly-troubleshooting-guide"


### PR DESCRIPTION
## What

Nests **Understanding dimension anomalies** under a collapsible **Dimension anomalies** group in the sidebar, instead of leaving it as a flat sibling that reads as an orphaned top-level page.

Before:
```
• Dimension anomalies
• Understanding dimension anomalies   ← flat sibling
• All columns anomalies
```

After:
```
▸ Dimension anomalies
    • Dimension anomalies
    • Understanding dimension anomalies
• All columns anomalies
```

## Changes

- `docs/docs.json` — wrap the two dimension pages in a `Dimension anomalies` group under the Anomaly Detection Tests nav.

Nav-only change. `mintlify broken-links` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)