### PR TITLE
perf: prune partitions in the remaining report queries

### DIFF
--- a/elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql
+++ b/elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql
@@ -2,14 +2,14 @@
     with elementary_test_results as (
         select * from {{ ref('elementary', 'elementary_test_results') }}
         {% if days_back %}
-            where {{ elementary.edr_datediff(elementary.edr_cast_as_timestamp('detected_at'), elementary.edr_current_timestamp(), 'day') }} < {{ days_back }}
+            where {{ elementary_cli.days_back_filter('detected_at', days_back, partition_column='created_at') }}
         {% endif %}
     ),
 
     dbt_run_results as (
         select * from {{ ref('elementary', 'dbt_run_results') }}
         {% if days_back %}
-            where {{ elementary.edr_datediff(elementary.edr_cast_as_timestamp('execute_completed_at'), elementary.edr_current_timestamp(), 'day') }} < {{ days_back }}
+            where {{ elementary_cli.days_back_filter('execute_completed_at', days_back, partition_column='created_at', column_is_string=true) }}
         {% endif %}
     ),
 

--- a/elementary/monitor/dbt_project/macros/get_result_rows_agate.sql
+++ b/elementary/monitor/dbt_project/macros/get_result_rows_agate.sql
@@ -1,32 +1,10 @@
 {% macro get_result_rows_agate(days_back, valid_ids_query = none) %}
-  {% do return(adapter.dispatch('get_result_rows_agate', 'elementary_cli')(days_back, valid_ids_query)) %}
-{% endmacro %}
-
-{% macro default__get_result_rows_agate(days_back, valid_ids_query = none) %}
   {% set query %}
   select
     elementary_test_results_id,
     result_row
   from {{ ref("test_result_rows", package="elementary") }}
-  where {{ elementary.edr_datediff(elementary.edr_cast_as_timestamp('detected_at'), elementary.edr_current_timestamp(), 'day') }} < {{ days_back }}
-  {% if valid_ids_query %}
-    and elementary_test_results_id in ({{ valid_ids_query }})
-  {% endif %}
-  {% endset %}
-  {% set res = elementary.run_query(query) %}
-  {% if not res %}
-    {% do return({}) %}
-  {% endif %}
-  {% do return(res.group_by("elementary_test_results_id")) %}
-{% endmacro %}
-
-{% macro bigquery__get_result_rows_agate(days_back, valid_ids_query = none) %}
-  {% set query %}
-  select
-    elementary_test_results_id,
-    result_row
-  from {{ ref("test_result_rows", package="elementary") }}
-  where detected_at > {{ elementary.edr_timeadd('day', -1 * days_back, elementary.edr_current_timestamp()) }}
+  where {{ elementary_cli.days_back_filter('detected_at', days_back, partition_column='created_at') }}
   {% if valid_ids_query %}
     and elementary_test_results_id in ({{ valid_ids_query }})
   {% endif %}

