### PR TITLE
perf: prune partitions in get_models_runs

### DIFF
--- a/elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql
+++ b/elementary/monitor/dbt_project/macros/base_queries/current_tests_run_results_query.sql
@@ -2,14 +2,14 @@
     with elementary_test_results as (
         select * from {{ ref('elementary', 'elementary_test_results') }}
         {% if days_back %}
-            where {{ elementary.edr_datediff(elementary.edr_cast_as_timestamp('detected_at'), elementary.edr_current_timestamp(), 'day') }} < {{ days_back }}
+            where {{ elementary_cli.days_back_filter('detected_at', days_back, partition_column='created_at') }}
         {% endif %}
     ),
 
     dbt_run_results as (
         select * from {{ ref('elementary', 'dbt_run_results') }}
         {% if days_back %}
-            where {{ elementary.edr_datediff(elementary.edr_cast_as_timestamp('execute_completed_at'), elementary.edr_current_timestamp(), 'day') }} < {{ days_back }}
+            where {{ elementary_cli.days_back_filter('execute_completed_at', days_back, partition_column='created_at', column_is_string=true) }}
         {% endif %}
     ),
 

--- a/elementary/monitor/dbt_project/macros/get_models_runs.sql
+++ b/elementary/monitor/dbt_project/macros/get_models_runs.sql
@@ -5,6 +5,7 @@
                 *,
                 row_number() over (partition by unique_id order by generated_at desc) as invocations_rank_index
             from {{ ref('elementary', 'model_run_results') }}
+            where {{ elementary_cli.days_back_filter('generated_at', days_back, partition_column='created_at', column_is_string=true) }}
         )
 
         select
@@ -22,9 +23,8 @@
             case when invocations_rank_index = 1 then compiled_code else NULL end as compiled_code,
             generated_at
         from model_runs
-        where {{ elementary.edr_datediff(elementary.edr_cast_as_timestamp('generated_at'), elementary.edr_current_timestamp(), 'day') }} < {{ days_back }}
         {% if exclude_elementary %}
-          and unique_id not like 'model.elementary.%'
+          where unique_id not like 'model.elementary.%'
         {% endif %}
         order by generated_at
     {% endset %}

--- a/elementary/monitor/dbt_project/macros/get_result_rows_agate.sql
+++ b/elementary/monitor/dbt_project/macros/get_result_rows_agate.sql
@@ -1,32 +1,10 @@
 {% macro get_result_rows_agate(days_back, valid_ids_query = none) %}
-  {% do return(adapter.dispatch('get_result_rows_agate', 'elementary_cli')(days_back, valid_ids_query)) %}
-{% endmacro %}
-
-{% macro default__get_result_rows_agate(days_back, valid_ids_query = none) %}
   {% set query %}
   select
     elementary_test_results_id,
     result_row
   from {{ ref("test_result_rows", package="elementary") }}
-  where {{ elementary.edr_datediff(elementary.edr_cast_as_timestamp('detected_at'), elementary.edr_current_timestamp(), 'day') }} < {{ days_back }}
-  {% if valid_ids_query %}
-    and elementary_test_results_id in ({{ valid_ids_query }})
-  {% endif %}
-  {% endset %}
-  {% set res = elementary.run_query(query) %}
-  {% if not res %}
-    {% do return({}) %}
-  {% endif %}
-  {% do return(res.group_by("elementary_test_results_id")) %}
-{% endmacro %}
-
-{% macro bigquery__get_result_rows_agate(days_back, valid_ids_query = none) %}
-  {% set query %}
-  select
-    elementary_test_results_id,
-    result_row
-  from {{ ref("test_result_rows", package="elementary") }}
-  where detected_at > {{ elementary.edr_timeadd('day', -1 * days_back, elementary.edr_current_timestamp()) }}
+  where {{ elementary_cli.days_back_filter('detected_at', days_back, partition_column='created_at') }}
   {% if valid_ids_query %}
     and elementary_test_results_id in ({{ valid_ids_query }})
   {% endif %}