--- a/elementary/monitor/dbt_project/macros/utils/days_back_filter.sql
+++ b/elementary/monitor/dbt_project/macros/utils/days_back_filter.sql
@@ -1,67 +1,44 @@
 {#
-    Renders the `where` predicate for a `days_back` lookback.
+  Filters `column` to the last `days_back` days.
 
-    The default implementation is the shape these queries have always used: wrap the column in a
-    timestamp cast and compare a `datediff` against `days_back`.
-
-    On BigQuery that shape cannot prune partitions — a function applied to the partition column
-    forces a full scan — so `bigquery__` compares the column directly instead, and optionally adds
-    a bound on `partition_column`.
-
-    That second bound looks redundant, and logically it is: it is implied by the first. It exists
-    because BigQuery only prunes on the raw partition column. It is needed whenever the column
-    being filtered is not the partition column, and whenever it has to be cast (dbt_run_results
-    stores `generated_at` and `execute_completed_at` as strings, so a cast is unavoidable there
-    and no predicate on them can ever prune).
-
-    The bound is deliberately given a day of slack. `created_at` is stamped by the warehouse at
-    insert time while the columns it guards come from the dbt client, so the two are not read from
-    the same clock. Pruning is only ever at day granularity, so the slack costs at most one extra
-    partition and removes any chance of the guard excluding a row the real predicate wanted.
-
-    Args:
-        column: the column to filter on.
-        days_back: size of the lookback window, in days.
-        partition_column: the table's partition column, when it differs from `column`. Adds the
-            pruning bound described above.
-        column_is_string: set when `column` is stored as a string and needs casting before
-            comparison.
+  Pass `partition_column` when `column` is not the table's partition column, or is a string and so
+  has to be cast: BigQuery prunes only on the raw partition column, and without this the query
+  scans all history. Its bound carries a day of slack because the two columns are stamped from
+  different clocks — the guarded ones by the dbt client, `created_at` by the warehouse on insert.
 #}
 
 {% macro days_back_filter(column, days_back, partition_column=none, column_is_string=false) %}
-    {% do return(
-        adapter.dispatch("days_back_filter", "elementary_cli")(
-            column, days_back, partition_column, column_is_string
-        )
-    ) %}
+  {% do return(
+    adapter.dispatch("days_back_filter", "elementary_cli")(
+      column, days_back, partition_column, column_is_string
+    )
+  ) %}
 {% endmacro %}
 
 {% macro default__days_back_filter(
-    column, days_back, partition_column=none, column_is_string=false
+  column, days_back, partition_column=none, column_is_string=false
 ) %}
-    {% set predicate %}
-        {{ elementary.edr_datediff(
-            elementary.edr_cast_as_timestamp(column), elementary.edr_current_timestamp(), 'day'
-        ) }} < {{ days_back }}
-    {% endset %}
-    {% do return(predicate) %}
+  {%- set days_diff = elementary.edr_datediff(
+    elementary.edr_cast_as_timestamp(column), elementary.edr_current_timestamp(), "day"
+  ) -%}
+  {% do return(days_diff ~ " < " ~ days_back) %}
 {% endmacro %}
 
 {% macro bigquery__days_back_filter(
-    column, days_back, partition_column=none, column_is_string=false
+  column, days_back, partition_column=none, column_is_string=false
 ) %}
-    {% set window_start = elementary.edr_timeadd(
-        "day", -1 * (days_back | int), elementary.edr_current_timestamp()
-    ) %}
-    {% set filtered = elementary.edr_cast_as_timestamp(column) if column_is_string else column %}
-    {% set predicate %}
-        {{ filtered }} > {{ window_start }}
-        {% if partition_column and partition_column != column %}
-            {# a day of slack, since this column is stamped from a different clock #}
-            and {{ partition_column }} > {{ elementary.edr_timeadd(
-                "day", -1 * (days_back | int + 1), elementary.edr_current_timestamp()
-            ) }}
-        {% endif %}
-    {% endset %}
-    {% do return(predicate) %}
+  {%- set filtered = elementary.edr_cast_as_timestamp(column) if column_is_string else column -%}
+  {%- set conditions = [
+    filtered ~ " > " ~ elementary.edr_timeadd(
+      "day", -1 * (days_back | int), elementary.edr_current_timestamp()
+    )
+  ] -%}
+  {%- if partition_column and partition_column != column -%}
+    {%- do conditions.append(
+      partition_column ~ " > " ~ elementary.edr_timeadd(
+        "day", -1 * ((days_back | int) + 1), elementary.edr_current_timestamp()
+      )
+    ) -%}
+  {%- endif -%}
+  {% do return(conditions | join(" and ")) %}
 {% endmacro %}

--- a/elementary/monitor/dbt_project/macros/utils/days_back_filter.sql
+++ b/elementary/monitor/dbt_project/macros/utils/days_back_filter.sql
@@ -1,0 +1,67 @@
+{#
+    Renders the `where` predicate for a `days_back` lookback.
+
+    The default implementation is the shape these queries have always used: wrap the column in a
+    timestamp cast and compare a `datediff` against `days_back`.
+
+    On BigQuery that shape cannot prune partitions — a function applied to the partition column
+    forces a full scan — so `bigquery__` compares the column directly instead, and optionally adds
+    a bound on `partition_column`.
+
+    That second bound looks redundant, and logically it is: it is implied by the first. It exists
+    because BigQuery only prunes on the raw partition column. It is needed whenever the column
+    being filtered is not the partition column, and whenever it has to be cast (dbt_run_results
+    stores `generated_at` and `execute_completed_at` as strings, so a cast is unavoidable there
+    and no predicate on them can ever prune).
+
+    The bound is deliberately given a day of slack. `created_at` is stamped by the warehouse at
+    insert time while the columns it guards come from the dbt client, so the two are not read from
+    the same clock. Pruning is only ever at day granularity, so the slack costs at most one extra
+    partition and removes any chance of the guard excluding a row the real predicate wanted.
+
+    Args:
+        column: the column to filter on.
+        days_back: size of the lookback window, in days.
+        partition_column: the table's partition column, when it differs from `column`. Adds the
+            pruning bound described above.
+        column_is_string: set when `column` is stored as a string and needs casting before
+            comparison.
+#}
+
+{% macro days_back_filter(column, days_back, partition_column=none, column_is_string=false) %}
+    {% do return(
+        adapter.dispatch("days_back_filter", "elementary_cli")(
+            column, days_back, partition_column, column_is_string
+        )
+    ) %}
+{% endmacro %}
+
+{% macro default__days_back_filter(
+    column, days_back, partition_column=none, column_is_string=false
+) %}
+    {% set predicate %}
+        {{ elementary.edr_datediff(
+            elementary.edr_cast_as_timestamp(column), elementary.edr_current_timestamp(), 'day'
+        ) }} < {{ days_back }}
+    {% endset %}
+    {% do return(predicate) %}
+{% endmacro %}
+
+{% macro bigquery__days_back_filter(
+    column, days_back, partition_column=none, column_is_string=false
+) %}
+    {% set window_start = elementary.edr_timeadd(
+        "day", -1 * (days_back | int), elementary.edr_current_timestamp()
+    ) %}
+    {% set filtered = elementary.edr_cast_as_timestamp(column) if column_is_string else column %}
+    {% set predicate %}
+        {{ filtered }} > {{ window_start }}
+        {% if partition_column and partition_column != column %}
+            {# a day of slack, since this column is stamped from a different clock #}
+            and {{ partition_column }} > {{ elementary.edr_timeadd(
+                "day", -1 * (days_back | int + 1), elementary.edr_current_timestamp()
+            ) }}
+        {% endif %}
+    {% endset %}
+    {% do return(predicate) %}
+{% endmacro %}


### PR DESCRIPTION
## What

The report queries filter their largest tables with `edr_datediff(edr_cast_as_timestamp(col), now, 'day') < days_back`. On BigQuery, a function applied to the column defeats partition pruning, so these scan all history however small `days_back` is.

This is the same defect #1940 fixed for `test_result_rows`, applied to the remaining sites — and it generalises that fix so the pattern is in one place instead of copied per macro.

## Measured

A 7-day lookback selecting a single column, on tables exactly as they are — no repartitioning needed to get this:

| Table | Before | After |
|---|---|---|
| `elementary_test_results` (12M rows, 13GB) | 1,368 MB | **13.68 MB** |
| `dbt_run_results` (17M rows, 41GB) | 1,627 MB | **63.56 MB** |
| `test_result_rows` (26M rows, 41GB) | 1,060 MB | **101 MB** |

For scale, an unfiltered scan of `elementary_test_results` reads 1,279 MB: the current predicate reads *more than no filter at all*, because it also pays to read the column it filters on.

## How

A dispatched `days_back_filter` macro. `default__` renders exactly the predicate these queries have always used, so **nothing changes off BigQuery**. `bigquery__` compares the column directly and adds a bound on the partition column.

Applied to both CTEs of `current_tests_run_results_query`, and to `get_result_rows_agate` — which lets that macro's `bigquery__` override go away. #1940 had to duplicate the entire body just to change one `where` clause; with the dispatch in the predicate helper, the two copies collapse back into one.

### About the redundant-looking bound

The BigQuery variant emits e.g. `detected_at > X and created_at > X-1day`. The second predicate is implied by the first — it exists only because BigQuery prunes on the raw partition column and nothing else. It is needed when the filtered column is not the partition column, and unavoidable for `dbt_run_results`, which stores `generated_at` and `execute_completed_at` as strings: those need a cast, and no cast predicate can ever prune.

It cannot exclude a row the real predicate wants, because `created_at` is stamped by `insert_rows` from `edr_current_timestamp()` at insert time and never read from the row payload — so it is always at or after the event timestamp it guards. Checked over 17.2M rows: `created_at - generated_at` >= 0s, `created_at - execute_completed_at` >= +5s, `created_at - detected_at` >= 0s across 12M and 26M row tables, zero violations of any.

Since those two timestamps are not read from the same clock — one warehouse-side, one client-side — the bound is given a day of slack rather than the same bound, so client drift cannot cost a row. Pruning is at day granularity, so that is at most one extra partition; on the figures above it measured as no difference at all, the real predicate being the binding constraint.

## Not included

`get_models_runs` has the same defect and is the largest single win, but it reads the `model_run_results` view, which does not expose `created_at` — so it has no prunable column until elementary-data/dbt-data-reliability#1057 lands. Deliberately left for a follow-up rather than shipped broken.

`get_source_freshness_results` and `can_upload_source_freshness` carry the same shape. I have no source-freshness data to measure, so I have not touched them — happy to if you would like them included.

## Testing

Rendering verified for each branch of the macro: timestamp column, string column (cast applied), the column being the partition column itself (bound correctly suppressed), a string-typed `days_back`, and the default path (byte-identical semantics to the predicate it replaces). Resulting predicates dry-run against real tables for the figures above. `typos` clean; the repo's Python hooks do not apply to `.sql`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved date-range filtering for recent test and run results.
  - BigQuery queries can make better use of partitioned data, potentially reducing scan volume and improving response times.

- **Consistency**
  - Standardized result filtering across supported database environments.
  - Preserved filtering by valid result IDs and grouping of returned rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->