--- a/elementary/monitor/dbt_project/macros/utils/days_back_filter.sql
+++ b/elementary/monitor/dbt_project/macros/utils/days_back_filter.sql
@@ -1,67 +1,44 @@
 {#
-    Renders the `where` predicate for a `days_back` lookback.
+  Filters `column` to the last `days_back` days.
 
-    The default implementation is the shape these queries have always used: wrap the column in a
-    timestamp cast and compare a `datediff` against `days_back`.
-
-    On BigQuery that shape cannot prune partitions — a function applied to the partition column
-    forces a full scan — so `bigquery__` compares the column directly instead, and optionally adds
-    a bound on `partition_column`.
-
-    That second bound looks redundant, and logically it is: it is implied by the first. It exists
-    because BigQuery only prunes on the raw partition column. It is needed whenever the column
-    being filtered is not the partition column, and whenever it has to be cast (dbt_run_results
-    stores `generated_at` and `execute_completed_at` as strings, so a cast is unavoidable there
-    and no predicate on them can ever prune).
-
-    The bound is deliberately given a day of slack. `created_at` is stamped by the warehouse at
-    insert time while the columns it guards come from the dbt client, so the two are not read from
-    the same clock. Pruning is only ever at day granularity, so the slack costs at most one extra
-    partition and removes any chance of the guard excluding a row the real predicate wanted.
-
-    Args:
-        column: the column to filter on.
-        days_back: size of the lookback window, in days.
-        partition_column: the table's partition column, when it differs from `column`. Adds the
-            pruning bound described above.
-        column_is_string: set when `column` is stored as a string and needs casting before
-            comparison.
+  Pass `partition_column` when `column` is not the table's partition column, or is a string and so
+  has to be cast: BigQuery prunes only on the raw partition column, and without this the query
+  scans all history. Its bound carries a day of slack because the two columns are stamped from
+  different clocks — the guarded ones by the dbt client, `created_at` by the warehouse on insert.
 #}
 
 {% macro days_back_filter(column, days_back, partition_column=none, column_is_string=false) %}
-    {% do return(
-        adapter.dispatch("days_back_filter", "elementary_cli")(
-            column, days_back, partition_column, column_is_string
-        )
-    ) %}
+  {% do return(
+    adapter.dispatch("days_back_filter", "elementary_cli")(
+      column, days_back, partition_column, column_is_string
+    )
+  ) %}
 {% endmacro %}
 
 {% macro default__days_back_filter(
-    column, days_back, partition_column=none, column_is_string=false
+  column, days_back, partition_column=none, column_is_string=false
 ) %}
-    {% set predicate %}
-        {{ elementary.edr_datediff(
-            elementary.edr_cast_as_timestamp(column), elementary.edr_current_timestamp(), 'day'
-        ) }} < {{ days_back }}
-    {% endset %}
-    {% do return(predicate) %}
+  {%- set days_diff = elementary.edr_datediff(
+    elementary.edr_cast_as_timestamp(column), elementary.edr_current_timestamp(), "day"
+  ) -%}
+  {% do return(days_diff ~ " < " ~ days_back) %}
 {% endmacro %}
 
 {% macro bigquery__days_back_filter(
-    column, days_back, partition_column=none, column_is_string=false
+  column, days_back, partition_column=none, column_is_string=false
 ) %}
-    {% set window_start = elementary.edr_timeadd(
-        "day", -1 * (days_back | int), elementary.edr_current_timestamp()
-    ) %}
-    {% set filtered = elementary.edr_cast_as_timestamp(column) if column_is_string else column %}
-    {% set predicate %}
-        {{ filtered }} > {{ window_start }}
-        {% if partition_column and partition_column != column %}
-            {# a day of slack, since this column is stamped from a different clock #}
-            and {{ partition_column }} > {{ elementary.edr_timeadd(
-                "day", -1 * (days_back | int + 1), elementary.edr_current_timestamp()
-            ) }}
-        {% endif %}
-    {% endset %}
-    {% do return(predicate) %}
+  {%- set filtered = elementary.edr_cast_as_timestamp(column) if column_is_string else column -%}
+  {%- set conditions = [
+    filtered ~ " > " ~ elementary.edr_timeadd(
+      "day", -1 * (days_back | int), elementary.edr_current_timestamp()
+    )
+  ] -%}
+  {%- if partition_column and partition_column != column -%}
+    {%- do conditions.append(
+      partition_column ~ " > " ~ elementary.edr_timeadd(
+        "day", -1 * ((days_back | int) + 1), elementary.edr_current_timestamp()
+      )
+    ) -%}
+  {%- endif -%}
+  {% do return(conditions | join(" and ")) %}
 {% endmacro %}

--- a/elementary/monitor/dbt_project/macros/utils/days_back_filter.sql
+++ b/elementary/monitor/dbt_project/macros/utils/days_back_filter.sql
@@ -1,0 +1,67 @@
+{#
+    Renders the `where` predicate for a `days_back` lookback.
+
+    The default implementation is the shape these queries have always used: wrap the column in a
+    timestamp cast and compare a `datediff` against `days_back`.
+
+    On BigQuery that shape cannot prune partitions — a function applied to the partition column
+    forces a full scan — so `bigquery__` compares the column directly instead, and optionally adds
+    a bound on `partition_column`.
+
+    That second bound looks redundant, and logically it is: it is implied by the first. It exists
+    because BigQuery only prunes on the raw partition column. It is needed whenever the column
+    being filtered is not the partition column, and whenever it has to be cast (dbt_run_results
+    stores `generated_at` and `execute_completed_at` as strings, so a cast is unavoidable there
+    and no predicate on them can ever prune).
+
+    The bound is deliberately given a day of slack. `created_at` is stamped by the warehouse at
+    insert time while the columns it guards come from the dbt client, so the two are not read from
+    the same clock. Pruning is only ever at day granularity, so the slack costs at most one extra
+    partition and removes any chance of the guard excluding a row the real predicate wanted.
+
+    Args:
+        column: the column to filter on.
+        days_back: size of the lookback window, in days.
+        partition_column: the table's partition column, when it differs from `column`. Adds the
+            pruning bound described above.
+        column_is_string: set when `column` is stored as a string and needs casting before
+            comparison.
+#}
+
+{% macro days_back_filter(column, days_back, partition_column=none, column_is_string=false) %}
+    {% do return(
+        adapter.dispatch("days_back_filter", "elementary_cli")(
+            column, days_back, partition_column, column_is_string
+        )
+    ) %}
+{% endmacro %}
+
+{% macro default__days_back_filter(
+    column, days_back, partition_column=none, column_is_string=false
+) %}
+    {% set predicate %}
+        {{ elementary.edr_datediff(
+            elementary.edr_cast_as_timestamp(column), elementary.edr_current_timestamp(), 'day'
+        ) }} < {{ days_back }}
+    {% endset %}
+    {% do return(predicate) %}
+{% endmacro %}
+
+{% macro bigquery__days_back_filter(
+    column, days_back, partition_column=none, column_is_string=false
+) %}
+    {% set window_start = elementary.edr_timeadd(
+        "day", -1 * (days_back | int), elementary.edr_current_timestamp()
+    ) %}
+    {% set filtered = elementary.edr_cast_as_timestamp(column) if column_is_string else column %}
+    {% set predicate %}
+        {{ filtered }} > {{ window_start }}
+        {% if partition_column and partition_column != column %}
+            {# a day of slack, since this column is stamped from a different clock #}
+            and {{ partition_column }} > {{ elementary.edr_timeadd(
+                "day", -1 * (days_back | int + 1), elementary.edr_current_timestamp()
+            ) }}
+        {% endif %}
+    {% endset %}
+    {% do return(predicate) %}
+{% endmacro %}


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft — depends on elementary-data/dbt-data-reliability#1057**, which exposes `created_at` on the `model_run_results` view. Until that is merged and this project's package dependency points at it, the guard below has no column to prune on and CI here will fail. Opening now so the change is ready; happy to rebase or close and re-open once the ordering suits you.
>
> It also stacks on #2351, which adds the `days_back_filter` macro this uses. The diff shown will shrink to a single file once that merges.

## What

`get_models_runs` computes `row_number()` over the entire `model_run_results` view and only *then* filters to `days_back`:

```sql
with model_runs as (
    select *, row_number() over (partition by unique_id order by generated_at desc) ...
    from {{ ref('elementary', 'model_run_results') }}     -- unbounded
)
select ...
from model_runs
where {{ edr_datediff(edr_cast_as_timestamp('generated_at'), now, 'day') }} < days_back
```

So every report run reads all history. On one warehouse this is the single most expensive query the CLI issues: ~12.4 GB per invocation against a 17M row / 41GB table, and ~1,115 GB over a week.

## The fix

Moving the filter into the CTE and bounding `created_at`, which is the column BigQuery can prune on.

Worth being precise that the filter move earns nothing by itself — it is the `created_at` bound that prunes. I had also replaced `select *` in the CTE with an explicit column list, and dropped it again after measuring: BigQuery already prunes to the columns a query references, so both shapes read **31,868 MB**, identical. It was ten lines and a second place to maintain the column set for no gain.

On the warehouse above, the 8-day window is **0.85%** of the table (146,402 of 17,207,248 rows across 779 partition-days), so this should fall to a fraction of a GB per invocation. I cannot post a measured after-figure until #1057 is in, and would rather leave it blank than estimate.

## Why the move is safe

The filter can move above the window function without changing any returned row's rank. For any row R inside the window, every row ranked above R for the same `unique_id` is *newer* than R, and therefore also inside the window. So no row that contributed to R's rank is removed, and R's rank is identical either way — which also preserves the `invocations_rank_index = 1 → compiled_code` selection exactly.

Confirmed rather than argued, over a 7-day window on real data:

```
rows_in_window          39,185
rank_mismatches              0
compiled_code rows (old) 1,678
compiled_code rows (new) 1,678
```

## Non-BigQuery adapters

Unchanged. `default__days_back_filter` renders the same `edr_datediff(edr_cast_as_timestamp(...)) < days_back` predicate this macro already used; only its position in the query moves, and that is rank-preserving as above.

`exclude_elementary` deliberately stays in the outer query. It could move into the CTE too — filtering whole `unique_id` groups cannot affect ranks within other groups — but it prunes nothing, so I left the change surface as small as possible.
